### PR TITLE
Worldmap consistent reloads

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 1.9.14
+Worldmap:
+  * consistent page reloads: center+zoom of the map kept in URL
 
 1.9.13
 Worldmap:

--- a/share/frontend/nagvis-js/js/ViewWorldmap.js
+++ b/share/frontend/nagvis-js/js/ViewWorldmap.js
@@ -76,7 +76,16 @@ var ViewWorldmap = ViewMap.extend({
             maxBounds: [ [-85,-180.0], [85,180.0] ],
             minZoom: 2,
             layers: [layers.map]
-        }).setView(getViewParam('worldmap_center').split(','), parseInt(getViewParam('worldmap_zoom')));
+        })
+        
+        let restored_coordinates = window.location.hash.substr(1).split('/');
+        if (restored_coordinates.length === 3) {
+            // place the map view according to location hash (#lat/lon/zoom) - consistent page reloads
+            g_map.setView([restored_coordinates[1], restored_coordinates[0]], restored_coordinates[2]);
+        } else {
+            // or default (map-defined) view
+            g_map.setView(getViewParam('worldmap_center').split(','), parseInt(getViewParam('worldmap_zoom')));
+        }   
         
         if (layers.satellite)
             L.control.layers(layers).addTo(g_map);
@@ -115,6 +124,10 @@ var ViewWorldmap = ViewMap.extend({
         setViewParam('worldmap_zoom', g_map.getZoom());
 
         this.render(); // re-render the whole map
+        
+        // Put the new map view coords into URL (location) - consistent reloads
+        new_center = g_map.getCenter();
+        window.location.hash = `${new_center.lng}/${new_center.lat}/${g_map.getZoom()}`;
     },
 
     saveView: function() {


### PR DESCRIPTION
## What
The worldmap now shows the same view after browser reloads the page.

## Why
Since worldmap allows user to pan and/or zoom to a specific location, two UX points were lost:
- after reload of the page, the same view should get displayed
- re-using the page URL (bookmarking it, sharing it, etc) should lead to the same view

This simple PR brings above points back.

## How

Before: the URL contains map name `awesome-map`
```
/nagvis/frontend/nagvis-js/index.php?mod=Map&act=view&show=awesome-map
```

After: the URL contains map name `awesome-map` *and* coordinates + zoom level
```
/nagvis/frontend/nagvis-js/index.php?mod=Map&act=view&show=awesome-map#13.099479675292969/49.10961304715635/13
```
