### PR TITLE
Fix type juggling vulnerability

### DIFF
--- a/share/server/core/classes/CoreLogonMultisite.php
+++ b/share/server/core/classes/CoreLogonMultisite.php
@@ -114,11 +114,9 @@ class CoreLogonMultisite extends CoreLogonModule {
             $hash = $this->generateHash($username, $sessionId, (string) $user_secret);
 
         // Validate the hash
-        if ($cookieHash != $hash) {
+        if ($cookieHash !== $hash) {
             throw new Exception();
         }
-
-        // FIXME: Maybe renew the cookie here too
 
         return $username;
     }


### PR DESCRIPTION
PHP evaluates `!=` a bit loose on the type. So "0000" == "0e5678" is
true in PHP. An attacker could send a zeroed cookie_hash `"0"*32` and
only need an collision with a calculated hash beginning with `0e`
followed by only numbers.

In our tests (with auth.secret set to `stable`) a valid cookie is
`cmkadmin:58191275:00000000000000000000000000000000`.

For a remote attacker this would have needed 58,191,275 guesses.