### PR TITLE
Performance & memory optimization - worldmap line rendering

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 1.9.14
 Worldmap:
   * memory and performance optimization: line rendering - clip long lines protruding out of viewport
+  * memory and performance optimization: fix getMapObject SQL query (lng/lat rectangle)
 
 1.9.13
 Worldmap:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 1.9.14
+Worldmap:
+  * memory and performance optimization: line rendering - clip long lines protruding out of viewport
 
 1.9.13
 Worldmap:

--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -972,6 +972,9 @@ var ElementLine = Element.extend({
      */
      
     cutLineBeyondViewport: function(xA, yA, xB, yB) {
+        if (!g_map)
+            return([xA, yA, xB, yB]); // no viewport - no clipping
+
         let viewport_size = g_map.getSize();
         const xMax = viewport_size.x; // 1920
         const yMax = viewport_size.y; // 1080

--- a/share/server/core/sources/worldmap.php
+++ b/share/server/core/sources/worldmap.php
@@ -159,18 +159,12 @@ function worldmap_get_objects_by_bounds($sw_lng, $sw_lat, $ne_lng, $ne_lat) {
     global $DB;
     worldmap_init_db();
 
+    if ($sw_lat > $ne_lat) swap($sw_lat, $ne_lat);
+    if ($sw_lng > $ne_lng) swap($sw_lng, $ne_lng);
+        
     $q = 'SELECT lat, lng, lat2, lng2, object FROM objects WHERE'
-        .'((:sw_lat < :ne_lat AND lat BETWEEN :sw_lat AND :ne_lat)'
-        .' OR (:ne_lat < :sw_lat AND lat BETWEEN :ne_lat AND :sw_lat)'
-        .'AND '
-        .'(:sw_lng < :ne_lng AND lng BETWEEN :sw_lng AND :ne_lng)'
-        .' OR (:ne_lng < :sw_lng AND lng BETWEEN :ne_lng AND :sw_lng))'
-        .'OR '
-        .'((:sw_lat < :ne_lat AND lat2 BETWEEN :sw_lat AND :ne_lat)'
-        .' OR (:ne_lat < :sw_lat AND lat2 BETWEEN :ne_lat AND :sw_lat)'
-        .'AND '
-        .'(:sw_lng < :ne_lng AND lng2 BETWEEN :sw_lng AND :ne_lng)'
-        .' OR (:ne_lng < :sw_lng AND lng2 BETWEEN :ne_lng AND :sw_lng))';
+        .'(lat BETWEEN :sw_lat AND :ne_lat AND lng BETWEEN :sw_lng AND :ne_lng)'
+        .'OR (lat2 BETWEEN :sw_lat AND :ne_lat AND lng2 BETWEEN :sw_lng AND :ne_lng)';
 
     $RES = $DB->query($q, array('sw_lng' => $sw_lng, 'sw_lat' => $sw_lat, 'ne_lng' => $ne_lng, 'ne_lat' => $ne_lat));
     $objects = array();
@@ -375,6 +369,12 @@ function process_worldmap($MAPCFG, $map_name, &$map_config) {
 function changed_worldmap($MAPCFG, $compare_time) {
     $db_path = cfg('paths', 'cfg').'worldmap.db';
     return !file_exists($db_path) || filemtime($db_path) > $compare_time;
+}
+
+function swap(&$x, &$y) {
+    $tmp=$x;
+    $x=$y;
+    $y=$tmp;
 }
 
 ?>


### PR DESCRIPTION
## What
Worldmap now renders long `line` objects more efficiently. Both backend and frontend CPU time is reduced, and browser memory usage is lower. Firefox doesn't crash anymore on an 8GB machine.

## Why & how
Same as the last time: we do pursue usability for our MAN monitoring. There is a need for smooth UX.

### (1) frontend rendering for `line` object 
Javascript renderer create `<canvas>` element for every line. For long lines protruding far beyond the viewport, many huge `<canvas>`es sizes 10000x10000-ish pixels ate a huge amount of memory. 

In both firefox and chrome, it did exhaust memory. Additionally, in firefox, occasional generic `NS_ERROR_FAILURE` jumped out of the rendering loop.

Now the long lines are clipped into the viewport using [Cohen–Sutherland](https://en.wikipedia.org/wiki/Cohen%E2%80%93Sutherland_algorithm) algorithm by a rectangle 10% bigger than the viewport.

See what happens when the browser window is enlarged:
<img width="871" alt="Screen Shot 2019-07-10 at 14 33 43" src="https://user-images.githubusercontent.com/20604326/61048252-a30cb980-a3e1-11e9-96f4-49fed1890c1d.png">



### (2) backend SQL query to `object` table
The backend ajax_handler.php call for `mod=Map&act=getMapObjects` did return extra objects laying out of the viewport (wrong SQL query). Extra objects didn't cause any harm in frontend; it's only about performance optimization.

Before:
The `worldmap_get_objects_by_bounds()` query returned objects located in the rectangle of interest, and also vertical region A and horizontal region B. (I believe it was the wrong parenthesis)

<img width="1146" alt="Screen Shot 2019-07-11 at 13 13 09" src="https://user-images.githubusercontent.com/20604326/61047941-e0247c00-a3e0-11e9-9eac-d2ad790c00fd.png">

After:
Only objects located (lines starting+ending) in a rectangle of interest are `SELECT`ed.
