### PR TITLE
Fix URLs still pointing to mathias-kettner.de documentation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@ Core:
          Entering correct proxy URLS with ports and one of the following schemas
          (tcp, udp, unix, udg, ssl, tls) would cause an error (Invalid format given)
          even though these proxies are correct.
+  * FIX: URLs still pointing to mathias-kettner.de documentation are now pointing to
+         the Checkmk documentation (docs.checkmk.com).
 
 Security
   * Added cookie session timestamps validation when Nagvis is run within Checkmk

--- a/docs/de_DE/about.html
+++ b/docs/de_DE/about.html
@@ -33,7 +33,7 @@
         <p>NagVis ist ein Pr&auml;sentationswerkzeug f&uuml;r die Informationen, die von Nagios gesammelt und mit Hilfe eines Backends zur Verf&uuml;gung gestellt werden.
         <p>Die unterst&uuml;tzten Backends sind:</p>
         <ul>
-            <li><a href="http://mathias-kettner.de/checkmk_livestatus.html">mklivestatus</a> (Default seit NagVis 1.5)</li>
+            <li><a href="https://docs.checkmk.com/latest/en/livestatus.html">mklivestatus</a> (Default seit NagVis 1.5)</li>
             <li><a href="http://www.nagios.org/download/addons">NDOUtils</a> / <a href="http://docs.icinga.org/latest/en/ch12">IDOUtils</a> (erfordert MySQL)</li>
             <li><a href="https://github.com/ITRS-Group/monitor-merlin">merlin</a> (erfordert MySQL)</li>
         </ul>

--- a/docs/de_DE/system_requirements.html
+++ b/docs/de_DE/system_requirements.html
@@ -24,7 +24,7 @@
     <p>Seit NagVis 1.5 ist MKLivestatus das Default-Backend, weil es viel schneller, leichtgewichtiger und stabiler als NDO ist.
         Au&szlig;erdem ist es einfacher zu handhaben und zu installieren. Sie ben&ouml;tigen keine Datenbank f&uuml;r MKLivestatus.</p>
     <p>MKLivestatus ist ein Eventbroker-Modul f&uuml;r Nagios, das einen Unix-Socket versorgt, mit dem sich Addons wie NagVis verbinden k&ouml;nnen, um aktuelle Statusinformationen abzufragen.</p>
-    <p>MKLivestatus bekommen Sie auf der <a href=http://www.mathias-kettner.de/checkmk_livestatus.html>offiziellen MKLivestatus-Homepage</a>.
+    <p>MKLivestatus bekommen Sie auf der <a href=https://docs.checkmk.com/latest/en/livestatus.html>offiziellen MKLivestatus-Homepage</a>.
     
     <h2>Webserver mit PHP-Unterst&uuml;tzung</h2>
     NagVis ist eine webbasierte Applikation, die in JavaScript und PHP realisiert ist.

--- a/docs/en_US/about.html
+++ b/docs/en_US/about.html
@@ -25,7 +25,7 @@
         <p>In general NagVis is a presentation tool for the information which is gathered by Nagios and transferred using backends. 
         <p>The supported backends are:</p>
         <ul>
-        <li><a href="http://mathias-kettner.de/checkmk_livestatus.html">mklivestatus</a> (default since NagVis 1.5)</li>
+        <li><a href="https://docs.checkmk.com/latest/en/livestatus.html">mklivestatus</a> (default since NagVis 1.5)</li>
         <li><a href="http://www.nagios.org/download/addons">NDOUtils</a> / <a href="http://docs.icinga.org/latest/en/ch12">IDOUtils</a> (requires MySQL)</li>
         <li><a href="https://github.com/ITRS-Group/monitor-merlin">merlin</a> (requires MySQL)</li>
         </ul>

--- a/docs/en_US/backend_mkbi.html
+++ b/docs/en_US/backend_mkbi.html
@@ -7,7 +7,7 @@
  <body>
     <h1>Check_MK Business Intelligence Backend</h1>
     <p>The Check_MK Business Intelligence (BI) Backend is used to connect NagVis directly with the
-       aggregations configured within <a href="http://mathias-kettner.de/checkmk_bi.html" target="_blank">Check_MK BI</a>.</p>
+       aggregations configured within <a href="https://docs.checkmk.com/latest/en/bi.html" target="_blank">Check_MK BI</a>.</p>
 
     <h2>The Check_MK BI API</h2>
     <p>Check_MK BI offers a webservice which is called by HTTP GET requests and

--- a/docs/en_US/backend_mklivestatus.html
+++ b/docs/en_US/backend_mklivestatus.html
@@ -13,7 +13,7 @@
              than the NDO, Livestatus does not actively write out data e.g. to the disk.
              Instead, it opens a socket for external applications to connect to and fetches
              the current status information from Nagios. For details about the new data
-             access provider take a look at the <a href="http://www.mathias-kettner.de/checkmk_livestatus.html#H1:How to access Nagios status data" target="_blank">official documentation</a>.</p>
+             access provider take a look at the <a href="https://docs.checkmk.com/latest/en/livestatus.html" target="_blank">official documentation</a>.</p>
         <p>Since the first NagVis 1.5 release the mklivestatus backend is included on
              delivery. It performs much better than all other existing backends and
              comes with less overhead than other backends. No additional database is

--- a/docs/en_US/system_requirements.html
+++ b/docs/en_US/system_requirements.html
@@ -19,7 +19,7 @@
         <p>MKLivestatus is an Event Broker Module for Nagios which serves a unix socket
             where third party addons like NagVis can connect to for gathering live status
             information in a very fast way.</p>
-        <p>You can get MKLivestatus from the <a href="http://www.mathias-kettner.de/checkmk_livestatus.html" target="_blank">official MKLivestatus Homepage</a>.</p>
+        <p>You can get MKLivestatus from the <a href="https://docs.checkmk.com/latest/en/livestatus.html" target="_blank">official MKLivestatus Homepage</a>.</p>
         
         <h2>Webserver with PHP support</h2>
         <p>NagVis is a web based application realised in Javascript and PHP. You need a webserver with PHP support to run NagVis. We recommend the usage of <a href="http://www.apache.org/" target="_blank">Apache Webserver</a> with <a href="http://www.apache.net/" target="_blank">mod_php</a>.</p>

--- a/share/server/core/classes/GlobalBackendmklivestatus.php
+++ b/share/server/core/classes/GlobalBackendmklivestatus.php
@@ -5,7 +5,7 @@
  *
  * Backend class for handling object and state information using the
  * livestatus NEB module. For mor information about CheckMK's Livestatus
- * Module please visit: http://mathias-kettner.de/checkmk_livestatus.html
+ * Module please visit: https://docs.checkmk.com/latest/en/livestatus.html
  *
  * Copyright (c) 2010 NagVis Project  (Contact: info@nagvis.org),
  *                    Mathias Kettner (Contact: mk@mathias-kettner.de)
@@ -32,7 +32,7 @@
  * @author  Lars Michelsen  <lm@larsmichelsen.com>
  *
  * For mor information about CheckMK's Livestatus Module
- * please visit: http://mathias-kettner.de/checkmk_livestatus.html
+ * please visit: https://docs.checkmk.com/latest/en/livestatus.html
  */
 class GlobalBackendmklivestatus implements GlobalBackendInterface {
     private $backendId = '';


### PR DESCRIPTION
all URLs are now pointing to the Checkmk documentation (docs.checkmk.com)
