### PR TITLE
FIX Support forum links no longer point to monitoring-portal.org

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,8 +4,12 @@ Core:
          Entering correct proxy URLS with ports and one of the following schemas
          (tcp, udp, unix, udg, ssl, tls) would cause an error (Invalid format given)
          even though these proxies are correct.
+
+Frontend:
   * FIX: URLs still pointing to mathias-kettner.de documentation are now pointing to
          the Checkmk documentation (docs.checkmk.com).
+  * FIX: Support forum links to no longer existing forum (monitoring-portal.org) are
+         now pointing to the Checkmk forum (forum.checkmk.com).
 
 Security
   * Added cookie session timestamps validation when Nagvis is run within Checkmk

--- a/share/userfiles/templates/default.header.html
+++ b/share/userfiles/templates/default.header.html
@@ -152,7 +152,7 @@
         <span id="support-ddheader" onclick="ddMenuToggle(event, 'support')">{$langNeedHelp}</span>
         <ul id="support-ddcontent">
             <li><a target="_blank" href="{$pathBase}/docs/{$docLanguage}/index.html">{$langOnlineDoc}</a></li>
-            <li><a target="_blank" href="https://www.monitoring-portal.org/woltlab/index.php?board/42-nagvis/">{$langForum}</a></li>
+            <li><a target="_blank" href="https://forum.checkmk.com/">{$langForum}</a></li>
             <li><a target="_blank" href="{$pathBase}/frontend/nagvis-js/index.php?mod=Info" class="underline">{$langSupportInfo}</a></li>
         </ul>
     </li>


### PR DESCRIPTION
Instead links to forum.checkmk.com
