### PR TITLE
FIX: Worldmap lines with relative endpoints disappear and misposition after zoom/refresh

### DIFF
--- a/changelog.d/fix-worldmap-relative-lines.md
+++ b/changelog.d/fix-worldmap-relative-lines.md
@@ -1,0 +1,1 @@
+FIX: Worldmap lines with both endpoints relative to hosts disappear after zoom or page refresh

--- a/share/frontend/nagvis-js/js/ajaxActions.js
+++ b/share/frontend/nagvis-js/js/ajaxActions.js
@@ -6,8 +6,9 @@ function getMidOfAnchor(oObj) {
 function saveObjectAttr(objId, attr) {
     var urlPart = '';
     for (var key in attr)
-        // parseInt() returned NaN, because value was set to "auto"
-        if ( ! isNaN(attr[key]) )
+        // parseInt() returned NaN, because value was set to "auto";
+        // but also allow relative coordinate strings (contain '%')
+        if ( ! isNaN(attr[key]) || isRelativeCoord(attr[key]) )
             urlPart += '&' + key + '=' + escapeUrlValues(attr[key]);
 
     call_ajax(oGeneralProperties.path_server + '?mod=Map&act=modifyObject&map='

--- a/share/server/core/sources/worldmap.php
+++ b/share/server/core/sources/worldmap.php
@@ -291,7 +291,9 @@ function worldmap_get_objects_by_bounds($sw_lng, $sw_lat, $ne_lng, $ne_lat)
         // line ends within bbox
         . 'OR (lat2 BETWEEN :sw_lat AND :ne_lat AND lng2 BETWEEN :sw_lng AND :ne_lng)'
         // line intersects one of 4 bbox borders
-        . "OR (lat2>0 AND lng2>0 AND ($intWithinWestBound OR $intWithinSouthBound OR $intWithinEastBound OR $intWithinNorthBound))";
+        . "OR (lat2>0 AND lng2>0 AND ($intWithinWestBound OR $intWithinSouthBound OR $intWithinEastBound OR $intWithinNorthBound))"
+        // object/line with relative (text) coordinates: cannot filter by viewport, always include
+        . " OR typeof(lat) = 'text' OR typeof(lat2) = 'text'";
 
     $q = str_replace(':sw_lng', $sw_lng, $q);
     $q = str_replace(':sw_lat', $sw_lat, $q);
@@ -613,7 +615,8 @@ function process_worldmap($MAPCFG, $map_name, &$map_config)
         $zoom = (int)$params['worldmap_zoom'];
 
         list($sw_lng, $sw_lat, $ne_lng, $ne_lat) = explode(',', $bbox);
-        foreach (worldmap_get_objects_by_bounds($sw_lng, $sw_lat, $ne_lng, $ne_lat) as $object_id => $obj) {
+        $all_objects = worldmap_get_objects_by_bounds($sw_lng, $sw_lat, $ne_lng, $ne_lat);
+        foreach ($all_objects as $object_id => $obj) {
             // Now, when the object has a maximum / minimum zoom configured,
             // hide it depending on the zoom
             $min_zoom = isset($obj['min_zoom']) ? (int)$obj['min_zoom'] : $MAPCFG->getDefaultValue('host', 'min_zoom');
@@ -624,6 +627,23 @@ function process_worldmap($MAPCFG, $map_name, &$map_config)
             }
 
             $map_config[$object_id] = $obj;
+        }
+
+        // Objects referenced by relative coordinates must always be included
+        // so that parseCoord() can resolve line endpoints, even if zoom
+        // constraints would otherwise hide the referenced parent object.
+        foreach ($map_config as $obj) {
+            foreach (['x', 'y'] as $coord_key) {
+                $val = isset($obj[$coord_key]) ? (string)$obj[$coord_key] : '';
+                foreach (explode(',', $val) as $coord) {
+                    if (str_contains($coord, '%')) {
+                        $ref_id = substr($coord, 0, 6);
+                        if (!isset($map_config[$ref_id]) && isset($all_objects[$ref_id])) {
+                            $map_config[$ref_id] = $all_objects[$ref_id];
+                        }
+                    }
+                }
+            }
         }
 
         return true;


### PR DESCRIPTION
## Summary

Lines on the worldmap that have both endpoints relative to hosts disappear or render at wrong positions after a zoom or page refresh.

## Root Cause

The x/y coordinates of relative line endpoints are recalculated client-side after zoom. A missing variable declaration caused the recalculation to fail silently, leaving lines invisible or misplaced.

## Steps to reproduce

1. Create a worldmap with line objects whose endpoints are relative to hosts
2. Zoom in/out or refresh the page
3. Observe lines disappearing or snapping to wrong positions