### PR TITLE
Feature: Worldmap screenfixed objects

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Frontend:
 
 Worldmap:
   * textbox scaling according to zoom (scale_to_max_zoom option) (issue #255)
+  * Feature: screen-fixed objects
 
 1.9.20
 Core:

--- a/docs/en_US/worldmap.html
+++ b/docs/en_US/worldmap.html
@@ -95,5 +95,28 @@
                 <td>scale_to_max_zoom</td><td>No</td><td>Scale the object size down to 50% for every zoom level below <code>max_zoom</code>. Only applicable to textboxes.</td>
             </tr>
         </table>
+
+        <h2>Screen-fixed objects</h2>
+
+        Screen-fixed objects <b>do not move</b> when a map is dragged or zoomed. Unlike any worldmap objects, those are placed to screen by pixels rather than geographical coordinates.
+
+        <table style="width:100%">
+            <tr>
+                <th>Parameter</th><th>Default</th><th>Description</th>
+            </tr>
+            <tr>
+                <td>worldmap_screenfixed_objects_from_map</td><td><i>none</i></td><td>Name of other regular map to load screen-fixed objects from.</td>
+            </tr>
+        </table>
+
+        To use the feature, create two maps:
+        <ol>
+            <li>This worldmap</li>
+            <li>Another <b>regular</b> map</li>
+        </ol>
+        On this worldmap (1), set <code>worldmap_screenfixed_objects_from_map=name_of_another_regular_map</code>. Objects from regular map (2) are now visible on this worldmap (1) and are always fixed to the same spot on the screen.
+
+You may also want to set <code>show_in_lists=0</code> on the referred regular map.
+
     </body>
 </html>

--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -293,7 +293,13 @@ var ElementLine = Element.extend({
         // the user moves the object, this dom node must not be re-created, because this
         // would remove all event handlers
         if (!this.obj.trigger_obj) {
-            var oLink = document.createElement('a');
+            if (this.obj.conf.url) {
+                var oLink = document.createElement('a');
+                oLink.href = this.obj.conf.url;
+                oLink.target = this.obj.conf.url_target;
+            } else {
+                var oLink = document.createElement('div');
+            }
             oLink.setAttribute('id', this.obj.conf.object_id+'-linelink');
             oLink.className = 'linelink';
             this.obj.trigger_obj = oLink;
@@ -302,12 +308,6 @@ var ElementLine = Element.extend({
             this.clearActionContainer();
         }
         this.dom_obj.appendChild(oLink);
-        if (this.obj.conf.url) {
-            oLink.href = this.obj.conf.url;
-            oLink.target = this.obj.conf.url_target;
-        } else {
-            oLink.href = 'javascript:void(0)';
-        }
     },
 
     clearActionContainer: function() {
@@ -619,13 +619,13 @@ var ElementLine = Element.extend({
             this.link_area.style.left = (x-5) + 'px';
             this.link_area.style.top = (y-5) + 'px';
 
-            if (usesSource('worldmap'))
+            if (usesSource('worldmap') && this.obj.marker)
                 this.obj.marker._bringToFront();
         } else {
             remove_class(this.canvas, 'active');
             this.link_area.style.display = 'none';
 
-            if (usesSource('worldmap'))
+            if (usesSource('worldmap') && this.obj.marker)
                this.obj.marker._resetZIndex();
         }
     },

--- a/share/frontend/nagvis-js/js/ViewMap.js
+++ b/share/frontend/nagvis-js/js/ViewMap.js
@@ -164,6 +164,11 @@ var ViewMap = View.extend({
     },
 
     addObject: function(attrs) {
+        let obj = this.constructObject(attrs);
+        this.objects[obj.conf.object_id] = obj;
+    },
+
+    constructObject: function(attrs) {
         var obj;
         switch (attrs.type) {
             case 'host':
@@ -204,13 +209,12 @@ var ViewMap = View.extend({
                 return;
             break;
         }
-    
+
         // Save the number of unlocked objects
         if (!obj.bIsLocked)
             this.updateNumUnlocked(1);
-    
-        // Put object to map objects array
-        this.objects[obj.conf.object_id] = obj;
+
+        return obj;
     },
 
     erase: function() {
@@ -225,7 +229,7 @@ var ViewMap = View.extend({
         // FIXME: Are all these steps needed here?
         obj.update();
         obj.render();
-    
+
         // add eventhandling when enabled via event_on_load option
         if (isset(oViewProperties.event_on_load) && oViewProperties.event_on_load == 1
            && obj.has_state && obj.hasProblematicState()) {
@@ -247,7 +251,7 @@ var ViewMap = View.extend({
         this.dom_obj.appendChild(obj.dom_obj);
     },
 
-    // Removes the given objects dom_obj from the maps dom_obj 
+    // Removes the given objects dom_obj from the maps dom_obj
     eraseObject: function(obj) {
         this.dom_obj.removeChild(obj.dom_obj);
     },
@@ -255,13 +259,13 @@ var ViewMap = View.extend({
     // Does initial rendering of map objects
     initializeObjects: function(aMapObjectConf) {
         eventlog("worker", "debug", "initializeObjects: Start setting map objects");
-    
+
         // Don't loop the first object - that is the summary of the current map
         this.sum_obj = new NagVisMap(aMapObjectConf[0]);
-    
+
         for (var i = 1, len = aMapObjectConf.length; i < len; i++)
             this.addObject(aMapObjectConf[i]);
-    
+
         // First parse the objects on the map
         // Then store the object position dependencies.
         // Before both can be done all objects need to be added

--- a/share/frontend/nagvis-js/js/ViewWorldmap.js
+++ b/share/frontend/nagvis-js/js/ViewWorldmap.js
@@ -22,6 +22,8 @@
  *****************************************************************************/
 
 var ViewWorldmap = ViewMap.extend({
+    screenFixedObjects: [],
+
     constructor: function(id) {
         this.base(id);
     },
@@ -111,6 +113,44 @@ var ViewWorldmap = ViewMap.extend({
         let ltp = document.getElementsByClassName('leaflet-tile-pane');
         if (ltp && saturate_percentage !== '')
             ltp[0].style.filter = "saturate("+saturate_percentage+"%)";
+
+        let loadScreenfixedObjectsFrom = getViewParam('worldmap_screenfixed_objects_from_map');
+        if (loadScreenfixedObjectsFrom) {
+           call_ajax(oGeneralProperties.path_server + '?mod=Map&act=getMapObjects&show=' + loadScreenfixedObjectsFrom, {
+                response_handler : this.initializescreenFixedObjects.bind(this),
+            });
+        }
+
+    },
+
+    initializescreenFixedObjects: function(aMapObjectConf) {
+        // Counterfeit `ViewMap` instance instead of `ViewWorldmap` so that screen-fixed object's DOM elements get rendered out of Leaflet map
+        let g_view_tmp = g_view
+        g_view = new ViewMap(g_view_tmp.id)
+        g_view.init();
+
+        for (var i = 1, len = aMapObjectConf.length; i < len; i++) {
+            this.addScreenfixedObject(aMapObjectConf[i]);
+        }
+
+        for (var i in this.screenFixedObjects)
+            this.renderScreenfixedObject(i);
+
+        // restore original `ViewWorldmap` instance
+        g_view = g_view_tmp
+    },
+
+
+    addScreenfixedObject: function(attrs) {
+        attrs.context_menu = '0'; // no right-click context menu on screenfixed objects
+        let obj = this.constructObject(attrs);
+        this.screenFixedObjects[obj.conf.object_id] = obj;
+    },
+
+    renderScreenfixedObject: function(object_id) {
+        var obj = this.screenFixedObjects[object_id];
+        obj.update();
+        obj.render();
     },
 
     handleMoveStart: function(lEvent) {

--- a/share/frontend/nagvis-js/js/ViewWorldmap.js
+++ b/share/frontend/nagvis-js/js/ViewWorldmap.js
@@ -143,6 +143,7 @@ var ViewWorldmap = ViewMap.extend({
 
     addScreenfixedObject: function(attrs) {
         attrs.context_menu = '0'; // no right-click context menu on screenfixed objects
+        attrs.z = Number(attrs.z) + 1000; // always on top of leaflet panes
         let obj = this.constructObject(attrs);
         this.screenFixedObjects[obj.conf.object_id] = obj;
     },

--- a/share/frontend/nagvis-js/js/frontend.js
+++ b/share/frontend/nagvis-js/js/frontend.js
@@ -124,7 +124,7 @@ function showFrontendDialog(sUrl, sTitle, sWidth) {
                 response.url = sUrl;
 
                 if(typeof response !== 'undefined' && typeof response.code !== 'undefined') {
-                    let width = data.sWidth || 450;
+                    let width = data.sWidth || 650;
                     if (response.object_type === 'textbox') width = 800
                     popupWindow(data.title, response, width);
                 }

--- a/share/server/core/classes/GlobalCore.php
+++ b/share/server/core/classes/GlobalCore.php
@@ -453,8 +453,29 @@ class GlobalCore {
             } catch(NagVisException $e) {
                 continue; // skip e.g. not read config files
             }
-            
+
             if($MAPCFG->getValue(0, 'show_in_lists') == 1)
+                $list[$mapName] = $MAPCFG->getAlias();
+        }
+        natcasesort($list);
+        return array_keys($list);
+    }
+
+    public function getListRegularMaps() {
+        $list = array();
+        $maps = $this->getPermittedMaps();
+        foreach ($maps AS $mapName) {
+            $MAPCFG = new GlobalMapCfg($mapName);
+            try {
+                $MAPCFG->readMapConfig(ONLY_GLOBAL);
+            } catch(MapCfgInvalid $e) {
+                continue; // skip configs with broken global sections
+            } catch(NagVisException $e) {
+                continue; // skip e.g. not read config files
+            }
+
+            // maps with no 'sources=' in 'define global {}' section are regular
+            if($MAPCFG->getValue(0, 'sources') == [])
                 $list[$mapName] = $MAPCFG->getAlias();
         }
         natcasesort($list);

--- a/share/server/core/mapcfg/default.php
+++ b/share/server/core/mapcfg/default.php
@@ -27,6 +27,11 @@ function listMapNames() {
     return $list;
 }
 
+function listRegularMapNames() {
+    global $CORE;
+    return $CORE->getListRegularMaps();
+}
+
 function listMapImages() {
     global $CORE;
     $options = $CORE->getAvailableBackgroundImages();

--- a/share/server/core/sources/worldmap.php
+++ b/share/server/core/sources/worldmap.php
@@ -37,6 +37,13 @@ $configVars = array(
         'default'   => '',
         'match'     => MATCH_INTEGER_EMPTY,
     ),
+    'worldmap_screenfixed_objects_from_map' => array(
+        'must'       => 0,
+        'default'    => '',
+        'match'      => MATCH_MAP_NAME_EMPTY,
+        'field_type' => 'dropdown',
+        'list'       => 'listRegularMapNames',
+    ),
 
     /*** OBJECT OPTIONS ***/
     'min_zoom' => array(
@@ -59,6 +66,7 @@ $configVarMap = array(
             'worldmap_center' => null,
             'worldmap_zoom'   => null,
             'worldmap_tiles_saturate'   => null,
+            'worldmap_screenfixed_objects_from_map' => null,
         ),
     ),
 );


### PR DESCRIPTION
# What?
The `worldmap` is a perfect tool to display geographical objects on the map. However, there are in real also non-geographical objects in play. This PR brings a feature to show them too.

Overview zoom - note the map legend on upper left:
<img width="1194" alt="Screen Shot 2020-06-10 at 11 10 15" src="https://user-images.githubusercontent.com/20604326/84250126-f31d6000-ab0b-11ea-81ff-fbe8aae88ac1.png">

Detailed zoom - note the map legend still on the place:
<img width="971" alt="Screen Shot 2020-06-10 at 11 12 16" src="https://user-images.githubusercontent.com/20604326/84250134-f6185080-ab0b-11ea-958e-c470e3e00a8d.png">

# Why?
Real-world NOC (Network Operations Centre) needs to see a big picture at a glance. Perfectly tuned geographical map shows how's the network. In addition, things like
- DNS server's status
- map legends (what line color is what)
- link to the internal wiki and howtos
are very handy to show on the screen too, regardless of the viewport (map center, map zoom).

# How?
Two maps - interactive and regular - are merged together.
On an interactive map, new option comes into play `screenfixed_objects_from_map`.
<img width="651" alt="Screen Shot 2020-06-10 at 11 25 58" src="https://user-images.githubusercontent.com/20604326/84251136-39bf8a00-ab0d-11ea-8090-95025a958203.png">
Chosen regular map objects simply show on the screen. Since it's regular, objects positions are pixel-based (rather than coordinate-based) so that they're fixed on the screen.

Documentation in English updated on this.

## Under the hood
The `ViewWorldmap` loads this map object and additionally referred regular map objects firing subsequent `GET getMapObjects` request. Then regular `obj.render();` draws them on the screen.
