### PR TITLE
[fix] Deprecated: Implicit conversion from float

### DIFF
--- a/share/server/core/classes/objects/NagVisStatefulObject.php
+++ b/share/server/core/classes/objects/NagVisStatefulObject.php
@@ -285,7 +285,7 @@ class NagVisStatefulObject extends NagVisObject {
             if(self::$dateFormat == '') {
                 self::$dateFormat = cfg('global','dateformat');
             }
-            return date(self::$dateFormat, $this->state[$attr]);
+            return date(self::$dateFormat, intval($this->state[$attr]));
         } else {
             return 'N/A';
         }


### PR DESCRIPTION
This PR fix "Deprecated: Implicit conversion from float" on Map preview
Error example:
`Deprecated: Implicit conversion from float 1688560905.334 to int loses precision in share/server/core/classes/objects/NagVisStatefulObject.php`

This fix use intval() to convert float in int