### PR TITLE
Enhancement: Adjust color for weathermap line that is down

### DIFF
--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -777,7 +777,7 @@ var ElementLine = Element.extend({
             return oStates["ERROR"].color;
 
         if (!this.perfdata)
-            return '#FFCC66';
+            return oStates["CRITICAL"].color;
 
         if (this.perfdata[id][2] == '%' && this.perfdata[id][1] !== null) {
             return this.getColorFill(this.perfdata[id][1]);


### PR DESCRIPTION
Remove hard-coded color for down weathermap line and use the state color instead.