### PR TITLE
Fix: multi-line string in textboxes

### DIFF
--- a/share/server/core/classes/GlobalMapCfg.php
+++ b/share/server/core/classes/GlobalMapCfg.php
@@ -301,7 +301,7 @@ class GlobalMapCfg {
         // here.
         if(version_compare(PHP_VERSION, '5.1.2', '==')) {
             $file = file($this->configFile);
-        } else { 
+        } else {
             $file = file($this->configFile, FILE_SKIP_EMPTY_LINES | FILE_IGNORE_NEW_LINES);
         }
 
@@ -624,7 +624,7 @@ class GlobalMapCfg {
             } else {
                 $val = $_REQUEST[$key];
             }
-                
+
             if(!$only_customized || ($val != $this->getValue(0, $key))) {
                 return $val;
             }
@@ -634,7 +634,7 @@ class GlobalMapCfg {
             $userParams = $USERCFG->getValue('params-' . $this->name);
             if(isset($userParams[$key])) {
                 return $userParams[$key];
-                
+
             } elseif(!$only_user_supplied) {
                 // Otherwise use the map global value (if allowed)
                 return $this->getValue(0, $key);
@@ -1544,6 +1544,8 @@ class GlobalMapCfg {
 
             if(is_array($val))
                 $val = implode(',', $val);
+
+            $val = str_replace( "\n", '<br/>', $val );
 
             $newLine = $key.'='.$val."\n";
 


### PR DESCRIPTION
A small fix.
The new HTML wysiwyg editor for textboxes allows multi-line strings. When such are saved into `etc/maps/*.cfg`, tge cfg file was broken. This fix converts the `\n` to `<br/>` which does the trick.

![image](https://user-images.githubusercontent.com/20604326/76439356-926f7180-63bc-11ea-908c-d80c17909340.png)


The *.cfg before (broken):
```
define textbox {
text=first
second
third
x=54
y=117
w=374
h=219
object_id=a0caf3
background_color=#A1B4FF
}
```

The *.cfg after (fixed):
```
define textbox {
text=first<br/>second<br/>third
x=54
y=117
w=374
h=219
object_id=a0caf3
background_color=#A1B4FF
}
```