### PR TITLE
install.sh: Wrong option display for backends in command call summary

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -562,7 +562,7 @@ check_backend() {
     fi
     
     BACKENDS=${BACKENDS#,}
-    [ ! -z "$BACKENDS" ] && CALL="$CALL -b $NAGVIS_BACKEND"
+    [ ! -z "$BACKENDS" ] && CALL="$CALL -i $BACKENDS"
 }
 
 # Check Apache PHP module


### PR DESCRIPTION
Hi,

In the install.sh script, the help says that the backends must be specified with -i but in the command displayed at the end of installation, backends are set using the -b option.
From what I understood from the code, the correct option is -i.

I corrected this in the associated pull request, if you want to have a look at this.