### PR TITLE
fix "You are not permitted to access this page (ChangePassword/view/)"

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 1.9.15
+Core:
+  * Fix "You are not permitted to access this page (ChangePassword/view/)" for users (issue #215)
 
 1.9.14
 Core:

--- a/share/server/core/classes/CorePDOHandler.php
+++ b/share/server/core/classes/CorePDOHandler.php
@@ -63,6 +63,7 @@ class CorePDOHandler {
                         .'WHERE users2roles."userId" = :id',
                     '-perm-rename-map' => 'UPDATE perms SET obj=:new_name '.
                         ' WHERE "mod"=\'Map\' AND obj=:old_name',
+                    '-perm-change-act' => 'UPDATE perms SET act=:new_act WHERE mod=:mod and act=:old_act',
 
                     '-role-add' => 'INSERT INTO roles (name) VALUES (:name)',
                     '-role-add-with-id' => 'INSERT INTO roles ("roleId", name) VALUES (:roleId, :name)',
@@ -128,6 +129,10 @@ class CorePDOHandler {
                 ),
 
                 'updates' => array(
+                    '1091500' => array(
+                        array('-perm-change-act', array('mod' => 'ChangePassword', 'old_act' => 'change', 'new_act' => '*'))
+                    ),
+
                     '1080600' => array(
                         array('-perm-add', array('mod' => 'Url', 'act' => 'view', 'obj' => '*')),
                         array('-create-pop-roles-perms-3', array(
@@ -462,7 +467,7 @@ class CorePDOHandler {
         try {
             ksort(self::$DRIVERS['_common']['updates']);
             foreach (self::$DRIVERS['_common']['updates'] as $ver => $queries) {
-                if (intval($ver) <= $dbVersion)
+                if (intval($ver) < $dbVersion)
                     continue;
 
                 if (!$this->inTrans) {
@@ -585,7 +590,7 @@ class CorePDOHandler {
         $this->queryFatal('-perm-add', array('mod' => 'User', 'act' => 'setOption', 'obj' => '*'));
 
         // Access controll: Change own password
-        $this->queryFatal('-perm-add', array('mod' => 'ChangePassword', 'act' => 'change', 'obj' => '*'));
+        $this->queryFatal('-perm-add', array('mod' => 'ChangePassword', 'act' => '*', 'obj' => '*'));
 
         // Access controll: View maps via multisite
         $this->queryFatal('-perm-add', array('mod' => 'Multisite', 'act' => 'getMaps', 'obj' => '*'));


### PR DESCRIPTION
# Why
It's reported bug #215. Easily reproducible in v1.9.15.

# What
The default `Users (read-only)` role have the following permission by default:
```sql
sqlite> select * from perms where mod='ChangePassword';
permId|mod|act|obj
28|ChangePassword|change|*
```
However the actual request URL called by browser is `...ajax_handler.php?mod=ChangePassword&act=view`. Note the **view** vs. **change**.

Without further ado, I have just enabled a wildcard `*` action for `ChangePassword`.

# How
For existing installations: using the `CorePDOHandler` updates aka "migrations" for v 1.9.15, or `1091500`.
For new installations, the `CorePDOHandler` does it right away in `createInitialDb()`.