### PR TITLE
Fix js error (closing popup window)

### DIFF
--- a/share/frontend/nagvis-js/js/frontendMessage.js
+++ b/share/frontend/nagvis-js/js/frontendMessage.js
@@ -29,7 +29,7 @@ function frontendMessagePresent(key) {
 
 function frontendMessageRemove(key) {
     if(frontendMessagePresent(key)) {
-        document.body.removeChild(frontendMessages[key]);
+        popupWindowClose();
         delete frontendMessages[key];
     }
 }


### PR DESCRIPTION
Simple fix.

The error was:
<img width="775" alt="Screen Shot 2020-05-22 at 14 57 37" src="https://user-images.githubusercontent.com/20604326/82669969-a47f5300-9c3c-11ea-96b9-1320a51cf66c.png">
and occurred randomly every now and then

when called frontendMessageRemove('serverError'), after some subsequent AJAX request succeeds.