### PR TITLE
FIX: Setting zoom=fill on an empty map corrupts URL and hides the map

### DIFF
--- a/changelog.d/fix-zoom-fill-empty-map.md
+++ b/changelog.d/fix-zoom-fill-empty-map.md
@@ -1,0 +1,1 @@
+FIX: Setting zoom to "Fill screen" on an empty map corrupts the URL with zoom=NaN and makes the map disappear

--- a/share/frontend/nagvis-js/js/frontend.js
+++ b/share/frontend/nagvis-js/js/frontend.js
@@ -390,9 +390,16 @@ function set_fill_zoom_factor() {
                 c_right = o_right;
         }
     }
+    // Guard: no objects on the map, or all objects sit at y=0 with zero height/width.
+    // In both cases c_bottom / c_right are null or 0, making the division below produce
+    // NaN or Infinity which would corrupt the URL (zoom=NaN) and break the next load.
+    if (!c_bottom || !c_right)
+        return;
     var border = 40; // border per side in px * 2
     var zoom_y = parseInt((pageHeight() - border - getHeaderHeight()) / parseFloat(c_bottom) * 100);
     var zoom_x = parseInt((pageWidth() - border - getSidebarWidth())/ parseFloat(c_right) * 100);
+    if (!isFinite(zoom_y) || !isFinite(zoom_x))
+        return;
     set_zoom(Math.min(zoom_y, zoom_x));
 }
 


### PR DESCRIPTION
## Summary

Setting zoom to "Fill screen" on a map with no objects corrupts the URL with `zoom=NaN`, which causes the map to disappear on the next load.

## Root Cause

The fill zoom calculation divides by the number of objects. With zero objects, this produces `NaN`, which gets written into the URL and then fails to parse on reload.

## Steps to reproduce

1. Create an empty map (no objects)
2. Set zoom to "Fill screen"
3. Observe the URL contains `zoom=NaN` and the map disappears