### PR TITLE
Javascript error on refresh after updating an object

### DIFF
--- a/share/frontend/nagvis-js/js/ElementContext.js
+++ b/share/frontend/nagvis-js/js/ElementContext.js
@@ -46,7 +46,7 @@ function context_handle_global_mousedown(event) {
     else {
         // Check for click on the context menu and do nothing in this case
         var object_id = target.id.split('-')[0];
-        if (object_id == g_context_open.obj.conf.object_id)
+        if (g_context_open && object_id == g_context_open.obj.conf.object_id)
             return preventDefaultEvents(event);
     }
 }
@@ -192,7 +192,12 @@ var ElementContext = Element.extend({
         if (this.dom_obj) {
             this.dom_obj.style.display = 'none';
         }
-        g_context_open = null;
+        if(g_context_open) {
+            const context_obj = document.getElementById(g_context_open.obj.conf.object_id+'-context');
+            if (context_obj)
+                context_obj.style.display = 'none';
+            g_context_open = null;
+        }
     },
 
     renderMenu: function () {


### PR DESCRIPTION
Currently, making a refresh right after modifying an object doesn't hide the context displayed. Context hide function were called to hide the whole dom_obj but was not hiding the element inside.

This commit will hide the context created upon right click and if it exists, it will make sure that it will be hidden after a mouse event. Also added a check on the condition for handling mouse clicks to avoid an error prompt, since it's expected to be null after the mouse event.

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>