### PR TITLE
Support regex for ignore_hosts in automaps

### DIFF
--- a/share/server/core/sources/automap.php
+++ b/share/server/core/sources/automap.php
@@ -127,7 +127,7 @@ $configVars = array(
     'ignore_hosts' => array(
         'must'       => false,
         'default'    => '',
-        'match'      => MATCH_STRING_NO_SPACE_EMPTY,
+        'match'      => MATCH_REGEX,
     ),
 
     'margin' => array(
@@ -469,6 +469,11 @@ function automap_fetch_tree($dir, $MAPCFG, $params, &$saved_config, $obj_name, $
 
         if (in_array($rel_name, $params['ignore_hosts']) == True){
             continue;
+        }
+        foreach($params['ignore_hosts'] as $value) {
+            if (preg_match('/'.$value.'/', $rel_name)) {
+                continue 2;
+            }
         }
         $obj = automap_obj($MAPCFG, $params, $saved_config, $rel_name);
 

--- a/share/server/core/sources/automap.php
+++ b/share/server/core/sources/automap.php
@@ -471,8 +471,10 @@ function automap_fetch_tree($dir, $MAPCFG, $params, &$saved_config, $obj_name, $
             continue;
         }
         foreach($params['ignore_hosts'] as $value) {
-            if (preg_match('/'.$value.'/', $rel_name)) {
-                continue 2;
+            if ($value != '') {
+                if (preg_match('/'.$value.'/', $rel_name)) {
+                    continue 2;
+                }
             }
         }
         $obj = automap_obj($MAPCFG, $params, $saved_config, $rel_name);


### PR DESCRIPTION
When having to ignore a huge number of hosts in an automap, using a regex might be more usable than having to list all hosts to be excluded.
I didn't touch the existing behaviour, so the current functionality should remain intact, but regex are now supported too.