### PR TITLE
Do not only consider acknowledged status but also downtime

### DIFF
--- a/share/userfiles/templates/default.css
+++ b/share/userfiles/templates/default.css
@@ -767,6 +767,7 @@ div.statediv.sPENDING, div.statediv.sUNCHECKED {
 
 div.statediv.sACK {
     border-style: dotted;
+    clip-path: polygon(100% 0, 100% 20%, 20% 100%, 0 100%, 0 0);
 }
 
 /*


### PR DESCRIPTION
Make acknowledged map state more prominent by making it a triangle (for the browsers that support a clip-path) additionally to keeping the border dotted

Fixes #224 

![image](https://user-images.githubusercontent.com/277893/69008950-b233e300-0950-11ea-801f-4970428d573c.png)
