### PR TITLE
A backend change to bypass a php error

### DIFF
--- a/share/server/core/classes/GlobalBackendPDO.php
+++ b/share/server/core/classes/GlobalBackendPDO.php
@@ -1200,6 +1200,19 @@ class GlobalBackendPDO implements GlobalBackendInterface {
     }
 
     /**
+     * PUBLIC Method getHostNamesInHostgroup
+     *
+     * This is required to bypass the filter_group error in automap if you integrate nagvis with icinga2
+     *
+     * @param		String		Name of hostgroup to get the hosts of
+     * @return	Array			Array with hostnames
+     */
+    public function getHostNamesInHostgroup($hostgroupName) {
+    	return $this->getHostsByHostgroupName($hostgroupName); 
+    }
+
+
+    /**
      * PUBLIC Method getServicesByServicegroupName
      *
      * Gets all services of a servicegroup


### PR DESCRIPTION
This function alias is required to bypass a filter_group related php error about a missing function.
This appears when one is editing an auto created map in case you integrate nagvis with icinga2 using ndomy backend and the related plugin.

Tested with Debian 9.

Thank you for your efforts.