### PR TITLE
Remove the file count for iconsets in the docs

### DIFF
--- a/docs/de_DE/extending/iconsets.html
+++ b/docs/de_DE/extending/iconsets.html
@@ -21,7 +21,7 @@ ist nicht das Problem, aber der std_small-Iconset von NagVis ist zu gro&szlig; f
 Erstellen Sie Ihr eigenes Iconset.
 <br>
 <h2>Was ist ein Iconset?</h2>
-<p>Ein vollst&auml;ndiges Iconset besteht aus elf Dateien. Diese Dateien sind PNG-Bilder, die folgenderma&szlig;en hei&szlig;en m&uuml;ssen:</p>
+<p>Ein vollst&auml;ndiges Iconset besteht aus mehreren Dateien. Diese Dateien sind PNG-Bilder, die folgenderma&szlig;en hei&szlig;en m&uuml;ssen:</p>
 
 <table border=0>
 <tr>

--- a/docs/de_DE/extending/iconsets.html
+++ b/docs/de_DE/extending/iconsets.html
@@ -24,12 +24,9 @@ Erstellen Sie Ihr eigenes Iconset.
 <p>Ein vollst&auml;ndiges Iconset besteht aus mehreren Dateien. Diese Dateien sind PNG-Bilder, die folgenderma&szlig;en hei&szlig;en m&uuml;ssen:</p>
 
 <table border=0>
-<tr>
-<th> Dateiname </th><th> Beschreibung </th>
-</tr>
                         <tr>
-                                <th>Filename</th>
-                                <th>Description</th>
+                                <th>Dateiname</th>
+                                <th>Beschreibung</th>
                         </tr>
                         <tr>
                                 <td>&lt;set&gt;_critical.png</td>

--- a/docs/de_DE/extending/iconsets.html
+++ b/docs/de_DE/extending/iconsets.html
@@ -27,48 +27,134 @@ Erstellen Sie Ihr eigenes Iconset.
 <tr>
 <th> Dateiname </th><th> Beschreibung </th>
 </tr>
-<tr>
-<td> &lt;set>_ack.png </td><td> best&auml;tigtes Problem (acknowledged)</td>
-</tr>
-<tr>
-<td> &lt;set>_critical.png </td><td> kritischer Zustand (critical) </td>
-</tr>
-<tr>
-<td> &lt;set>_down.png </td><td> Down-Zustand (Host) </td>
-</tr>
-<tr>
-<td> &lt;set>_downtime.png </td><td> Ausfallzeit (Host) </td>
-</tr>
-<tr>
-<td> &lt;set>_error.png </td><td> Fehler beim Holen des Zustands </td>
-</tr>
-<tr>
-<td> &lt;set>_ok.png </td><td> OK-Status </td>
-</tr>
-<tr>
-<td> &lt;set>_pending.png </td><td> Pending-Zustand </td>
-</tr>
-<tr>
-<td> &lt;set>_sack.png </td><td> best&auml;tigtes Problem (Service) </td>
-</tr>
-<tr>
-<td> &lt;set>_sdowntime.png </td><td> Ausfallzeit (Service) </td>
-</tr>
-<tr>
-<td> &lt;set>_unchecked.png </td><td> ungepr&uuml;fter Zustand (Pending) </td>
-</tr>
-<tr>
-<td> &lt;set>_unknown.png </td><td> unbekannter Zustand (unknown) </td>
-</tr>
-<tr>
-<td> &lt;set>_unreachable.png </td><td> unerreichbarer Zustand (Host) </td>
-</tr>
-<tr>
-<td> &lt;set>_up.png </td><td> Up-Zustand (Host) </td>
-</tr>
-<tr>
-<td> &lt;set>_warning.png </td><td> Warning-Zustand </td>
-</tr>
+                        <tr>
+                                <th>Filename</th>
+                                <th>Description</th>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_critical.png</td>
+                                <td>kritischer Zustand (critical)</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_critical_ack.png</td>
+                                <td>Acknowledged critical state</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_critical_dt.png</td>
+                                <td>Critical state in downtime</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_critical_stale.png</td>
+                                <td>Stale critical state</td>
+                        </tr>
+
+                        <tr>
+                                <td>&lt;set&gt;_down.png</td>
+                                <td>Down-Zustand (Host)</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_down_ack.png</td>
+                                <td>Acknowledged down state</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_down_dt.png</td>
+                                <td>Down state in downtime</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_down_stale.png</td>
+                                <td>Stale down state</td>
+                        </tr>
+
+                        <tr>
+                                <td>&lt;set&gt;_error.png</td>
+                                <td>Fehler beim Holen des Zustands</td>
+                        </tr>
+
+                        <tr>
+                                <td>&lt;set&gt;_ok.png</td>
+                                <td>OK-Status</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_ok_dt.png</td>
+                                <td>OK state in downtime</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_ok_stale.png</td>
+                                <td>Stale ok state</td>
+                        </tr>
+
+                        <tr>
+                                <td>&lt;set&gt;_pending.png</td>
+                                <td>Pending-Zustand</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_unchecked.png</td>
+                                <td>ungepr&uuml;fter Zustand (Pending)</td>
+                        </tr>
+
+                        <tr>
+                                <td>&lt;set&gt;_unknown.png</td>
+                                <td>unbekannter Zustand (unknown)</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_unknown_ack.png</td>
+                                <td>Acknowledged unknown state</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_unknown_dt.png</td>
+                                <td>Unknown state in downtime</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_unknown_stale.png</td>
+                                <td>Stale unknown state</td>
+                        </tr>
+
+                        <tr>
+                                <td>&lt;set&gt;_unreachable.png</td>
+                                <td>unerreichbarer Zustand (Host)</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_unreachable_ack.png</td>
+                                <td>Acknowledged unreachable state</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_unreachable_dt.png</td>
+                                <td>Unreachable state in downtime</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_unreachable_stale.png</td>
+                                <td>Stale unreachable state</td>
+                        </tr>
+
+                        <tr>
+                                <td>&lt;set&gt;_up.png</td>
+                                <td>Up-Zustand (Host)</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_up_dt.png</td>
+                                <td>Up state in downtime</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_up_stale.png</td>
+                                <td>Stale up state</td>
+                        </tr>
+
+                        <tr>
+                                <td>&lt;set&gt;_warning.png</td>
+                                <td>Warning-Zustand</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_warning_ack.png</td>
+                                <td>Acknowledged warning state</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_warning_dt.png</td>
+                                <td>Warning state in downtime</td>
+                        </tr>
+                        <tr>
+                                <td>&lt;set&gt;_warning_stale.png</td>
+                                <td>Stale warning state</td>
+                        </tr>
 </table>
 <br>
 NagVis sucht nach <code>&lt;set>_ok.png</code>-Bildern, um die Iconsets aufzulisten. Das hei&szlig;t, dass ein <code>&lt;set&gt;_ok.png</code>-Bild vorhanden sein muss,

--- a/docs/en_US/extending/iconsets.html
+++ b/docs/en_US/extending/iconsets.html
@@ -16,7 +16,7 @@
         <h3>Solution</h3>
         <p>Build your own iconset.</p>
         <h2>What is an iconset?</h2>
-        <p>A complete iconset consists of 14 files. These files are png images which are named like this:</p>
+        <p>A complete iconset consists of a number of files. These files are png images which are named like this:</p>
         <table>
                 <tbody>
                         <tr>


### PR DESCRIPTION
Remove the file count for iconsets in the docs
It frequently seems to be out of step with the table, either listing more, or fewer files, so it's probably better to make people count themselves than have an invalid count.

Also attempt to make the German docs more accurate (if sometimes in the wrong language).