### PR TITLE
Feature: Allow alpha channel (#RRGGBBAA) in color definitions

### DIFF
--- a/share/server/core/defines/matches.php
+++ b/share/server/core/defines/matches.php
@@ -54,7 +54,7 @@ define('MATCH_BOOLEAN', '/^(?:1|0)$/i');
 define('MATCH_BOOLEAN_EMPTY', '/^(?:1|0)*$/i');
 define('MATCH_LATLONG', '/^-?[0-9]+(.[0-9]+),-?[0-9]+(.[0-9]+)?$/');
 
-define('MATCH_COLOR', '/^(#?[0-9a-f]{3,6}|transparent)$/i');
+define('MATCH_COLOR', '/^(#?[0-9a-f]{3,8}|transparent)$/i');
 define('MATCH_OBJECTTYPE', '/^(?:global|host|service|dyngroup|aggr|hostgroup|servicegroup|map|textbox|shape|line|template|container)$/i');
 define('MATCH_OBJECTID', '/^(?:[a-z0-9]+)$/i');
 define('MATCH_OBJECTID_EMPTY', '/^(?:[a-z0-9]*)$/i');


### PR DESCRIPTION
Simple amendment: colors may now have fourth byte - alpha channel, or transparency.
This comes handy for textbox background color:

<img width="1034" alt="Screen Shot 2020-08-27 at 11 55 51" src="https://user-images.githubusercontent.com/20604326/91426267-91dc7180-e85c-11ea-8a8e-c1efe3d9c0f5.png">
