### PR TITLE
FIX: Fix BI-Backend HTTPS incompatibility

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,7 @@
 1.9.34
+Core:
+  * FIX: BI-Backend HTTPS incompatibility
+
 Frontend:
   * FIX: Fix PHP 8.1 incompatibility in "General configuration" dialog
 


### PR DESCRIPTION
After changing the a Checkmk Site to use HTTPS the following issues with  the BI Backend occur.

1. The old, already created, objects don't show the correct information anymore
![Bildschirmfoto vom 2022-06-22 12-49-50](https://user-images.githubusercontent.com/46791457/175011746-40620836-1483-46a9-97e4-5cb412221d94.png)
2. Creation of new objects is no longer possible
![Bildschirmfoto vom 2022-06-22 12-50-13](https://user-images.githubusercontent.com/46791457/175014507-7ade9d6f-e4c4-47bd-873b-32082b47fcef.png)

The actual error can be seen by changing the error handling of the file_get_contents call:
![Bildschirmfoto vom 2022-06-22 13-01-15](https://user-images.githubusercontent.com/46791457/175014335-1cc88ae0-01e7-4d74-bc67-92fc3028c335.png)

With this fix no verification can be disabled or the path to the needed certificate can be added.