### PR TITLE
Allow double quotes in service descriptions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
   * FIX: Fix creating users during first login in some cases (#294)
   * FIX: Fix if parseInt() interpret "auto" as NaN (#416 Thanks to ArminRadmueller)
   * FIX: URL-encode object names and service descriptions in map links to handle special characters like '#'
+  * FIX: Allow double quotes in service descriptions to support Checkmk if64 interface names
 
 1.9.48
   * FIX: Fix exclude_members related PHP 8.1 compatibility issue (#400 Thanks to ekapsner-ne)

--- a/share/server/core/defines/matches.php
+++ b/share/server/core/defines/matches.php
@@ -77,7 +77,7 @@ define('MATCH_BACKEND_ID', '/^[0-9a-z._-]*$/iu');
 define('MATCH_DOC_DIR', '/^([a-z]{2}_[A-Z]{2})/');
 define('MATCH_MAINCFG_FILE', '/^.+\.ini\.php$/i');
 
-define('MATCH_SERVICE_DESCRIPTION', '/^[0-9a-zа-яё\p{L}\s:+[\]()_.,\'\-\*?!#@=\/\\\]+$/iu');
+define('MATCH_SERVICE_DESCRIPTION', '/^[0-9a-zа-яё\p{L}\s:+[\]()_.,\'\-\*?!#@=\/\\"]+$/iu');
 define('MATCH_MAP_NAME', '/^[0-9A-Za-z_\-]+$/');
 define('MATCH_MAP_NAME_EMPTY', '/^[0-9A-Za-z_-]*$/');
 define('MATCH_ROTATION_NAME', '/^[0-9A-Za-z_-]+$/');


### PR DESCRIPTION
Checkmk adds double quotes to interface descriptions when discovered via
if64 (e.g. 'Interface "eth0"'). The validation regex rejected these,
preventing maps with such services from loading.

SUP-27795
