### PR TITLE
Feature: textbox scales according to zoom (scale_to_max_zoom option)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@
 Frontend:
   * FIX: Fix random error "NotFoundError: Node.removeChild"
 
+Worldmap:
+  * textbox scaling according to zoom (scale_to_max_zoom option)
+
 1.9.20
 Core:
   * Drop some PHP < 5.2 compatibility code for json encoding / decoding

--- a/docs/en_US/worldmap.html
+++ b/docs/en_US/worldmap.html
@@ -62,7 +62,8 @@
         coordinates to use as initial center for the worldmaps viewport.</p>
 
         <p>The <code>worldmap_zoom=6</code> specifies the initial zoom level to be used when rendering the worldmap.
-        NagVis allows zoom levels from 2 to 18.</p>
+        NagVis allows zoom levels from 2 (world) to 20 (building, detail).</p>
+
 
         <p>The <code>worldmap_tiles_saturate=33</code> dims the colors of default OpenStreetMap so that red motorways or
         large green forests don't interfere with actual map objects. Possible values are 0 (no colors, grayscale) through 100 (full colors).</p>
@@ -77,5 +78,22 @@
 
         <p>You can also create a new worldmap from an existing one by zoom and pan to create the viewport you like
         to use for your new worldmap, then choose <i>Edit Map > Viewport > Save as new Map</i>.
+
+        <h2>Objects on worldmap and zoom</h2>
+        The map object (host, line, textbox, ...) may be configured to only show at certain zoom levels. Related object attributes are:
+        <table style="width:100%">
+            <tr>
+                <th>Parameter</th><th>Default</th><th>Description</th>
+            </tr>
+            <tr>
+                <td>min_zoom</td><td>2</td><td>Only show the object at specified zoom level or higher (more detailed view)</td>
+            </tr>
+            <tr>
+                <td>max_zoom</td><td>20</td><td>Only show the object at specified zoom levels or lower (wider view)</td>
+            </tr>
+            <tr>
+                <td>scale_to_max_zoom</td><td>No</td><td>Scale the object size down to 50% for every zoom level below <code>max_zoom</code>. Only applicable to textboxes.</td>
+            </tr>
+        </table>
     </body>
 </html>

--- a/share/frontend/nagvis-js/js/ElementBox.js
+++ b/share/frontend/nagvis-js/js/ElementBox.js
@@ -23,12 +23,22 @@
 
 var ElementBox = Element.extend({
     render: function() {
+        let scale = 1;
+        if (g_map && usesSource('worldmap') && this.obj.conf.scale_to_max_zoom == '1') {
+            let currentZoom = g_map.getZoom();
+            let maxZoom = Number(this.obj.conf.max_zoom)
+            if (currentZoom < maxZoom) {
+                scale = 1 / Math.pow(2, maxZoom-currentZoom)
+            }
+        }
+
         this.dom_obj = renderNagVisTextbox(
             this.obj.conf.object_id+'-label',
             this.obj.conf.background_color, this.obj.conf.border_color,
             0, 0, // coords are set by this.place()
             this.obj.conf.z, this.obj.conf.w,
-            this.obj.conf.h, this.obj.getText(), this.obj.conf.style
+            this.obj.conf.h, this.obj.getText(), this.obj.conf.style,
+            scale
         );
         this.obj.trigger_obj = this.dom_obj;
         this.place();

--- a/share/frontend/nagvis-js/js/nagvis.js
+++ b/share/frontend/nagvis-js/js/nagvis.js
@@ -951,7 +951,7 @@ function hideStatusMessage() {
  * @return  Object  Returns the div object of the textbox
  * @author  Lars Michelsen <lm@larsmichelsen.com>
  */
-function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, customStyle) {
+function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, customStyle, scale) {
     var oLabelDiv = document.createElement('div');
     oLabelDiv.setAttribute('id', id);
     oLabelDiv.className = 'box';
@@ -968,6 +968,9 @@ function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, cust
         oLabelDiv.style.height = addZoomFactor(h) + 'px';
 
     oLabelDiv.style.zIndex = parseInt(z) + 1;
+
+    if (scale)
+        oLabelDiv.style.transform = `scale(${scale})`;
 
     /**
      * IE workaround: The transparent for the color is not enough. The border

--- a/share/server/core/mapcfg/default.php
+++ b/share/server/core/mapcfg/default.php
@@ -861,6 +861,12 @@ $mapConfigVars = Array(
         'field_type' => 'color',
         'match'      => MATCH_COLOR,
     ),
+    'scale_to_max_zoom' => Array(
+        'must'       => 0,
+        'default'    => 0,
+        'match'      => MATCH_BOOLEAN,
+        'field_type' => 'boolean',
+    ),
     'style' => Array(
         'must' => 0,
         'default' => '',
@@ -1427,6 +1433,9 @@ $mapConfigVarMap['textbox'] = Array(
         'type' => null,
         'use' => null,
     ),
+    'worldmap' => array(
+        'scale_to_max_zoom' => null,
+    )
 );
 
 $mapConfigVarMap['shape'] = Array(


### PR DESCRIPTION
Textboxes shrink as you zoom out. Just set `scale_to_max_zoom=Yes`.

## Description
A textbox can now shrink according to the map zoom.
![image](https://user-images.githubusercontent.com/20604326/82891407-fdf1c580-9f4d-11ea-8a18-8329166584eb.png)
This textbox would render 
- 100% size (width x height) at max zoom (20)
- 50% size at zoom 19
- 25% at zoom 18
- and so on

### Examples:
Full zoom
<img width="999" alt="Screen Shot 2020-05-26 at 12 32 37" src="https://user-images.githubusercontent.com/20604326/82892821-6fcb0e80-9f50-11ea-85b8-2a19f745d1e4.png">

One level up:
<img width="997" alt="Screen Shot 2020-05-26 at 12 33 27" src="https://user-images.githubusercontent.com/20604326/82892838-76f21c80-9f50-11ea-9089-e2cbdc7b5063.png">

Two levels up:
<img width="996" alt="Screen Shot 2020-05-26 at 12 33 37" src="https://user-images.githubusercontent.com/20604326/82892842-79547680-9f50-11ea-84a6-471c9c6d99d7.png">


