### PR TITLE
Mitigate arbitrary file read

### DIFF
--- a/share/server/core/classes/NagVisHoverUrl.php
+++ b/share/server/core/classes/NagVisHoverUrl.php
@@ -84,7 +84,7 @@ class NagVisHoverUrl {
         // Only allow urls not paths for security reasons
         // Reported here: http://news.gmane.org/find-root.php?message_id=%3cf60c42280909021938s7f36c0edhd66d3e9156a5d081%40mail.gmail.com%3e
         $aUrl = parse_url($this->url);
-        if(!isset($aUrl['scheme']) || $aUrl['scheme'] == '')
+        if(!isset($aUrl['scheme']) || $aUrl['scheme'] == '' || ($aUrl['scheme'] != 'http' && $aUrl['scheme'] != 'https'))
             throw new NagVisException(l('problemReadingUrl', Array('URL' => $this->url,
                                                                    'MSG' => l('Not allowed url'))));
 


### PR DESCRIPTION
With this change the URL is restricted to http and https. So no local
files can be read. This still is a Server-side request forgery (SSRF).