### PR TITLE
Minor fix in default.css

### DIFF
--- a/share/userfiles/templates/default.css
+++ b/share/userfiles/templates/default.css
@@ -696,7 +696,7 @@ div#popupWindow h1 {
 #sidebar li {margin:0;padding:0;line-height:25px;}
 #sidebar li.spacerbottom {border-bottom:1px dotted #e5e5e5}
 #sidebar li.spacertop {border-top:1px dotted #e5e5e5}
-#sidebar li > div {width:200px;height:25px;clear:both;}
+#sidebar li > div {width:200px;clear:both;}
 #sidebar li > div a {padding-left:20px;}
 
 #sidebar li.parent div {}


### PR DESCRIPTION
Sorry this is my first time using GitHub and I'm probably doing everything wrong I could be doing, but I wanted to share this little bug and the solution with the developers.

The fixed height of the list element causes the text to overlap when the names are to long.

Before:
![2018-10-24 15_49_30__ nagvis 1 9 10](https://user-images.githubusercontent.com/44438203/47435242-7b6ab800-d7a4-11e8-9769-9e9ee40a3959.png)

After:
![2018-10-24 15_50_54__ nagvis 1 9 10](https://user-images.githubusercontent.com/44438203/47435318-a6550c00-d7a4-11e8-81e5-1ad91adf2b7d.png)
