### PR TITLE
allow overview page to display the scrollbar

### DIFF
--- a/share/userfiles/templates/default.css
+++ b/share/userfiles/templates/default.css
@@ -119,6 +119,10 @@ div.control.togglemid {
 
 /* new overview page */
 
+div.infopage {
+    overflow: auto;    
+}
+
 div.infopage h2 {
     margin: 20px 10px 0 10px;
 }


### PR DESCRIPTION
When there are many maps created, they will be displayed on the Overview page, but no scrollbar will be displayed when the maps exceed the visible area of the page.