### PR TITLE
Fix for rendering of weathermap halves

### DIFF
--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -377,8 +377,19 @@ var ElementLine = Element.extend({
                     var yMid = y[1];
                 }
 
-                this.renderArrow(0, xStart, yStart, xMid, yMid, width);
-                this.renderArrow(1, xEnd, yEnd, xMid, yMid, width);
+                if (cut == 1) {
+                // only ---> part, TODO: label handling, disabling for now
+                    this.renderArrow(0, xStart, yStart, xEnd, yEnd, width);
+                    this.obj.conf.line_label_show = '0';
+                } else if (cut == 0) {
+                // only <--- part, TODO: label handling, disabling for now
+                    this.renderArrow(1, xEnd, yEnd, xStart, yStart, width);
+                    this.obj.conf.line_label_show = '0';
+                } else {
+                // both parts, default behaviour
+                    this.renderArrow(0, xStart, yStart, xMid, yMid, width);
+                    this.renderArrow(1, xEnd, yEnd, xMid, yMid, width);
+                }
             break;
             default:
                 alert('Error: Unknown line type');


### PR DESCRIPTION
When using `conf.line_cut` values of 0 and 1 only one half of line should be drawn.
Unfortunately, disabling one of the two `renderArrow`s messes up `parts` array id's and consequently label drawing.
This patch is intended to fix render behavior for these values while disabling labels functionality for affected weathermap lines.
Haven't found easy way to make labels work as well, as it would seemingly require big changes to how render code for weathermap lines works.