### PR TITLE
Fix: check_mk bit/s detecion again

### DIFF
--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -819,12 +819,10 @@ var ElementLine = Element.extend({
         var line_label_in = 'in';
         var line_label_out = 'out';
 
-        // Check_MK if/if64 checks support switching between bytes/bits. The detection
-        // can be made by some curios hack. The most hackish hack I've ever seen. From hell.
-        // Well, let's deal with it.
+        // Check_MK if/if64 checks support switching between bytes/bits.
         var display_bits = false;
-        output = output.match("In: [0-9](.*)Out: [0-9]")[1] || "";
-        if(output.includes("bit/s")){
+
+        if (output.match('In: [0-9].*bit/s.*Out: [0-9]+')) {
             display_bits=true;
         }
 


### PR DESCRIPTION
Subsequent fix of @soeren-gugel 's [PR 247](https://github.com/NagVis/nagvis/pull/247). I found this change breaking the functionality.

<img width="649" alt="Screen Shot 2020-05-25 at 08 31 15" src="https://user-images.githubusercontent.com/20604326/82785045-1edcec80-9e62-11ea-9569-444140c1870a.png">

The `output.match()[1]` construct fails when it does not match.

Fixed.