### PR TITLE
Sanitize pathname for cache file

### DIFF
--- a/share/server/core/classes/GlobalMapCfg.php
+++ b/share/server/core/classes/GlobalMapCfg.php
@@ -800,7 +800,7 @@ class GlobalMapCfg {
         if(isset($params['source_file']))
             unset($params['source_file']);
         $param_values = $this->paramsToString($params);
-        $cacheFile = cfg('paths','var').'source-'.$this->name.'.cfg-'.$param_values.'-'.$this->isView.'-'.CONST_VERSION.'.cache';
+        $cacheFile = cfg('paths','var').'source-'.$this->name.'.cfg-'.sha1($param_values.'-'.$this->isView.'-'.CONST_VERSION).'.cache';
         $CACHE = new GlobalFileCache(array(), $cacheFile);
 
         // 2a. Check if the cache file exists


### PR DESCRIPTION
AFAIK not exploitable, nevertheless it can cause failures.

The params are not read from the files later on so some hashing helps to sanitize everything.