### PR TITLE
Fix object state sort regression

### DIFF
--- a/share/server/core/classes/objects/NagVisObject.php
+++ b/share/server/core/classes/objects/NagVisObject.php
@@ -495,7 +495,7 @@ class NagVisObject {
         $state2 = $OBJ2->sum[STATE];
         $subState2 = $OBJ2->getSubState(SUMMARY_STATE);
 
-        return NagVisObject::sortObjectsByState($state1, $subState1, $state2, $subState2, self::$sSortOrder);
+        return NagVisObject::sortStatesByStateValues($state1, $subState1, $state2, $subState2, self::$sSortOrder);
     }
 
     /**


### PR DESCRIPTION
This was introduced with 29231795d5a7ead5f5694e933203657c1b8f9247

Report: https://monitoring-portal.org/t/nagvis-update-to-1-9-6/1814

Haven't tested it, but from the code it looks like a copy-paste error. 