### PR TITLE
Individual indicators for sidebar icons if acked and/or in downtime

### DIFF
--- a/share/userfiles/templates/default.css
+++ b/share/userfiles/templates/default.css
@@ -765,8 +765,17 @@ div.statediv.sPENDING, div.statediv.sUNCHECKED {
     background-color: #C0C0C0;
 }
 
-div.statediv.sACK {
+div.statediv.sACK:not(.sDOWNTIME) {
     border-style: dotted;
+    clip-path: polygon(100% 0, 100% 100%, 50% 50%, 0 100%, 0 0);
+}
+div.statediv.sDOWNTIME:not(.sACK) {
+    border-style: dotted;
+    clip-path: polygon(100% 0, 100% 100%, 0 100%, 0 0, 50% 50%);
+}
+div.statediv.sACK.sDOWNTIME {
+    border-style: dotted;
+    clip-path: polygon(50% 50%, 100% 0, 100% 100%, 50% 50%, 0 100%, 0 0);
 }
 
 /*

--- a/share/userfiles/templates/default.header.js
+++ b/share/userfiles/templates/default.header.js
@@ -103,8 +103,11 @@ function headerUpdateState(map_conf) {
     var side = document.getElementById('side-state-' + map['name']);
     if (side) {
         side.className = 'statediv s' + map['summary_state'];
-        if (map['summary_problem_has_been_acknowledged']==1) {
+        if (map['summary_problem_has_been_acknowledged'] == 1) {
             side.className += ' sACK';
+        }
+        if (map['summary_in_downtime'] == 1) {
+            side.className += ' sDOWNTIME';
         }
         side = null;
     }


### PR DESCRIPTION
Fixes #224 

Note that for older browsers not supporting clip paths, we still show the dotted border indicating something is going on which should work in any case. So this is actually an extension of #221.