### PR TITLE
Fix bit/byte detection for Checkmk average interface output formats

### DIFF
--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -817,8 +817,9 @@ var ElementLine = Element.extend({
 
         // Checkmk if/if64 checks support switching between bytes/bits.
         var display_bits = false;
+        var reBits = /\bIn(?:\s+average\s+[^:]+)?:\s*[0-9][0-9.,]*\s*\S*Bit\/s\b[\s\S]*?\bOut(?:\s+average\s+[^:]+)?:\s*[0-9][0-9.,]*\s*\S*Bit\/s\b/i;
 
-        if (output.match('In: [0-9].*(Bit|bit)/s.*Out: [0-9]+')) {
+        if (output.match(reBits)) {
             display_bits=true;
         }
 


### PR DESCRIPTION
NagVis decides whether to display link bandwidth in bits or bytes by matching the service output against a fixed In: / Out: pattern.
This works for classic interface outputs but fails for average formats in Checkmk such as In average 20min: / Out average 20min: 

Problem:
The current regex only matches outputs like:
In: 3.29 MBit/s ... Out: 1.97 MBit/s

but does not match outputs like:
In average 20min: 503 MBit/s ... Out average 20min: 858 MBit/s

even though both clearly report traffic in Bit/s.
Example: Standard Output Format:
[Uplink], (up), MAC: 83:12:C1:41:C6:1E, Speed: 1 GBit/s, In: 3.29 MBit/s (0.33%), Out: 1.97 MBit/s (0.20%)

Example: Average Output Format:
[Uplink], (up), MAC: A0:4B:1A:5D:73:6A, Speed: 100 GBit/s, In average 20min: 503 MBit/s (0.50%), Out average 20min: 858 MBit/s (0.86%), Total average 20min: 1.36 GBit/s (0.68%)