### PR TITLE
replace E_STRICT in PHP 8.0 and above

### DIFF
--- a/share/server/core/defines/global.php
+++ b/share/server/core/defines/global.php
@@ -28,11 +28,14 @@ define('CONST_VERSION', '1.9.49');
 // Set PHP error handling to standard level
 // Different levels for php versions below 5.1 because PHP 5.1 reports
 // some annoying strict messages which are OK for us. From version 5.2
-// everything is OK when using E_STRICT.
-if(version_compare(PHP_VERSION, '5.2') >= 0)
-	error_reporting(E_ALL ^ E_STRICT);
+// everything is OK when using E_STRICT and use for compatibility issues
+// from version 8.0 and above E_DEPRECATED
+if (version_compare(PHP_VERSION, '8.0') >= 0)
+    error_reporting(E_ALL & ~E_DEPRECATED);
+elseif (version_compare(PHP_VERSION, '5.2') >= 0)
+    error_reporting(E_ALL ^ E_STRICT);
 else
-	error_reporting(E_ALL);
+    error_reporting(E_ALL);
 
 /**
  * Set the search path for included files


### PR DESCRIPTION
E_STRICT is deprecated in PHP 8.0; E_DEPRECATED should be used instead
