### PR TITLE
Updates frontend.js to fix broken urls

### DIFF
--- a/share/frontend/nagvis-js/js/frontend.js
+++ b/share/frontend/nagvis-js/js/frontend.js
@@ -340,7 +340,7 @@ function playSound(objectId, iNumTimes){
         var oEmbed = document.createElement('embed');
         oEmbed.setAttribute('id', 'sound'+sState);
         // Relative URL does not work, add full url
-        oEmbed.setAttribute('src', window.location.protocol + '//' + window.location.host + ':'
+        oEmbed.setAttribute('src', window.location.protocol + '//' + window.location.hostname + ':'
                                                  	+ window.location.port + oGeneralProperties.path_sounds+sSound);
         oEmbed.setAttribute('width', '0');
         oEmbed.setAttribute('height', '0');


### PR DESCRIPTION
Fixes bug with loading sound resources occurring when running NagVis on nonstandard Port (e.g. :4443) resulting in malformed URLs with :4443:4443.