### PR TITLE
Fix worldmap PHP 8.1 incompatibility

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
 1.9.34
+Core:
+  * FIX: Fix worldmap PHP 8.1 incompatibility
 
 1.9.33
 Frontend:

--- a/share/server/core/sources/worldmap.php
+++ b/share/server/core/sources/worldmap.php
@@ -262,7 +262,7 @@ function worldmap_get_objects_by_bounds($sw_lng, $sw_lat, $ne_lng, $ne_lat) {
         $obj = json_decode($data['object'], true);
         $objects[$obj['object_id']] = $obj;
         // check all coordinates for relative coords
-        $coords = array($data['lat'], $data['lng'], $data['lat2'], $data['lng2']);
+        $coords = array_map('strval', array($data['lat'], $data['lng'], $data['lat2'], $data['lng2']));
         foreach ($coords as $coord) {
             if (strpos($coord, '%') !== false) {
                 $referenced[substr($coord, 0, 6)] = null;


### PR DESCRIPTION
Using PHP 8.1 adding elements to the worldmap causes this error to occur.
![error_worldmap](https://user-images.githubusercontent.com/46791457/170248361-e2d33d40-1392-4966-b3e2-dfe482956612.png)
