### PR TITLE
Fix: simplify relative coordinates & adjust documentation

### DIFF
--- a/docs/en_US/map_config_format_description.html
+++ b/docs/en_US/map_config_format_description.html
@@ -1825,11 +1825,17 @@
     <p>When lines have one part (e.g. <i>---&gt;</i>) there must be two coords set.
         When using lines with two (e.g. <i>---&gt;&lt;---</i>) parts it is possible to set two coordinates for
     direct lines or three coordinates to reposition the middle of the line to a custom place.</p>
-
+    <h3>Relative coordinates</h3>
         <p>Since NagVis 1.6 it is possible to position objects depending on other objects. A relationship between
         two objects is defined from the &quot;childs&quot; view. This means the configuration needs to be done in
         the object which belongs to another object.<br />
         To define a relationship the coordinate is not given as integer anymore. Instead of the px offset the <i>object_id</i> of the parent object is used to define a relative position.</p>
+        Examples:
+        <ul>
+            <li><code>41790e%+30</code> = coordinate of object 41790e plus 30 pixels</li>
+            <li><code>41790e%-199</code> = coordinate of object 41790e minus 199 pixels</li>
+            <li><code>41790e%+0</code> = coordinate same as of object 41790e</li>
+        </ul>
         <p>We adapt the examples above and give the start of the line a relative position to the host object:</p>
     <pre>define host {
  object_id=41790e
@@ -1844,8 +1850,8 @@ define service {
  service_description=Interface eth0
  view_type=line
  line_type=10
- x=41790e,200
- y=41790e,200
+ x=41790e%+0,200
+ y=41790e%+0,200
 }</pre>
     <p>With the configuration above the beginning of the line is attached to the host object and moved every time
   the host object is moved.</p>

--- a/share/frontend/nagvis-js/js/NagVisObject.js
+++ b/share/frontend/nagvis-js/js/NagVisObject.js
@@ -335,34 +335,25 @@ var NagVisObject = Base.extend({
 
         var coord = 0;
 
-        // no relative coordinates on worldmap
-        if(!oViewProperties.params.worldmap_zoom && isRelativeCoord(val)) {
-            // This must be an object id. Is there an offset given?
-            if(val.search('%') !== -1) {
-                var parts     = val.split('%');
-                var objectId  = parts[0];
-                var offset    = parts[1];
-                var refObj    = getMapObjByDomObjId(objectId);
-                if (refObj) {
-                    coord = parseFloat(refObj.parseCoord(refObj.conf[dir], dir, false));
-                    if (addZoom)
-                        coord = addZoomFactor(coord, true);
-
-                    if (addZoom)
-                        coord += addZoomFactor(parseFloat(offset), false);
-                    else
-                        coord += parseFloat(offset);
-
-                    return coord;
-                }
-            } else {
-                // Only an object id. Get the coordinate and return it
-                var refObj = getMapObjByDomObjId(val);
-                if(refObj)
-                    coord = parseInt(refObj.parseCoord(refObj.conf[dir], dir, false));
-            }
-        } else {
+        if(!isRelativeCoord(val)) {
             coord = parseInt(val);
+        } else {
+            var parts     = val.split('%');
+            var objectId  = parts[0];
+            var offset    = parts[1];
+            var refObj    = getMapObjByDomObjId(objectId);
+            if (refObj) {
+                coord = parseFloat(refObj.parseCoord(refObj.conf[dir], dir, false));
+                if (addZoom)
+                    coord = addZoomFactor(coord, true);
+
+                if (addZoom)
+                    coord += addZoomFactor(parseFloat(offset), false);
+                else
+                    coord += parseFloat(offset);
+
+                return coord;
+            }
         }
 
         if (addZoom)

--- a/share/frontend/nagvis-js/js/NagVisObject.js
+++ b/share/frontend/nagvis-js/js/NagVisObject.js
@@ -131,7 +131,7 @@ var NagVisObject = Base.extend({
 
         // The line labels need a) the line added to DOM and b) the label added
         // to the dom before being able to calculate the correct coordinates
-        // needed in place().   
+        // needed in place().
         if (this.conf.type == 'line' || this.conf.view_type == 'line')
             for (var i = 0; i < this.elements.length; i++)
                 this.elements[i].place();
@@ -334,9 +334,9 @@ var NagVisObject = Base.extend({
             addZoom = true;
 
         var coord = 0;
-        if(!isRelativeCoord(val)) {
-            coord = parseInt(val);
-        } else {
+
+        // no relative coordinates on worldmap
+        if(!oViewProperties.params.worldmap_zoom && isRelativeCoord(val)) {
             // This must be an object id. Is there an offset given?
             if(val.search('%') !== -1) {
                 var parts     = val.split('%');
@@ -361,6 +361,8 @@ var NagVisObject = Base.extend({
                 if(refObj)
                     coord = parseInt(refObj.parseCoord(refObj.conf[dir], dir, false));
             }
+        } else {
+            coord = parseInt(val);
         }
 
         if (addZoom)

--- a/share/frontend/nagvis-js/js/nagvis.js
+++ b/share/frontend/nagvis-js/js/nagvis.js
@@ -1151,8 +1151,7 @@ function pxToInt(v) {
 // san francisco and zooming to new your will lead to a negative 5 digit
 // negative coord).
 function isRelativeCoord(v) {
-    return isset(v) && ((!isInt(v) && !isFloat(v))
-                        || (v.length === 6 && v.charAt(0) != "-" && v.indexOf(".") == -1));
+    return typeof(v) === 'string' && v.includes('%')
 }
 
 // Helper function to determine the number of entries in an object


### PR DESCRIPTION
Another fix for worldmap. 

## What?
Long south-north line, big zoom (20) and the [isRelativeCoord function](https://github.com/NagVis/nagvis/blob/d2787927b12c9988966a5b99cdcf1cdffe98cb52/share/frontend/nagvis-js/js/nagvis.js#L1155). The Y coordinate number gets over 100k, it's 6-digit number, see screenshot B, and gets interpreted as a relative coordinate.

Screenshot A, zoom 19
<img width="1872" alt="Screen Shot 2020-05-19 at 08 33 32" src="https://user-images.githubusercontent.com/20604326/82293282-9f0bd980-99ac-11ea-9274-7dba06d6b399.png">

Screenshot B, zoom 20
<img width="1873" alt="Screen Shot 2020-05-19 at 08 33 55" src="https://user-images.githubusercontent.com/20604326/82293298-a3d08d80-99ac-11ea-8906-60f534868128.png">

## How?
Simply avoiding [the problematic code](https://github.com/NagVis/nagvis/blob/master/share/frontend/nagvis-js/js/nagvis.js#L1153) for `worldmap` type maps.  Since relative coords don't work on `worldmap` anyway ([see: lat-lng based SELECT from database](https://github.com/NagVis/nagvis/blob/d2787927b12c9988966a5b99cdcf1cdffe98cb52/share/server/core/sources/worldmap.php#L216)) it doesn't seem to be a big deal.
