### PR TITLE
Fix gadgets not updating due to caching of images

### DIFF
--- a/share/frontend/nagvis-js/js/ElementGadget.js
+++ b/share/frontend/nagvis-js/js/ElementGadget.js
@@ -122,7 +122,7 @@ var ElementGadget = Element.extend({
 
             addZoomHandler(oGadget);
 
-            oGadget.src = this.obj.conf.gadget_url + sParams;
+            oGadget.src = this.obj.conf.gadget_url + sParams + "&cache=" + new Date().getTime();
 
             var alt = this.obj.conf.type + '-' + this.obj.conf.name;
             if (this.obj.conf.type == 'service')


### PR DESCRIPTION
Not exactly sure why, but innewer versions of Chrome, part of the gadget refresh mechanism is broken.

When an image gadget should be updated but it doesn't change its URL (i.e, if there has been a change in the status text) it should also trigger an image reload, but Chrome seems to think that the image is the same (even if it has headers to avoid being stored in cache) and thus it doesn't even try to load the image again.

This is really annoying when creating gadgets that use other mechanisms to grab the status summary from services (e.g, using livestatus behind the scenes), as the images won't update unless the real status or perfdata changes.

This patch should ensure that images are always reloaded when the refresh conditions apply.