### PR TITLE
fix (frontend): match "Bit" and "bit" to display bit/s

### DIFF
--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -822,7 +822,7 @@ var ElementLine = Element.extend({
         // Check_MK if/if64 checks support switching between bytes/bits.
         var display_bits = false;
 
-        if (output.match('In: [0-9].*bit/s.*Out: [0-9]+')) {
+        if (output.match('In: [0-9].*[Bit|bit]/s.*Out: [0-9]+')) {
             display_bits=true;
         }
 


### PR DESCRIPTION
It seems like some checks in cmk use "Bit" and others use "bit".
This bridges the gap for the checks that use "Bit" instead of "bit".

B = byte
b = bit