### PR TITLE
Configurable  OpenStreetMap tile server URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@
 .metadata
 .site
 install.log
+launch.json
+
+# Exclude actual config files
+etc/auth.db
+etc/perms.db
 
 # Exclude main configuration file
 etc/nagvis.ini.php

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ launch.json
 etc/auth.db
 etc/perms.db
 etc/worldmap.db
+etc/profiles
 
 # Exclude main configuration file
 etc/nagvis.ini.php

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ launch.json
 # Exclude actual config files
 etc/auth.db
 etc/perms.db
+etc/worldmap.db
 
 # Exclude main configuration file
 etc/nagvis.ini.php

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 1.9.13
+Worldmap:
+  * Configurable OpenStreetMap tile server URL (worldmap_tiles_url)
 
 1.9.12
 Core:
@@ -80,7 +82,7 @@ Core:
     (Configure this per object by adding the attribute hover_childs_sort=k).
 
 Frontend:
-  * On demand automaps: Hostgroup filter in header menu is now a searchable dropdown field 
+  * On demand automaps: Hostgroup filter in header menu is now a searchable dropdown field
   * FIX: Fixed moving textbox objects in IE
 
 1.9.3
@@ -103,7 +105,7 @@ Core:
 
 1.9.1
 Core:
-  * FIX: Fixed incompatibility with pecl-http (Cannot redeclare http_redirect()) 
+  * FIX: Fixed incompatibility with pecl-http (Cannot redeclare http_redirect())
   * FIX: Fixed duplicate global section in sample automaps after editing
 
 Frontend:
@@ -641,9 +643,9 @@ Automap:
 1.8b3
 Frontend:
   * Added option "zoom_scale_objects" to default section of global config to
-    allow users to control the scaling behaviour of zoomed objects. By 
-    default the whole maps is zoomed like in previous versions. But when 
-    zoom_scale_objects is set to 0, the map objects and labels are not 
+    allow users to control the scaling behaviour of zoomed objects. By
+    default the whole maps is zoomed like in previous versions. But when
+    zoom_scale_objects is set to 0, the map objects and labels are not
     resized, but only repositioned according to the given zoom factor.
   * FIX: Fixed broken NagVis Multisite sidebar dashlet
   * FIX: Fixed showing URLs as hover menus (hover_url option)
@@ -655,7 +657,7 @@ Frontend:
 
 Core:
   * Allowing ~ chars in URLs now (Thanks to Daniel Albers for the patch)
-  * FIX: Fixed rare occuring encoding problems of vars in several places 
+  * FIX: Fixed rare occuring encoding problems of vars in several places
   * FIX: Fixed PHP error with map objects linking to not existing maps
   * FIX: Trying to workaround broken processing of non UTF-8 pages in hover_urls
 
@@ -676,7 +678,7 @@ Core:
   * FIX: Fixed host alias attribute in livestatus backend
   * Dropped the merlinmy backend for the moment as it was not working for a
     time. Please provide a fixed one if you like to see this working again
-  * FIX: Fixed PHP errors when acknowleding host/service problems 
+  * FIX: Fixed PHP errors when acknowleding host/service problems
   * FIX: Fixed missing values alias, display_name, address values in hover templates
 
 Installer:
@@ -704,7 +706,7 @@ Core:
     filter on the map. In first instance it automatically gathers the list of
     objects to add on this map and positions them in a grid on the map. The
     user can then modify all the objects, for example change their options
-    like, positions and visualisation. 
+    like, positions and visualisation.
   * Changed default http_timeout from 10 to 2 seconds
   * Added new iconset std_area, which can be used to create maps which are
     visible from a greater distance
@@ -777,13 +779,13 @@ Geomap:
 Frontend:
   * FIX: Fixed "Undefined index" error when changing backend_id of maps
   * FIX: Fixed hiding of shapes during refresh (enable_refresh=1)
-  * Reverted change from 1.7.5 (Weathermap lines with byte/bit values in 
+  * Reverted change from 1.7.5 (Weathermap lines with byte/bit values in
     labels should print human) which broke the handling for some plugins
 
 1.7.7
 Core:
   * Implemented "on demand" maps. Maps which only need a basic configuration
-    of global parameters like automaps and geomaps can now be configured and 
+    of global parameters like automaps and geomaps can now be configured and
     created on demand by URL parameters. This mode is reached by simply
     calling the map URL without "show=" parameter and a bunch of parameters
     for the global section of the map instead.
@@ -934,7 +936,7 @@ Core
 Frontend
   * Added new map config option (global section) event_on_load to raise frontend events
     also on page loading
-  * Added new options event_repeat_interval and event_repeat_duration to 
+  * Added new options event_repeat_interval and event_repeat_duration to
     configured repeated frontend events
   * Added rotations to sidebar
   * Info page shows json_encode/json_decode capability of used PHP
@@ -1109,7 +1111,7 @@ Core
   * NagVis creates now "omdadmin" user in OMD environments when creating new auth.db files
   * Bugfix: Added missing default permissions for guest role (viewing demo maps)
   * Bugfix: Fixed version number format for stable versions like (1.6)
-    
+
 Frontend
   * Ajax call for redrawing map objects is not cacheable anymore (prevent strange
     hopping of icons after unlock -> edit -> lock in some cases.
@@ -1206,7 +1208,7 @@ Frontend
   * Bugfix: Don't hide dependent fiels where the master attribute is not available
   * Bugfix: Fixed map global section editing
   * Bugfix: IE8 fixing event registration (javascript errors on page loading)
-  * Updating map object information while having the hover menu open does not close 
+  * Updating map object information while having the hover menu open does not close
     open hover menus anymore
 
 1.6rc1

--- a/docs/en_US/nagvis_config_format_description.html
+++ b/docs/en_US/nagvis_config_format_description.html
@@ -101,6 +101,12 @@
 	  <td>http://geomap.nagvis.org/</td>
 	  <td>The server to use as source for the NagVis geomaps. Must implement the API which can be found <a href="http://pafciu17.dev.openstreetmap.org/">here</a></td>
         </tr>
+        
+        <tr>
+            <td>worldmap_tiles_url <font color="#ff0000">(new in 1.9)</font></td>
+            <td>https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png</td>
+            <td>Worldmap uses OpenStreetMap tiles as a map background. The URL specifies where to GET the PNG tile images from.</td>
+        </tr>
 
         <tr>
           <td>http_proxy <font color="#ff0000">(new in 1.6)</font></td>

--- a/docs/en_US/nagvis_config_format_description.html
+++ b/docs/en_US/nagvis_config_format_description.html
@@ -103,7 +103,7 @@
         </tr>
         
         <tr>
-            <td>worldmap_tiles_url <font color="#ff0000">(new in 1.9)</font></td>
+            <td>worldmap_tiles_url <font color="#ff0000">(new in 1.9.13)</font></td>
             <td>https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png</td>
             <td>Worldmap uses OpenStreetMap tiles as a map background. The URL specifies where to GET the PNG tile images from.</td>
         </tr>

--- a/docs/en_US/worldmap.html
+++ b/docs/en_US/worldmap.html
@@ -22,12 +22,13 @@
         <h2>Prerequisites</h2>
         <p>There is no special software needed on the NagVis server, but there is one special requirement. To
         be able to use this feature, the browser opening NagVis worldmaps needs to be able to fetch the background
-        images (map tiles) from the internet. In most corporate environments this means that your client needs
+        images (map tiles) from the internet, or a local mirror, see below. In most corporate environments this means that your client needs
         to have a proxy server configured.</p>
-        <p>The worldmaps currently use the official tile servers of Open Street Map 
-        (<code>https://{s}.tile.openstreetmap.org/</code>). This is currently hardcoded, but might be made configurable
-        in the future.</p>
-        
+        <p>The worldmaps use the official tile servers of Open Street Map (<code>https://{s}.tile.openstreetmap.org/</code>) as a default.
+        Alternative tile server (local mirror) may be set in configuration, for example: <code>worldmap_tiles_url="http://my-tiles.local/{z}/{x}/{y}.png"</code> </p>
+
+        <p>The <a href="https://switch2osm.org/serving-tiles/">switch2osm guides</a> might help you to spin up your local OpenStreetMap mirror.</p>
+
         <h2>The first call</h2>
         <p>NagVis comes with a demo worldmap called "demo-worldmap". If your NagVis is configured correctly
         and your browser is able to fetch the background images from the tile server, you should see a map
@@ -37,7 +38,7 @@
 
         <p>This worldmap is defined using the map configuration file "demo-worldmap.cfg". The contents
         look like this:</p>
-        
+
         <pre>define global {
     alias=Demo: 4 Worldmap
     parent_map=demo-overview

--- a/etc/nagvis.ini.php-sample
+++ b/etc/nagvis.ini.php-sample
@@ -71,6 +71,9 @@
 ; can be found on http://pafciu17.dev.openstreetmap.org/
 ;geomap_server="http://geomap.nagvis.org/"
 ;
+; Public or private mirror of OpenStreetMap tiles server
+;worldmap_tiles_url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+;
 ; In some cases NagVis needs to open connections to the internet. The cases are:
 ; - The new geomap needs access to openstreetmap webservices to be able to fetch
 ;   mapping information

--- a/share/frontend/nagvis-js/js/ViewWorldmap.js
+++ b/share/frontend/nagvis-js/js/ViewWorldmap.js
@@ -60,7 +60,7 @@ var ViewWorldmap = ViewMap.extend({
             maxBounds: [ [-85,-180.0], [85,180.0] ],
             minZoom: 2
         }).setView(getViewParam('worldmap_center').split(','), parseInt(getViewParam('worldmap_zoom')));
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        L.tileLayer(oGeneralProperties.worldmap_tiles_url, {
             attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
             noWrap: true, // don't repeat the world on horizontal axe
             detectRetina: true, // look nice on high resolution screens

--- a/share/server/core/classes/CorePDOHandler.php
+++ b/share/server/core/classes/CorePDOHandler.php
@@ -287,6 +287,7 @@ class CorePDOHandler {
                 $res = $this->DB->exec($q);
                 if($res === false) {
                     $this->DB = null;
+                    $this->lastErrorInfo = "Initial DB query ($q) failed";
                     return false;
                 }
             }

--- a/share/server/core/classes/CorePDOHandler.php
+++ b/share/server/core/classes/CorePDOHandler.php
@@ -261,6 +261,7 @@ class CorePDOHandler {
         }
         $drv_data = self::$DRIVERS[$driver];
         $dsn = "$driver:".$drv_data['build_dsn']($params);
+        $this->dsn = $dsn;
 
         try {
             $this->DB = new PDO($dsn, $username, $password, array(
@@ -270,12 +271,12 @@ class CorePDOHandler {
             ));
         } catch(PDOException $e) {
             error_log('Could not initialize a database connection: '.$e->getMessage());
+            $this->lastErrorInfo = $e->getMessage();
             return false;
-    	}
+        }
         if($this->DB === false || $this->DB === null)
             return false;
 
-        $this->dsn = $dsn;
         $this->driver = $driver;
         $this->data = $drv_data;
         $this->updating = false;
@@ -356,7 +357,7 @@ class CorePDOHandler {
         if (isset($this->lastErrorInfo))
             return $this->lastErrorInfo;
         else
-            return $this->DB->errorInfo();
+            return $this->DB ? $this->DB->errorInfo() : '';
     }
 
     public function errorString() {
@@ -618,7 +619,7 @@ class CorePDOHandler {
 
         // Access control: View URLs e.g. in rotation pools
         $this->queryFatal('-perm-add', array('mod' => 'Url', 'act' => 'view', 'obj' => '*'));
-        
+
         // Assign the new permission to the managers, users, guests
         $this->queryFatal('-create-pop-roles-perms-3', array(
             'r1' => 'Managers', 'r2' => 'Users (read-only)', 'r3' => 'Guests',

--- a/share/server/core/classes/GlobalMainCfg.php
+++ b/share/server/core/classes/GlobalMainCfg.php
@@ -154,6 +154,12 @@ class GlobalMainCfg {
                     'match'   => MATCH_STRING_URL,
                 ),
 
+                'worldmap_tiles_url' => array(
+                    'must'    => 0,
+                    'default' => 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    'match'   => MATCH_STRING_URL,
+                ),
+
                 'http_proxy' => array(
                     'must'    => 0,
                     'default' => null,
@@ -655,7 +661,7 @@ class GlobalMainCfg {
                     'must'       => 0,
                     'editable'   => 1,
                     'default'    => '0',
-                    'match'      => MATCH_BOOLEAN, 
+                    'match'      => MATCH_BOOLEAN,
                     'field_type' => 'boolean',
                 ),
                 'line_weather_colors' => Array(
@@ -2184,6 +2190,7 @@ class GlobalMainCfg {
           'internal_title'     => $this->getValue('internal', 'title'),
           'header_show_states' => intval($this->getValue('defaults', 'header_show_states')),
           'zoom_scale_objects' => intval($this->getValue('defaults', 'zoom_scale_objects')),
+          'worldmap_tiles_url' => $this->getValue('global', 'worldmap_tiles_url'),
         );
 
         // Add custom action configuration

--- a/share/server/core/defines/matches.php
+++ b/share/server/core/defines/matches.php
@@ -21,7 +21,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  *
  *****************************************************************************/
- 
+
 /**
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
@@ -37,7 +37,7 @@ define('MATCH_STRING_NO_SPACE_EMPTY', '/^[0-9a-zа-яё\p{L}:+[\]()_.,\-\*?!#@=\
 define('MATCH_CONDITION', '/^[0-9a-zа-яё\p{L}\s_\-~=]*$/iu');
 
 define('MATCH_STRING_PATH', '/^[0-9a-z\s_.\-\/\\\]+$/i');
-define('MATCH_STRING_URL', '/^[0-9a-z\s:;|+[\]()=%?&_,.\-#@=\/\\\~]+$/i');
+define('MATCH_STRING_URL', '/^[0-9a-z\s:;|+[\]()=%?&_,.\-#@=\/\\\~\{\}]+$/i');
 define('MATCH_STRING_URL_EMPTY', '/^[0-9a-z\s:;|+[\]()=%?&_,.\-#@=\/\\\~]*$/i');
 define('MATCH_GADGET_OPT', '/^[0-9a-z\s:+[\]()_.,\-&?!#@=\/\\\%]+$/i');
 define('MATCH_STRING_STYLE', '/^[0-9a-z:;\-+%#(),.]*$/i');


### PR DESCRIPTION
Added one extra configuration option, `worldmap_tiles_url` into `[global]` section of `nagvis.ini.php`

The formerly hardcoded value `https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png` is now default and can be overriden in `nagvis.ini.php` or via browser nagvis -> options -> general configuration.

* backwards compatible
* changelog & docs updated
* added to current version 1.9.13
