### PR TITLE
Added JS replace() for # in service descriptions to use %23 

### DIFF
--- a/share/frontend/nagvis-js/js/ElementHover.js
+++ b/share/frontend/nagvis-js/js/ElementHover.js
@@ -670,7 +670,7 @@ var ElementHover = Element.extend({
         if(this.obj.conf.type === 'service') {
             oMacros.service_description = this.obj.conf.service_description;
             oMacros.pnp_hostname = this.obj.conf.name.replace(/\s/g,'%20');
-            oMacros.pnp_service_description = this.obj.conf.service_description.replace(/\s/g,'%20');
+            oMacros.pnp_service_description = this.obj.conf.service_description.replace(/\s/g,'%20').replace(/#/g, '%23');
         } else
             oSectionMacros.service = '<!--\\sBEGIN\\sservice\\s-->.+?<!--\\sEND\\sservice\\s-->';
     


### PR DESCRIPTION
Even though it's not very "ethical" to use "#" (hashtag) signs inside of Nagios/Nagvis.. I experienced a client who had work orders, ethernet numbers, etc. (Description: Port 1/4 WorkOrder #12345) (Description: ESX Server #1)

PNP graphs inside hover menus do not show up with hash tags in them.  This will patch that issue.