### PR TITLE
Fix multi-line strings and control characters in textboxes

### DIFF
--- a/share/server/core/classes/GlobalMapCfg.php
+++ b/share/server/core/classes/GlobalMapCfg.php
@@ -1547,6 +1547,9 @@ class GlobalMapCfg {
                 $val = implode(',', $val);
 
             $val = str_replace( "\n", '<br/>', $val );
+            $val = str_replace( "\r", '', $val );
+            $val = str_replace( "\t", ' ', $val );
+            $val = preg_replace( '/[\x00-\x1f]/', '', $val );
 
             $newLine = $key.'='.$val."\n";
 


### PR DESCRIPTION
A small fix, amendment to [245](https://github.com/NagVis/nagvis/pull/245/).

All control characters (0x00 - 0x1F) are now converted or removed when `text=...` is being saved into *.ini file.
