### PR TITLE
Fix fatal autoloader error when backendtype is empty or missing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 1.9.49
+  * FIX: Prevent fatal autoloader error when backend has empty or missing backendtype
   * FIX: Fix creating users during first login in some cases (#294)
   * FIX: Fix if parseInt() interpret "auto" as NaN (#416 Thanks to ArminRadmueller)
 

--- a/share/server/core/classes/CoreBackendMgmt.php
+++ b/share/server/core/classes/CoreBackendMgmt.php
@@ -567,12 +567,13 @@ class CoreBackendMgmt {
      */
     public function checkBackendExists($backendId, $printErr) {
         global $CORE;
-        if($CORE->checkExisting(cfg('paths','class').'GlobalBackend'.cfg('backend_'.$backendId,'backendtype').'.php', false))
+        $backendType = cfg('backend_'.$backendId,'backendtype');
+        if($backendType != '' && $CORE->checkExisting(cfg('paths','class').'GlobalBackend'.$backendType.'.php', false))
             return true;
 
         if($printErr == 1)
             throw new NagVisException(l('backendNotExists', Array('BACKENDID'   => $backendId,
-                                                                  'BACKENDTYPE' => cfg('backend_'.$backendId,'backendtype'))));
+                                                                  'BACKENDTYPE' => $backendType)));
         return false;
     }
 
@@ -673,7 +674,7 @@ class CoreBackendMgmt {
      */
     public function checkBackendFeature($backendId, $feature, $printErr = 1) {
         $backendClass = 'GlobalBackend'.cfg('backend_'.$backendId, 'backendtype');
-        if(method_exists($backendClass, $feature)) {
+        if(class_exists($backendClass, false) && method_exists($backendClass, $feature)) {
             return true;
         } else {
             if($printErr == 1) {


### PR DESCRIPTION
When a backend section exists in the config but has no backendtype set,
cfg() returns an empty string, causing the class name to be "GlobalBackend".
The autoloader then tries require("GlobalBackend.php") which fails fatally.

- checkBackendExists(): guard against empty backendtype before file check
- checkBackendFeature(): use class_exists(..., false) before method_exists()
  to avoid triggering the autoloader for an unloaded/invalid class

CMK-29609
