### PR TITLE
fix if parseInt() interpret "auto" as NaN

### DIFF
--- a/share/frontend/nagvis-js/js/ajaxActions.js
+++ b/share/frontend/nagvis-js/js/ajaxActions.js
@@ -7,7 +7,7 @@ function saveObjectAttr(objId, attr) {
     var urlPart = '';
     for (var key in attr)
         // parseInt() returned NaN, because value was set to "auto"
-        if ( ! isNaN(escapeUrlValues(attr[key])) )
+        if ( ! isNaN(attr[key]) )
             urlPart += '&' + key + '=' + escapeUrlValues(attr[key]);
 
     call_ajax(oGeneralProperties.path_server + '?mod=Map&act=modifyObject&map='


### PR DESCRIPTION
workaround if the height or width of a text box and other elements is set to auto, but parseInt() does not parse this correctly