### PR TITLE
Moved demo rotation configuration to demo.ini.php file

### DIFF
--- a/etc/conf.d/demo.ini.php
+++ b/etc/conf.d/demo.ini.php
@@ -3,9 +3,17 @@
 ; viewing this file from web.
 ; DON'T REMOVE IT!
 
-; This file defines a backend instance of the Test backend
+; This file defines the rotation object for default maps. This
+; can be removed when you are not interested in demo maps rotation.
+
+; This file also defines a backend instance of the Test backend
 ; which is used by some demo maps. This can be removed when
 ; you are not interested in the demo maps.
+
+
+[rotation_demo]
+maps="demo-germany,demo-ham-racks,demo-load,demo-muc-srv1,demo-geomap,demo-automap"
+interval=15
 
 [backend_demo]
 backendtype=Test

--- a/etc/nagvis.ini.php-sample
+++ b/etc/nagvis.ini.php-sample
@@ -441,15 +441,15 @@ backendtype="ndomy"
 ; ----------------------------
 
 ; in this example the browser switches between the maps demo and demo2 every 15
-; seconds, the rotation is enabled by url: index.php?rotation=demo
-[rotation_demo]
+; seconds, the rotation is enabled by url: index.php?rotation=example
+;[rotation_example]
 ; These steps are rotated. The single steps may have optional prefixes like "Demo2:"
 ; which are used as display text on the index pages rotation list.
 ; You may also add external URLs as steps. Simply enclose the url using []
 ; instead of the map name.
-maps="demo-germany,demo-ham-racks,demo-load,demo-muc-srv1,demo-geomap,demo-automap"
+;maps="map1,map2,map3"
 ; rotation interval (seconds)
-interval=15
+;interval=15
 
 ; ----------------------------
 ; Action definitions


### PR DESCRIPTION
Hi,

When installing nagvis with the ./install.sh script, the -o option can remove all demo configuration.
All maps are removed, but the demo rotation is still defined because it is present in the nagvis.ini.php file.

To allow the -o option to remove the demo rotation as well, I moved the rotation definition in the demo.ini.php file. In the nagvis.ini.php, a sample rotation definition is still present (but in comments) to show the user how to define a rotation.

I only tested this change when using the install.sh script, so I don't know if this also works when using the OMD install.