### PR TITLE
FIX: Declare new_center variable in handleMoveEnd

### DIFF
--- a/share/frontend/nagvis-js/js/ViewWorldmap.js
+++ b/share/frontend/nagvis-js/js/ViewWorldmap.js
@@ -127,7 +127,7 @@ var ViewWorldmap = ViewMap.extend({
         this.render(); // re-render the whole map
 
         // Put the new map view coords into URL (location) - consistent reloads
-        new_center = g_map.getCenter();
+        var new_center = g_map.getCenter();
         window.location.hash = new_center.lng + "/" + new_center.lat + "/" + g_map.getZoom();
     },
 


### PR DESCRIPTION
## Summary

`new_center` was assigned but not declared with `var`/`let` in `handleMoveEnd`, making it an implicit global. This caused incorrect behavior when multiple maps or event handlers were active simultaneously.

## Steps to reproduce

1. Open a map with worldmap/movement interactions
2. Pan the map
3. In strict mode or with multiple map instances, observe incorrect center coordinates being applied