### PR TITLE
FIX: worldmap textbox visibility per zoom level

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 1.9.13
+Worldmap:
+  * FIX: worldmap textbox visibility per zoom level
 
 1.9.12
 Core:

--- a/share/server/core/sources/worldmap.php
+++ b/share/server/core/sources/worldmap.php
@@ -337,7 +337,7 @@ function process_worldmap($MAPCFG, $map_name, &$map_config) {
         $min_zoom = isset($obj['min_zoom']) ? (int)$obj['min_zoom'] : $MAPCFG->getDefaultValue('host', 'min_zoom');
         $max_zoom = isset($obj['max_zoom']) ? (int)$obj['max_zoom'] : $MAPCFG->getDefaultValue('host', 'max_zoom');
 
-        if ($min_zoom < $max_zoom && ($zoom < $min_zoom || $zoom > $max_zoom))
+        if ($min_zoom <= $max_zoom && ($zoom < $min_zoom || $zoom > $max_zoom))
             continue;
 
         $map_config[$object_id] = $obj;


### PR DESCRIPTION
One-line fix for the issue #132. Textboxes are now only visible in specified zoom levels, including one level only (`min_zoom`==`max_zoom`==`16` for example).