### PR TITLE
If an ack_bgcolor configuration var is set, use it

### DIFF
--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -403,7 +403,12 @@ var ElementLine = Element.extend({
         if (this.obj.conf.summary_problem_has_been_acknowledged === 1
             || this.obj.conf.summary_in_downtime === 1
             || this.obj.conf.summary_stale) {
-            color = lightenColor(color, 100, 100, 100);
+
+            if ((typeof(oStates[this.obj.conf.summary_state].ack_bgcolor) != 'undefined') && oStates[this.obj.conf.summary_state].ack_bgcolor != '') {
+                color = oStates[this.obj.conf.summary_state].ack_bgcolor;
+            } else {
+                color = lightenColor(color, 100, 100, 100);
+            }
         }
 
         return [color, border_color];


### PR DESCRIPTION
I found that setting a `critical_ack_bgcolor` in configuration was ignored. This is my patch to use it if it exists, otherwise fall back to the default behaviour of `lightenColor`.