### PR TITLE
Enhancement: worldmap now shows even middle sections of long lines

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Core:
 Frontend:
   * Sidebar map states now indicate acknowledgement and downtime states (issue #221)
   * Textboxes can now be edited using a simple WYSIWIG editor (issue #216)
+  * Worldmap: render middle sections of long lines
 
 1.9.17
 Core:


### PR DESCRIPTION
# What
The maps of type `worldmap` may contain (long) lines, and allow to user to pan and zoom anywhere. When the viewport shows a strip of land that a long line passes by, and such line begins and ends far beyond viewport edges, its section is now visible properly.

## situation
<img width="671" alt="Screen Shot 2020-01-06 at 14 11 12" src="https://user-images.githubusercontent.com/20604326/71820982-278a7d00-3091-11ea-9150-ece1d831c136.png">

## the purple viewport before
<img width="671" alt="Screen Shot 2020-01-06 at 14 14 01" src="https://user-images.githubusercontent.com/20604326/71821098-7cc68e80-3091-11ea-9382-49cedab89ef9.png">

## the purple viewport after
<img width="672" alt="Screen Shot 2020-01-06 at 14 13 49" src="https://user-images.githubusercontent.com/20604326/71821101-7fc17f00-3091-11ea-92a4-f175abf81f2e.png">


# Why
It has emerged over time that users had used the map following way: Find location A (possibly using browser bookmark) and then drag, drag, drag, and drag **along the line** to the location B. Following the lines were not possible after the edge of viewport has left the A, and by the user found B, they are lost.

# How
The SQL query that `SELECT`s objects to render is altered.
In a human speech:

before: 
```
SELECT lines WHERE a-point within bounding-box OR b-point within bounding-box
```

now:
```
SELECT lines WHERE a-point within bounding-box OR b-point within bounding-box
OR the line intersects western or eastern or southern or northern edge of bounding-box
```

The `intersects` condition is implemented using common 2D `rx + sx + t = 0` line equation, and resolving a set of such 2 equations, and testing whether the found common point lays onto and edge line. Everything coded in pure SQL, therefore computed within SQLite engine. Thanks for [mat-phys](https://www.mff.cuni.cz/en) fellows for a theory on this.