### PR TITLE
Suppress PHPStan false positives for relative require_once paths

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,3 +14,10 @@ parameters:
         - share/server/core/ext/php-gettext-1.0.12/gettext.inc
         - stub_multisite_auth.php
         - stub_hosttags.php
+    ignoreErrors:
+        -
+            identifier: requireOnce.fileNotFound
+            path: share/server/core/classes/CoreTemplateSystem.php
+        -
+            identifier: requireOnce.fileNotFound
+            path: share/server/core/classes/GlobalLanguage.php


### PR DESCRIPTION
CoreTemplateSystem.php and GlobalLanguage.php use relative require_once
paths that are resolved at runtime via include_path but can't be
statically resolved by PHPStan. Both files are already handled via
bootstrapFiles; ignore the requireOnce.fileNotFound errors.
