### PR TITLE
Security: Validate session cookie expiration

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,9 @@ Core:
          (tcp, udp, unix, udg, ssl, tls) would cause an error (Invalid format given)
          even though these proxies are correct.
 
+Security
+  * Added cookie session timestamps validation when Nagvis is run within Checkmk
+
 1.9.42
 Security:
   * FIX: Fix various XSS issues (std_table.php gadget, malicious graph elements, service names and script outputs).

--- a/share/server/core/classes/CoreLogonMultisite.php
+++ b/share/server/core/classes/CoreLogonMultisite.php
@@ -135,6 +135,31 @@ class CoreLogonMultisite extends CoreLogonModule {
             throw new Exception();
         }
 
+        // Check session periods validity
+        $site = cfg('defaults', 'backend')[0];
+        $baseUrl = cfg('backend_' . $site . '_bi', 'base_url');
+        $headers = [
+            'Content-type: application/json',
+            'Accept: application/json',
+            "Cookie: $cookieName=$cookieValue",
+        ];
+
+        $url = $baseUrl . 'api/1.0/version';
+
+        $contextOptions = [
+            'http' => [
+                'method' => 'GET',
+                'header' => implode("\r\n", $headers),
+            ]
+        ];
+
+        $context = stream_context_create($contextOptions);
+        $result = file_get_contents($url, false, $context);
+        if ($result === false) {
+            throw new Exception();
+        }
+        
+
         return $username;
     }
 


### PR DESCRIPTION
The authentication logic in CoreLogonMultisite.php only verifies the cookie hash, but does not include any check for session expiration.

This change performs that validation by using the session cookie to authenticate against the Checkmk Rest API. If the session is expired, then that connection will fail and the session cookie will be invalid.