### PR TITLE
Fix error "Object of class DateTime could not be converted to int"

### DIFF
--- a/share/server/core/classes/objects/NagVisStatefulObject.php
+++ b/share/server/core/classes/objects/NagVisStatefulObject.php
@@ -312,7 +312,14 @@ class NagVisStatefulObject extends NagVisObject {
             if(self::$dateFormat == '') {
                 self::$dateFormat = cfg('global','dateformat');
             }
-            return date(self::$dateFormat, intval($this->state[$attr]));
+
+            if($this->state[$attr] instanceof DateTime) {
+                $timestamp = $this->state[$attr]->getTimestamp();
+            } else {
+                $timestamp = intval($this->state[$attr]);
+            }
+
+            return date(self::$dateFormat, $timestamp);
         } else {
             return 'N/A';
         }


### PR DESCRIPTION
Hi,

First of all, thank you very much for the great work!

We're using Icinga Web 2 in combination with the nagvis plugin. However, this combination causes the following exception when performing various actions like placing hosts/services in nagvis:

`{"type":"error","message":"Object of class DateTime could not be converted to int","title":"Error: Unhandled Exception"}`

The only other related reference I was able to find is this: https://community.icinga.com/t/icingadb-web-1-1-0-and-nagvis-module/12713

This very small adjustment fixes the problem for us completely.