### PR TITLE
Match kiloMultipliers in ElementLine with check_mk

### DIFF
--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -861,10 +861,10 @@ var ElementLine = Element.extend({
     /**
      * Transform bits in a perfdata set to a human readable value
      */
-    perfdataCalcBitsReadable: function(set) {
-        var KB   = 1024;
-        var MB   = 1024 * 1024;
-        var GB   = 1024 * 1024 * 1024;
+    perfdataCalcBitsReadable: function(set, kiloMultiplier=1024) {
+        var KB   = kiloMultiplier;
+        var MB   = kiloMultiplier * kiloMultiplier;
+        var GB   = kiloMultiplier * kiloMultiplier * kiloMultiplier;
         if(set[1] > GB) {
             set[1] /= GB
             set[2]  = 'Gbit/s'
@@ -884,10 +884,10 @@ var ElementLine = Element.extend({
     /**
      * Transform bytes in a perfdata set to a human readable value
      */
-    perfdataCalcBytesReadable: function(set) {
-        var KB   = 1024;
-        var MB   = 1024 * 1024;
-        var GB   = 1024 * 1024 * 1024;
+    perfdataCalcBytesReadable: function(set, kiloMultiplier=1000) {
+        var KB   = kiloMultiplier;
+        var MB   = kiloMultiplier * kiloMultiplier;
+        var GB   = kiloMultiplier * kiloMultiplier * kiloMultiplier;
         if(set[1] > GB) {
             set[1] /= GB
             set[2]  = 'GB/s'


### PR DESCRIPTION
## What?

Check MK uses different kiloMultipliers for Bytes and Bits.

## Why?

https://forum.checkmk.com/t/nagvis-weatherlines-falsche-anzeige-werte/15139/12
https://forum.checkmk.com/t/bug-nagvis-checkmk-nagvis-service-line-how-to-change-unit-to-bit-s/23632

## How?

This would always show the same value as Check MK.