### PR TITLE
Single quote needed in match string

### DIFF
--- a/share/server/core/defines/matches.php
+++ b/share/server/core/defines/matches.php
@@ -30,7 +30,7 @@ define('MATCH_NOT_EMPTY', '/^.+$/');
 define('MATCH_REGEX', '/^.*$/i');
 
 // These regex allow unicode matching
-define('MATCH_STRING', '/^[0-9a-zа-яё\p{L}\s:+[\]()_.,\-\*?!#@=\/\\\]+$/iu');
+define('MATCH_STRING', '/^[0-9a-zа-яё\p{L}\s:+[\]()_.,\'\-\*?!#@=\/\\\]+$/iu');
 define('MATCH_STRING_EMPTY', '/^[0-9a-zа-яё\p{L}\s:+[\]()_.,\-\*?!#@=\/\\\\*]*$/iu');
 define('MATCH_STRING_NO_SPACE', '/^[0-9a-zа-яё\p{L}:+[\]()_.,\-\*?!#@=\/\\\\*]+$/iu');
 define('MATCH_STRING_NO_SPACE_EMPTY', '/^[0-9a-zа-яё\p{L}:+[\]()_.,\-\*?!#@=\/\\\]*$/iu');


### PR DESCRIPTION
With actual CheckMK 2.0 the services description can also have single quotes as legal characters so there the single quote must be matched.