### PR TITLE
Bugfix: Update ViewMap.js

### DIFF
--- a/share/frontend/nagvis-js/js/ViewMap.js
+++ b/share/frontend/nagvis-js/js/ViewMap.js
@@ -237,7 +237,7 @@ var ViewMap = View.extend({
         var parents = obj.getParentObjectIds();
         if (parents) {
             for (var parentObjId in parents) {
-                if (obj.childs.length != 0) this.objects[parentObjId].addChild(obj);
+                if (isset(this.objects[parentObjId])) this.objects[parentObjId].addChild(obj);
             }
         }
     },

--- a/share/frontend/nagvis-js/js/ViewMap.js
+++ b/share/frontend/nagvis-js/js/ViewMap.js
@@ -237,7 +237,7 @@ var ViewMap = View.extend({
         var parents = obj.getParentObjectIds();
         if (parents) {
             for (var parentObjId in parents) {
-                this.objects[parentObjId].addChild(obj);
+                if (obj.childs.length != 0) this.objects[parentObjId].addChild(obj);
             }
         }
     },


### PR DESCRIPTION
JS Error on .addchild when object doesn't have children.  Check for length of array before calling function.