### PR TITLE
Error Fix for Exclude Members Function using PHP 8.1+

### DIFF
--- a/share/server/core/classes/objects/NagVisStatefulObject.php
+++ b/share/server/core/classes/objects/NagVisStatefulObject.php
@@ -360,9 +360,9 @@ class NagVisStatefulObject extends NagVisObject {
     public function getExcludeFilterKey($isCount) {
         // When this is a count use the exclude_member_states over the 
         // exclude_members
-        if($isCount && $this->exclude_member_states !== '')
+        if($isCount && $this->exclude_member_states != '')
             return 'exclude_member_states';
-        elseif($this->exclude_members !== '')
+        elseif($this->exclude_members != '')
             return 'exclude_members';
         else
             return '';


### PR DESCRIPTION
Below is a screenshot of an error that occurs when trying to use the exclude_member option in NagVis 1.9.47/Checkmk 2.4.0p3.cre on Ubuntu 24.04.
![Screenshot 2025-06-11 at 14-48-03 Checkmk Local site monitoring - eh mitt (CRITICAL) NagVis 1 9 47](https://github.com/user-attachments/assets/010caf16-0a71-448c-badd-6127716e76f1)
With PHP 8.1, passing null to non-nullable internal function has been [deprecated](https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation). Ubuntu 24.04 comes with PHP 8.3.

Because getExcludeFilterKey() uses not identical operators when comparing exclude_members and exclude_member_states to an empty string, null values can slip past this check and get passed to explode() in excludeMapObject(). After changing these operators to not equal, null values are caught and an empty string will be returned instead.