### PR TITLE
Fix off-screen text in popups

### DIFF
--- a/share/userfiles/templates/default.css
+++ b/share/userfiles/templates/default.css
@@ -403,7 +403,6 @@ div#popupWindow h1 {
 #popupWindowContent table.mytable td.tdfield {
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
 }
 #popupWindowContent input[type="radio"] {
     vertical-align: middle;

--- a/share/userfiles/templates/default.css
+++ b/share/userfiles/templates/default.css
@@ -410,7 +410,6 @@ div#popupWindow h1 {
 #popupWindowContent table.mytable tr td.tdlabel input {
     width: 140x;
 }
-#popupWindowContent table.mytable tr td.tdfield input,
 #popupWindowContent table.mytable tr td.tdfield textarea,
 #popupWindowContent table.mytable tr td.tdfield select {
     width: 99%;


### PR DESCRIPTION
Previously the text would not be wrapped at all, causing text to run off
the popup box. With this commit the wrapping in the popup is changed, so
that hopefully it stays inside the popup box.

Prior to fix:
![screenshot_20211125_163620](https://user-images.githubusercontent.com/7610459/143476419-05a847d0-6cf5-40a5-93e0-0bfaf7d43922.png)

After fix:
![screenshot_20211125_172507](https://user-images.githubusercontent.com/7610459/143476453-9da73b51-37d8-4e1e-be3a-c60fdf782363.png)
