### PR TITLE
Visual Improvement for Automaps using exclude_members

### DIFF
--- a/share/frontend/nagvis-js/js/ViewMap.js
+++ b/share/frontend/nagvis-js/js/ViewMap.js
@@ -223,7 +223,7 @@ var ViewMap = View.extend({
         var obj = this.objects[object_id];
         var parents = obj.getParentObjectIds();
 
-        if (parents){
+        if (parents && usesSource('automap')){
             for (var parentObjId in parents) {
                 if (!this.objects[parentObjId]){
                     return;

--- a/share/frontend/nagvis-js/js/ViewMap.js
+++ b/share/frontend/nagvis-js/js/ViewMap.js
@@ -221,6 +221,15 @@ var ViewMap = View.extend({
 
     renderObject: function(object_id) {
         var obj = this.objects[object_id];
+        var parents = obj.getParentObjectIds();
+
+        if (parents){
+            for (var parentObjId in parents) {
+                if (!this.objects[parentObjId]){
+                    return;
+                }
+            }
+        }
 
         // FIXME: Are all these steps needed here?
         obj.update();
@@ -234,7 +243,6 @@ var ViewMap = View.extend({
         }
 
         // Store object dependencies
-        var parents = obj.getParentObjectIds();
         if (parents) {
             for (var parentObjId in parents) {
                 if (isset(this.objects[parentObjId])) this.objects[parentObjId].addChild(obj);


### PR DESCRIPTION
When using exclude_members in an automap, the members are excluded, but their lines are not. This leads to unwanted behavior, as these lines now point to the top left corner. These changes seek to remedy this by checking if the parent has been excluded before rendering the object. This only applies to automaps. On other types of maps, elements that are relative to an excluded element will still be rendered normally.

Without excluding members:
![image](https://github.com/user-attachments/assets/d1a9ea59-2091-4314-93e3-4d914b9eae65)

Before fix:
![image](https://github.com/user-attachments/assets/e14336a1-4093-4195-8947-061041995368)

After fix:
![image](https://github.com/user-attachments/assets/1fe42877-1e68-4849-92ea-c050b2a1058d)

Fixes #401 