### PR TITLE
Set object's default max_zoom to 20 (was: 18)

### DIFF
--- a/share/server/core/sources/worldmap.php
+++ b/share/server/core/sources/worldmap.php
@@ -46,7 +46,7 @@ $configVars = array(
     ),
     'max_zoom' => array(
         'must'      => false,
-        'default'   => 18,
+        'default'   => 19,
         'match'     => MATCH_WORLDMAP_ZOOM,
     ),
 );
@@ -161,7 +161,7 @@ function worldmap_get_objects_by_bounds($sw_lng, $sw_lat, $ne_lng, $ne_lat) {
 
     if ($sw_lat > $ne_lat) swap($sw_lat, $ne_lat);
     if ($sw_lng > $ne_lng) swap($sw_lng, $ne_lng);
-        
+
     $q = 'SELECT lat, lng, lat2, lng2, object FROM objects WHERE'
         .'(lat BETWEEN :sw_lat AND :ne_lat AND lng BETWEEN :sw_lng AND :ne_lng)'
         .'OR (lat2 BETWEEN :sw_lat AND :ne_lat AND lng2 BETWEEN :sw_lng AND :ne_lng)';

--- a/share/server/core/sources/worldmap.php
+++ b/share/server/core/sources/worldmap.php
@@ -2,7 +2,7 @@
 
 class WorldmapError extends MapSourceError {}
 
-define('MATCH_WORLDMAP_ZOOM', '/^1?[0-9]$/');
+define('MATCH_WORLDMAP_ZOOM', '/^1?[0-9]|20$/');
 
 // Register this source as being selectable by the user
 global $selectable;
@@ -46,7 +46,7 @@ $configVars = array(
     ),
     'max_zoom' => array(
         'must'      => false,
-        'default'   => 19,
+        'default'   => 20,
         'match'     => MATCH_WORLDMAP_ZOOM,
     ),
 );


### PR DESCRIPTION
This is an amendment to https://github.com/NagVis/nagvis/pull/201. Maximum zoom on worldmap is now 20, however, the object's default is `max_zoom=18`. That causes newly created object to not show when on zoom 20, which is common use case.

