### PR TITLE
prevent null deref in CoreModule.php

### DIFF
--- a/share/server/core/classes/CoreModule.php
+++ b/share/server/core/classes/CoreModule.php
@@ -117,7 +117,7 @@ abstract class CoreModule {
         // Maybe the requested action is summarized by some other
         $action = !is_bool($this->aActions[$this->sAction]) ? $this->aActions[$this->sAction] : $this->sAction;
 
-        if(!$AUTHORISATION->isPermitted($this->sName, $action, $this->sObject))
+        if($authorized && !$AUTHORISATION->isPermitted($this->sName, $action, $this->sObject))
             $authorized = false;
 
         if(!$authorized)


### PR DESCRIPTION
There is a test in isPermitted() in CoreModule.php, if AUTHORISATION
might be null, and $authorized is then set to false. However, later
AUTHORISATION is dereferenced unconditionally. Add a check to $authorized
before dereferencing AUTHORISATION.

I'm currently struggling with nagvis under OpenBSD, chrooted nginx, php_fpm, etc.
and ran into the issue that the session files get reset to 0 bytes after a successful logon.