### PR TITLE
[fix] Call to a member function prepare() on nullarray(1) in MySQL

### DIFF
--- a/share/server/core/classes/CorePDOHandler.php
+++ b/share/server/core/classes/CorePDOHandler.php
@@ -242,7 +242,7 @@ class CorePDOHandler {
                 ),
 
                 'init' => array(
-                    "SET SESSION sql_mode = 'postgresql'",
+                    "SET SESSION sql_mode = 'PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE'",
                 ),
             ),
 


### PR DESCRIPTION
Fix to #271 issue.

The sql_mode "postgresql" is deprecated. It is removed in MySQL 8.0 as the documentation says: [documentation](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_postgresql).

`SQL_MODE = POSTGRESQL` is equivalent to `PIPES_AS_CONCAT, ANSI_QUOTES, IGNORE_SPACE, NO_KEY_OPTIONS, NO_TABLE_OPTIONS, NO_FIELD_OPTIONS.`

But, `NO_KEY_OPTIONS, NO_TABLE_OPTIONS, NO_FIELD_OPTIONS` it is also depreciated, then only `PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE` will be used.