### PR TITLE
install.sh: Display 'update backend configuration' only when not in quiet mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -423,8 +423,13 @@ detect_livestatus_socket() {
 check_backend() {
     # Ask to configure the backends during update
     if [ $INSTALLER_ACTION = "update" ]; then
-        confirm "Do you want to update the backend configuration?" "n"
-        if [ "$ANS" = "N" ]; then
+        ANS="n"
+        if [ $INSTALLER_QUIET -ne 1 ]; then
+            ask_user "ANS" "n" 1 "check_confirm" \
+                "Do you want to update the backend configuration?"
+        fi
+
+        if [ "$ANS" = "n" ]; then
             return
         fi
     fi


### PR DESCRIPTION
Hi,

In the install.sh script, the -q parameters allows to bypass confirmations and use default values. When using this parameter, all confirmations are bypassed except one ("Update backend configuration").
I think it is annoying and defeats the purpose of the -q parameter, so I tried to fix this.