### PR TITLE
Fix potential XSS via WYSIWYG editor

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 1.9.47
   * FIX: Don't show complete backtrace if crashing. Now the backtrace is being logged to the apache error log
+  * FIX: Fix potential XSS via WYSIWYG editor. Now the option to edit these such elements is moved to a specific
+   permission and only administrators can use this editor per default. (CVE-2024-47090)
 
 1.9.46
   * Feature: add option to verify session cookie via curl. Before when having allow_url_fopen

--- a/share/server/core/classes/CoreAuthorisationHandler.php
+++ b/share/server/core/classes/CoreAuthorisationHandler.php
@@ -53,6 +53,7 @@ class CoreAuthorisationHandler {
             'createObject' => 'edit',
             'deleteObject' => 'edit',
             'addModify' => 'edit',
+            'editHtml' => 'edit',
         ),
         'Overview' => Array(
             'getOverviewRotations' => 'view',

--- a/share/server/core/classes/ViewMapAddModify.php
+++ b/share/server/core/classes/ViewMapAddModify.php
@@ -116,6 +116,11 @@ class ViewMapAddModify {
         $perm_user   = get_checkbox('perm_user');
         $show_dialog = false;
 
+        global $AUTHORISATION;
+        if(!$AUTHORISATION->isPermitted('Map', 'editHtml', '*')) {
+            throw new NagVisException(l('Cannot edit HTML. Please contact your administrator'));
+        }
+
         // Modification/Creation?
         // The object_id is known on modification. When it is not known 'type' is set
         // to create new objects

--- a/share/server/core/functions/html.php
+++ b/share/server/core/functions/html.php
@@ -271,6 +271,11 @@ function textarea($name, $default = '', $class = '', $style = '') {
     if (submitted($form_name))
         $default = post($name, $default);
 
+    global $AUTHORISATION;
+    if(!$AUTHORISATION->isPermitted('Map', 'editHtml', '*')) {
+        echo '<b>Cannot edit HTML. Please contact your administrator.</b>';
+        return;
+    }
     // plain <textarea>
     echo '<textarea id="textarea_'.$name.'" name="'.$name.'"'.$class.$style.'>'.escape_html($default).'</textarea>'.N;
 


### PR DESCRIPTION
Now the option to edit these such elements is moved to a specific
permission and only administrators can use this editor per default.
