### PR TITLE
Feature: textbox scales according to zoom (amendment: configurable 1:1 level)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,7 @@ Frontend:
   * FIX: Remove "\r", "\t" and 0x00 - 0x1F from multiline text boxes (issue #258)
 
 Worldmap:
-  * textbox scaling according to zoom (scale_to_max_zoom option) (issue #255)
+  * textbox scaling according to zoom (scale_to_zoom option) (pull #255, #263)
 
 1.9.20
 Core:

--- a/docs/en_US/worldmap.html
+++ b/docs/en_US/worldmap.html
@@ -91,8 +91,21 @@
             <tr>
                 <td>max_zoom</td><td>20</td><td>Only show the object at specified zoom levels or lower (wider view)</td>
             </tr>
+        </table>
+
+        <h2>Scalable textboxes on worldmap</h2>
+        Static textboxes can scale according to the view zoom level. In other words, a box shrinks as you zoom out, or grows as you zoom in.
+        <table style="width:100%">
             <tr>
-                <td>scale_to_max_zoom</td><td>No</td><td>Scale the object size down to 50% for every zoom level below <code>max_zoom</code>. Only applicable to textboxes.</td>
+                <th>Parameter</th><th>Default</th><th>Description</th>
+            </tr>
+            <tr>
+                <td>scale_to_zoom</td><td>No</td><td>Scale the textbox size down to 50% for every zoom level below <code>normal_size_at_zoom</code>,
+                    or 50% up for every zoom level above.
+                </td>
+            </tr>
+            <tr>
+                <td>normal_size_at_zoom</td><td>19</td><td>At this zoom level, the <code>scale_to_zoom=yes</code> textboxes are displayed at original 1:1 (100%) size.</td>
             </tr>
         </table>
     </body>

--- a/share/frontend/nagvis-js/js/ElementBox.js
+++ b/share/frontend/nagvis-js/js/ElementBox.js
@@ -24,11 +24,14 @@
 var ElementBox = Element.extend({
     render: function() {
         let scale = 1;
-        if (g_map && usesSource('worldmap') && this.obj.conf.scale_to_max_zoom == '1') {
+        if (g_map && usesSource('worldmap') && this.obj.conf.scale_to_zoom == '1') {
             let currentZoom = g_map.getZoom();
-            let maxZoom = Number(this.obj.conf.max_zoom)
-            if (currentZoom < maxZoom) {
-                scale = 1 / Math.pow(2, maxZoom-currentZoom)
+            let one2oneZoom = Number(this.obj.conf.normal_size_at_zoom) || 19
+            if (currentZoom < one2oneZoom) {
+                scale = 1 / Math.pow(2, one2oneZoom-currentZoom)
+            }
+            if (currentZoom > one2oneZoom) {
+                scale = Math.pow(2, currentZoom-one2oneZoom)
             }
         }
 

--- a/share/frontend/nagvis-js/js/ViewWorldmap.js
+++ b/share/frontend/nagvis-js/js/ViewWorldmap.js
@@ -263,10 +263,9 @@ L.NagVisMarker = L.Marker.extend({
     // Update the size off the icon to make the object being centered
     _onAdd: function(lEvent) {
         var icon = this.options.icon,
-            obj = icon.options.obj,
             trigger_obj = icon.options.obj.trigger_obj,
-            w = trigger_obj.clientWidth,
-            h = trigger_obj.clientHeight;
+            w = pxToInt(trigger_obj.style.width),
+            h = pxToInt(trigger_obj.style.height);
 
         icon.options.iconSize = [w, h];
         icon._applyOffset();

--- a/share/frontend/nagvis-js/js/edit.js
+++ b/share/frontend/nagvis-js/js/edit.js
@@ -125,8 +125,8 @@ function resizeMouseDown(event) {
 
     g_resize_obj.grabx  = event.clientX;
     g_resize_obj.graby  = event.clientY;
-    g_resize_obj.width  = target.offsetWidth;
-    g_resize_obj.height = target.offsetHeight;
+    g_resize_obj.width  = pxToInt(target.style.width);
+    g_resize_obj.height = pxToInt(target.style.height);
     g_resize_obj.left   = pxToInt(target.style.left);
     g_resize_obj.top    = pxToInt(target.style.top);
 
@@ -195,24 +195,59 @@ function resizeMouseMove(event) {
     if (g_resize_obj === null)
         return true;
 
-    var xMin = 8, // The smallest width and height possible
-        yMin = 8;
+    var scale = g_resize_obj.el.dataset.theScale ? g_resize_obj.el.dataset.theScale : 1;
 
-    if(g_resize_obj.dir.indexOf("e") != -1)
-        g_resize_obj.el.style.width = Math.max(xMin, g_resize_obj.width + event.clientX - g_resize_obj.grabx) + "px";
+    var minWidth = 8 * scale, // The smallest width and height possible
+        minHeight = 8 * scale;
 
+    let grabOffsetX = event.clientX - g_resize_obj.grabx;
+    let grabOffsetY = event.clientY - g_resize_obj.graby;
+
+    if(g_resize_obj.dir.indexOf("e") != -1) {
+        grabOffsetX = Math.max(grabOffsetX, -g_resize_obj.width*scale + minWidth);
+
+        let newWidth = g_resize_obj.width + grabOffsetX/scale;
+        let newLeft = g_resize_obj.left + grabOffsetX/2;
+        let newMarginLeft = -newWidth/2;
+
+        g_resize_obj.el.style.width = newWidth + "px";
+        g_resize_obj.el.style.left = newLeft + "px";
+        g_resize_obj.el.style.marginLeft = newMarginLeft + "px";
+    }
     if(g_resize_obj.dir.indexOf("s") != -1) {
-        g_resize_obj.el.style.height = Math.max(yMin, g_resize_obj.height + event.clientY - g_resize_obj.graby) + "px";
+        grabOffsetY = Math.max(grabOffsetY, -g_resize_obj.height*scale + minHeight);
+
+        let newHeight = g_resize_obj.height + grabOffsetY/scale;
+        let newTop = g_resize_obj.top + grabOffsetY/2;
+        let newMarginTop = -newHeight/2;
+
+        g_resize_obj.el.style.height = newHeight + "px";
+        g_resize_obj.el.style.top = newTop + "px";
+        g_resize_obj.el.style.marginTop = newMarginTop + "px";
     }
 
     if(g_resize_obj.dir.indexOf("w") != -1) {
-        g_resize_obj.el.style.left = Math.min(g_resize_obj.left + event.clientX - g_resize_obj.grabx, g_resize_obj.left + g_resize_obj.width - xMin) + "px";
-        g_resize_obj.el.style.width = Math.max(xMin, g_resize_obj.width - event.clientX + g_resize_obj.grabx) + "px";
+        grabOffsetX = Math.min(grabOffsetX, g_resize_obj.width*scale - minWidth);
+
+        let newWidth = g_resize_obj.width - grabOffsetX/scale;
+        let newLeft = g_resize_obj.left + grabOffsetX/2;
+        let newMarginLeft = -newWidth/2;
+
+        g_resize_obj.el.style.width = newWidth + "px";
+        g_resize_obj.el.style.left = newLeft + "px";
+        g_resize_obj.el.style.marginLeft = newMarginLeft + "px";
     }
     if(g_resize_obj.dir.indexOf("n") != -1) {
-        g_resize_obj.el.style.top = Math.min(g_resize_obj.top + event.clientY - g_resize_obj.graby, g_resize_obj.top + g_resize_obj.height - yMin) + "px";
-        g_resize_obj.el.style.height = Math.max(yMin, g_resize_obj.height - event.clientY + g_resize_obj.graby) + "px";
-    }
+        grabOffsetY = Math.min(grabOffsetY, g_resize_obj.height*scale - minHeight);
+
+        let newHeight = g_resize_obj.height - grabOffsetY/scale;
+        let newTop = g_resize_obj.top + grabOffsetY/2;
+        let newMarginTop = -newHeight/2;
+
+        g_resize_obj.el.style.height = newHeight + "px";
+        g_resize_obj.el.style.top = newTop + "px";
+        g_resize_obj.el.style.marginTop = newMarginTop + "px";
+  }
 
     return preventDefaultEvents(event);
 }

--- a/share/frontend/nagvis-js/js/edit.js
+++ b/share/frontend/nagvis-js/js/edit.js
@@ -150,26 +150,19 @@ function resizeMouseUp(event) {
     var objW = rmZoomFactor(parseInt(dom_obj.style.width));
     var objH = rmZoomFactor(parseInt(dom_obj.style.height));
 
-    // Reposition in frontend
-    var obj = getMapObjByDomObjId(objId);
-    obj.conf.x = objX;
-    obj.conf.y = objY;
-    obj.conf.w = objW;
-    obj.conf.h = objH;
-    obj.place();
-
-    if (!isInt(objX) || !isInt(objY) || !isInt(objW) || !isInt(objH)) {
-        alert('ERROR: Invalid coords ('+objX+'/'+objY+'/'+objW+'/'+objH+'). Terminating.');
-        return false;
+    // (worldmap) X and Y are center coordinates, not the top/left corner
+    var objMarginTop = rmZoomFactor(pxToInt(dom_obj.style.marginTop), true);
+    var objMarginLeft = rmZoomFactor(pxToInt(dom_obj.style.marginLeft), true);
+    if (objMarginLeft && objMarginTop) {
+      objX = Math.round(objX + objMarginLeft + objW/2);
+      objY = Math.round(objY + objMarginTop + objH/2);
     }
 
     var parts = g_view.unproject(objX, objY);
-    objX = parts[0];
-    objY = parts[1];
 
     saveObjectAttr(objId, {
-        'x': objX,
-        'y': objY,
+        'x': parts[0],
+        'y': parts[1],
         'w': objW,
         'h': objH
     });
@@ -683,7 +676,7 @@ function addClick(e) {
                + '&x=' + addX.join(',')
                + '&y=' + addY.join(',');
 
-    if(addObjType != 'textbox' && addObjType != 'container' 
+    if(addObjType != 'textbox' && addObjType != 'container'
        && addObjType != 'shape' && addViewType != 'icon' && addViewType != '')
         sUrl += '&view_type=' + addViewType;
 

--- a/share/frontend/nagvis-js/js/nagvis.js
+++ b/share/frontend/nagvis-js/js/nagvis.js
@@ -969,8 +969,10 @@ function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, cust
 
     oLabelDiv.style.zIndex = parseInt(z) + 1;
 
-    if (scale)
+    if (scale) {
         oLabelDiv.style.transform = `scale(${scale})`;
+        oLabelDiv.dataset.theScale = scale;
+    }
 
     /**
      * IE workaround: The transparent for the color is not enough. The border

--- a/share/server/core/mapcfg/default.php
+++ b/share/server/core/mapcfg/default.php
@@ -861,12 +861,6 @@ $mapConfigVars = Array(
         'field_type' => 'color',
         'match'      => MATCH_COLOR,
     ),
-    'scale_to_max_zoom' => Array(
-        'must'       => 0,
-        'default'    => 0,
-        'match'      => MATCH_BOOLEAN,
-        'field_type' => 'boolean',
-    ),
     'style' => Array(
         'must' => 0,
         'default' => '',
@@ -1433,9 +1427,7 @@ $mapConfigVarMap['textbox'] = Array(
         'type' => null,
         'use' => null,
     ),
-    'worldmap' => array(
-        'scale_to_max_zoom' => null,
-    )
+    // See also: core/sources/worldmap.php (textbox-specific options)
 );
 
 $mapConfigVarMap['shape'] = Array(

--- a/share/server/core/sources/worldmap.php
+++ b/share/server/core/sources/worldmap.php
@@ -49,6 +49,19 @@ $configVars = array(
         'default'   => 20,
         'match'     => MATCH_WORLDMAP_ZOOM,
     ),
+
+    'scale_to_zoom' => Array(
+        'must'       => 0,
+        'default'    => 0,
+        'match'      => MATCH_BOOLEAN,
+        'field_type' => 'boolean',
+    ),
+    'normal_size_at_zoom' => array(
+        'must'      => false,
+        'default'   => 19,
+        'match'     => MATCH_WORLDMAP_ZOOM,
+    ),
+
 );
 
 // Assign config variables to specific object types
@@ -72,6 +85,12 @@ foreach (getMapObjectTypes() AS $type) {
         ),
     );
 }
+
+// Textbox-specific options
+$configVarMap['textbox']['worldmap'] = array_merge($configVarMap['textbox']['worldmap'], array(
+    'scale_to_zoom' => null,
+    'normal_size_at_zoom' => null,
+));
 
 // Global config vars not to show for worldmaps
 $hiddenConfigVars = array(


### PR DESCRIPTION
# What?
This is a small amendment to PR #255. An assumption that the original (1:1) size of a textbox whould be the `max_zoom` has shown as not optimal. It's often `18` or `19` on real maps, whereas there's still `max_zoom=20`.

# How?
This PR brings an option to set it. For example a textbox like this:
```
min_zoom=15
maz_zoom=20
scale_to_zoom=yes
normal_size_at_zoom=18
```

scales down to 12.5% at zoom 15
scales down to 25% at zoom 16
scales down to 50% at zoom 17
shows 1:1 at zoom 18
scales up to 200% at zoom 19
scales up to 400% at zoom 20

# Why?
In pursue of always better user experience. Textboxes hold important location-specific notes. It's practical to have textboxes `max_zoom=19` (not 20) in many (but not all) locations. Now, the user wants to scroll "down" to a specific location to see what's around, *pulls the mouse wheel hard* and jumps to the farthest zoom level possible: 20. To show enlarged textbox here seems more consistent from UX perspective, than showing nothing.



