### PR TITLE
Usability fix: remove 'detectRetina' feature of Leaflet

### DIFF
--- a/share/frontend/nagvis-js/js/ViewWorldmap.js
+++ b/share/frontend/nagvis-js/js/ViewWorldmap.js
@@ -59,7 +59,7 @@ var ViewWorldmap = ViewMap.extend({
             "map": L.tileLayer(oGeneralProperties.worldmap_tiles_url, {
                 attribution: oGeneralProperties.worldmap_tiles_attribution,
                 noWrap: true, // don't repeat the world on horizontal axis
-                detectRetina: true, // look nice on high resolution screens
+                detectRetina: false, // this causes trouble with maximum zoom level (19 vs. 20), don't use
                 maxZoom: 20,
             }),
         }
@@ -67,7 +67,7 @@ var ViewWorldmap = ViewMap.extend({
             layers.satellite = L.tileLayer(oGeneralProperties.worldmap_satellite_tiles_url, {
                 attribution: oGeneralProperties.worldmap_satellite_tiles_attribution,
                 noWrap: true, // don't repeat the world on horizontal axis
-                detectRetina: true, // look nice on high resolution screens
+                detectRetina: false,
                 maxZoom: 20,
             })
         }


### PR DESCRIPTION
I've recently introduced the [detectRetina feature](https://leafletjs.com/reference-1.6.0.html#tilelayer-detectretina) into worldmap view. It was not a good idea, and now I want to roll it back.

Although it does render beautiful map layers on MacBook retina displays, there's a major usability problem: the maximum usable zoom level is 19 (with hi-res display) which makes all important objects in level 20 unusable.
