### PR TITLE
Feature: dim openstreetmap colors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@
 Worldmap:
   * FIX: worldmap textbox visibility per zoom level
   * Configurable OpenStreetMap tile server URL (worldmap_tiles_url)
-  * FIX: worldmap textbox visibility per zoom level
+  * Feature: dim openstreetmap colors
 
 1.9.12
 Core:

--- a/docs/en_US/worldmap.html
+++ b/docs/en_US/worldmap.html
@@ -49,6 +49,7 @@
     sources=worldmap
     worldmap_center=50.86837814203458,10.21728515625
     worldmap_zoom=6
+    worldmap_tiles_saturate=33
 }</pre>
 
         <p>Only the last three attributes are worldmap specific definitions, all of them are mandatory for
@@ -63,6 +64,8 @@
         <p>The <code>worldmap_zoom=6</code> specifies the initial zoom level to be used when rendering the worldmap.
         NagVis allows zoom levels from 2 to 18.</p>
 
+        <p>The <code>worldmap_tiles_saturate=33</code> dims the colors of default OpenStreetMap so that red motorways or
+        large green forests don't interfere with actual map objects. Possible values are 0 (no colors, grayscale) through 100 (full colors).</p>
 
         <h2>Create your own worldmap</h2>
 

--- a/etc/maps/demo-worldmap.cfg
+++ b/etc/maps/demo-worldmap.cfg
@@ -6,6 +6,7 @@ define global {
     backend_id=demo
     worldmap_center=50.86837814203458,10.21728515625
     worldmap_zoom=6
+    worldmap_tiles_saturate=33
     iconset=std_geo
     icon_size=32
 }

--- a/share/frontend/nagvis-js/js/ViewWorldmap.js
+++ b/share/frontend/nagvis-js/js/ViewWorldmap.js
@@ -80,6 +80,12 @@ var ViewWorldmap = ViewMap.extend({
         if (typeof checkHideMenu !== "undefined")
             g_map.on('mousedown', checkHideMenu);
         g_map.on('mousedown', context_handle_global_mousedown);
+
+        // dim the colors of map background so that red motorways don't distract
+        let saturate_percentage = getViewParam('worldmap_tiles_saturate')
+        let ltp = document.getElementsByClassName('leaflet-tile-pane');
+        if (ltp && saturate_percentage !== '')
+            ltp[0].style.filter = `saturate(${saturate_percentage}%)`
     },
 
     handleMoveStart: function(lEvent) {

--- a/share/server/core/sources/worldmap.php
+++ b/share/server/core/sources/worldmap.php
@@ -32,6 +32,11 @@ $configVars = array(
         'default'   => 6,
         'match'     => MATCH_WORLDMAP_ZOOM,
     ),
+    'worldmap_tiles_saturate' => array(
+        'must'      => false,
+        'default'   => '',
+        'match'     => MATCH_INTEGER_EMPTY,
+    ),
 
     /*** OBJECT OPTIONS ***/
     'min_zoom' => array(
@@ -53,6 +58,7 @@ $configVarMap = array(
         'worldmap' => array(
             'worldmap_center' => null,
             'worldmap_zoom'   => null,
+            'worldmap_tiles_saturate'   => null,
         ),
     ),
 );


### PR DESCRIPTION
New minor feature that greatly improves the readability of the worldmap maps. When using OpenStreetMap background, red motorways and green forest stretches easily visually collide with red and green objects. This is to add worldmap_tiles_saturate map option (percentage, 0 - 100). Values around 25% make the default mapnik images good enough.

Configuration (map options)
`worldmap_tiles_saturate=25`

Before:
<img width="853" alt="Screen Shot 2019-07-01 at 16 15 22" src="https://user-images.githubusercontent.com/20604326/60653406-4726bb80-9e4a-11e9-9f52-9c0059b09128.png">

After:
<img width="853" alt="Screen Shot 2019-07-01 at 16 15 48" src="https://user-images.githubusercontent.com/20604326/60653409-49891580-9e4a-11e9-930a-d844a47584d4.png">

enjoy 😎
Vojtech