### PR TITLE
Fix URL encoding of object names and service descriptions in map links

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 1.9.49
   * FIX: Fix creating users during first login in some cases (#294)
   * FIX: Fix if parseInt() interpret "auto" as NaN (#416 Thanks to ArminRadmueller)
+  * FIX: URL-encode object names and service descriptions in map links to handle special characters like '#'
 
 1.9.48
   * FIX: Fix exclude_members related PHP 8.1 compatibility issue (#400 Thanks to ekapsner-ne)

--- a/share/frontend/nagvis-js/js/NagVisStatefulObject.js
+++ b/share/frontend/nagvis-js/js/NagVisStatefulObject.js
@@ -415,13 +415,13 @@ var NagVisStatefulObject = NagVisObject.extend({
 
             this.conf.url = this.conf.url.replace(getRegEx('htmlbase', '\\[htmlbase\\]', 'g'), oGeneralProperties.path_base);
 
-            this.conf.url = this.conf.url.replace(getRegEx(name, '\\['+name+'\\]', 'g'), this.conf.name);
+            this.conf.url = this.conf.url.replace(getRegEx(name, '\\['+name+'\\]', 'g'), encodeURIComponent(this.conf.name));
             if(this.conf.type == 'service') {
-                this.conf.url = this.conf.url.replace(getRegEx('service_description', '\\[service_description\\]', 'g'), this.conf.service_description);
+                this.conf.url = this.conf.url.replace(getRegEx('service_description', '\\[service_description\\]', 'g'), encodeURIComponent(this.conf.service_description));
             }
 
             if(this.conf.type != 'map') {
-                this.conf.url = this.conf.url.replace(getRegEx('backend_id', '\\[backend_id\\]', 'g'), this.conf.backend_id);
+                this.conf.url = this.conf.url.replace(getRegEx('backend_id', '\\[backend_id\\]', 'g'), encodeURIComponent(this.conf.backend_id));
             }
         }
     },


### PR DESCRIPTION
Special characters like '#' in host/service names were not percent-encoded
when substituted into URLs, causing browsers to interpret them as fragment
identifiers. Wrap dynamic URL parameter values with encodeURIComponent().

SUP-28123
