### PR TITLE
Fix cookie session timestamp validation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 1.9.45
   * FIX: Fix XSS on support info page (Thanks to jmacario24)
+  * FIX: Fix not working cookie session timestamps validation introduced with 1.9.43 in
+         when localhost is blocked or takes a long time to resolve
 
 1.9.44
   * FIX: Fix not working cookie session timestamps validation introduced with 1.9.43 in

--- a/share/server/core/classes/CoreLogonMultisite.php
+++ b/share/server/core/classes/CoreLogonMultisite.php
@@ -137,8 +137,9 @@ class CoreLogonMultisite extends CoreLogonModule {
 
         // Check session periods validity
         $site = getenv('OMD_SITE');
-        $port = $_SERVER['SERVER_PORT'];
-        $url = "http://localhost:$port/$site/check_mk/api/1.0/version";
+        $port = getenv('CONFIG_APACHE_TCP_PORT');
+        $host = getenv('CONFIG_APACHE_TCP_ADDR');
+        $url = "http://$host:$port/$site/check_mk/api/1.0/version";
         
         $headers = [
             'Content-type: application/json',


### PR DESCRIPTION
In certain scenarios localhost could be blocked or take a long time to
resolve, hence the cookie session validation now uses the loopback
address directly instead of localhost
