### PR TITLE
Add missed var assignment

### DIFF
--- a/share/server/core/classes/GlobalBackendPDO.php
+++ b/share/server/core/classes/GlobalBackendPDO.php
@@ -997,7 +997,7 @@ class GlobalBackendPDO implements GlobalBackendInterface {
             $stateAttr = 'ss.current_state';
 
         // FIXME: Recognize host ack/downtime
-        $this->parseFilter($objects, $filters, 'o', 'o2', MEMBER_QUERY, COUNT_QUERY, !HOST_QUERY);
+        $filter = $this->parseFilter($objects, $filters, 'o', 'o2', MEMBER_QUERY, COUNT_QUERY, !HOST_QUERY);
         $QUERYHANDLE = $this->DB->query('SELECT
             o.name1, sg.alias,
             SUM(CASE WHEN ss.has_been_checked=0 THEN 1 ELSE 0 END) AS pending,


### PR DESCRIPTION
In `getServicegroupStateCounts()`, `$filter` is used whilst undefined in line 1025 and beyond. Similar functions use the return value of `parseFilter()` - edited to match.