### PR TITLE
Don't show complete backtrace if crashing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 1.9.47
+  * FIX: Don't show complete backtrace if crashing. Now the backtrace is being logged to the apache error log
 
 1.9.46
   * Feature: add option to verify session cookie via curl. Before when having allow_url_fopen

--- a/share/server/core/functions/nagvisErrorHandler.php
+++ b/share/server/core/functions/nagvisErrorHandler.php
@@ -37,7 +37,9 @@ function nagvisException($OBJ) {
             echo $OBJ;
         } else {
             echo "Error (".get_class($OBJ)."): ".$OBJ->getMessage();
-            var_dump(debug_backtrace());
+            echo "<br>";
+            echo "For more information check the apache error log.";
+            error_log(print_r(debug_backtrace(), true));
         }
 
         die();


### PR DESCRIPTION
Now the backtrace is being logged to the apache error log
