### PR TITLE
Enhancement: New config options to specify line_labels

### DIFF
--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -814,6 +814,8 @@ var ElementLine = Element.extend({
     calculateUsage: function(oldPerfdata) {
         var newPerfdata = [];
         var foundNew = false;
+        var line_label_in = 'in';
+        var line_label_out = 'out';
 
         // Check_MK if/if64 checks support switching between bytes/bits. The detection
         // can be made by some curios hack. The most hackish hack I've ever seen. From hell.
@@ -824,8 +826,14 @@ var ElementLine = Element.extend({
 
         // This loop takes perfdata with the labels "in" and "out" and uses the current value
         // and maximum values to parse the percentage usage of the line
+        if (typeof this.obj.conf.line_label_in !== 'undefined') {
+            line_label_in = this.obj.conf.line_label_in;
+        }
+        if (typeof this.obj.conf.line_label_out !== 'undefined') {
+            line_label_out = this.obj.conf.line_label_out;
+        }
         for(var i = 0; i < oldPerfdata.length; i++) {
-            if(oldPerfdata[i][0] == 'in' && (oldPerfdata[i][2] === null || oldPerfdata[i][2] === '')) {
+            if(oldPerfdata[i][0] == line_label_in && (oldPerfdata[i][2] === null || oldPerfdata[i][2] === '')) {
                 newPerfdata[0] = this.perfdataCalcPerc(oldPerfdata[i]);
                 if(!display_bits) {
                     newPerfdata[2] = this.perfdataCalcBytesReadable(oldPerfdata[i]);
@@ -835,7 +843,7 @@ var ElementLine = Element.extend({
                 }
                 foundNew = true;
             }
-            if(oldPerfdata[i][0] == 'out' && (oldPerfdata[i][2] === null || oldPerfdata[i][2] === '')) {
+            if(oldPerfdata[i][0] == line_label_out && (oldPerfdata[i][2] === null || oldPerfdata[i][2] === '')) {
                 newPerfdata[1] = this.perfdataCalcPerc(oldPerfdata[i]);
                 if(!display_bits) {
                     newPerfdata[3] = this.perfdataCalcBytesReadable(oldPerfdata[i]);
@@ -945,7 +953,7 @@ var ElementLine = Element.extend({
         // Break perfdata parts into array
         for (var i = 0; i < perfdataMatches.length; i++) {
             // Get parts of perfdata from string
-            var tmpSetMatches = perfdataMatches[i].match(/(&#145;)?([\w\s\=\']*)(&#145;)?\=([\d\.\-\+]*)([\w%]*)[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-\+]*)[\;|\s]?([\d\.\-\+]*)/);
+            var tmpSetMatches = perfdataMatches[i].match(/(&#145;)?([\w\s\=\'\-]*)(&#145;)?\=([\d\.\-\+]*)([\w%]*)[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-\+]*)[\;|\s]?([\d\.\-\+]*)/);
 
             // Check if we got any perfdata
             if (tmpSetMatches === null)

--- a/share/server/core/mapcfg/default.php
+++ b/share/server/core/mapcfg/default.php
@@ -543,6 +543,20 @@ $mapConfigVars = Array(
         'depends_on'    => 'view_type',
         'depends_value' => 'line'
     ),
+    'line_label_in' => Array(
+        'must'          => 0,
+        'default'       => 'in',
+        'match'         => MATCH_STRING,
+        'depends_on'    => 'view_type',
+        'depends_value' => 'line',
+    ),
+    'line_label_out' => Array(
+        'must'          => 0,
+        'default'       => 'out',
+        'match'         => MATCH_STRING,
+        'depends_on'    => 'view_type',
+        'depends_value' => 'line',
+    ),
     'line_label_y_offset' => Array(
         'must'          => 0,
         'default'       => 2,
@@ -1195,6 +1209,8 @@ $mapConfigVarMap['service'] = Array(
         'line_type' => null,
         'line_cut' => null,
         'line_label_show' => null,
+        'line_label_in' => null,
+        'line_label_out' => null,
         'line_label_pos_in' => null,
         'line_label_pos_out' => null,
         'line_label_y_offset' => null,


### PR DESCRIPTION
This adds two new config values 'line_label_in' and 'line_label_out' to specify which values to use from perfdata for weathermap lines. The default values are set to 'in' and 'out' for backward compatibility.