### PR TITLE
Completes support for svg iconsets #403

### DIFF
--- a/share/server/core/defines/matches.php
+++ b/share/server/core/defines/matches.php
@@ -71,7 +71,7 @@ define('MATCH_PNG_GIF_JPG_FILE_OR_URL', '/^((.+)\.(png|gif|jpg)|\[[0-9a-z\s:+[\]
 define('MATCH_ROTATION_STEP_TYPES_EMPTY', '/^(?:map|url)?$/');
 define('MATCH_LANGUAGE_EMPTY', '/^[a-zA-Z0-9\-_]*$/');
 define('MATCH_LANGUAGE_FILE', '/^([^.].*)/');
-define('MATCH_ICONSET', '/^(.+)_ok.(png|gif|jpg)$/u');
+define('MATCH_ICONSET', '/^(.+)_ok.(png|gif|jpg|svg)$/u');
 define('MATCH_BACKEND_FILE', '/^GlobalBackend([^MI].+)\.php$/');
 define('MATCH_BACKEND_ID', '/^[0-9a-z._-]*$/iu');
 define('MATCH_DOC_DIR', '/^([a-z]{2}_[A-Z]{2})/');

--- a/share/server/core/sources/general.php
+++ b/share/server/core/sources/general.php
@@ -50,12 +50,49 @@ function iconset_size($iconset) {
     $fileType = $CORE->getIconsetFiletype($iconset);
     $iconPath      = path('sys',  'global', 'icons').'/'.$iconset.'_ok.'.$fileType;
     $iconPathLocal = path('sys',  'local',  'icons').'/'.$iconset.'_ok.'.$fileType;
-    if(file_exists($iconPathLocal))
-        return getimagesize($iconPathLocal);
-    elseif(file_exists($iconPath))
-        return getimagesize($iconPath);
+    if(file_exists($iconPathLocal)) {
+        if($fileType == "svg") {
+            return svg_size($iconPathLocal);
+        }
+        else {
+            return getimagesize($iconPathLocal);
+        }
+    }
+    elseif(file_exists($iconPath)){
+        if($fileType == "svg") {
+            return svg_size($iconPath);
+        }
+        else {
+            return getimagesize($iconPath);
+        }
+    }
     else
         return array(0, 0);
+}
+
+function svg_size($filepath) {
+    if (!file_exists($filepath)) {
+        return array(0, 0);
+    }
+
+    $doc = new DOMDocument();
+    $doc->load($filepath);
+
+    $svg = $doc->getElementsByTagName('svg')->item(0);
+    $width = $svg->getAttribute('width');
+    $height = $svg->getAttribute('height');
+
+    // Fallback to viewBox
+    if (empty($width) || empty($height)) {
+        $viewBox = $svg->getAttribute('viewBox');
+        $parts = preg_split('/[\s,]+/', $viewBox);
+        if (count($parts) === 4) {
+            $width = $parts[2];
+            $height = $parts[3];
+        }
+    }
+
+    return array(floatval($width), floatval($height));
 }
 
 function shape_size($icon) {


### PR DESCRIPTION
Closes #403 

This PR adds two quick changes that satisfy issue #403 by allowing SVG images to be used as user supplied iconsets