### PR TITLE
Add changelog.d/ fragment-based changelog mechanism

### DIFF
--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,33 @@
+# Changelog Fragments
+
+Each fix or feature adds **one file** to this directory instead of editing
+`ChangeLog` directly. This prevents merge conflicts since every change lives
+in its own file.
+
+## Filename convention
+
+```
+<type>-<short-description>.md
+```
+
+Types: `fix`, `feat`, `security`, `deprecation`, `removal`
+
+Examples: `fix-worldmap-lines.md`, `feat-dark-mode.md`
+
+## File content
+
+A single line — the changelog entry text, without the leading `  * `:
+
+```
+FIX: Worldmap lines with both endpoints relative disappear after zoom
+```
+
+## Release process
+
+```
+tools/changelog-release.sh
+```
+
+The script inserts all fragments under the current version heading in
+`ChangeLog` and then deletes the fragment files. Run it as part of the
+release commit.

--- a/tools/changelog-release.sh
+++ b/tools/changelog-release.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Insert changelog fragments under the current version heading in ChangeLog.
+#
+# Usage: tools/changelog-release.sh
+#
+# Reads the version from the first line of ChangeLog, collects all *.md files
+# from changelog.d/ (except README.md), inserts them as "  * <line>" entries
+# directly after the version heading, then deletes the fragment files.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FRAGMENTS_DIR="$SCRIPT_DIR/../changelog.d"
+CHANGELOG="$SCRIPT_DIR/../ChangeLog"
+
+version=$(head -1 "$CHANGELOG")
+
+entries=""
+for f in "$FRAGMENTS_DIR"/*.md; do
+    [ -f "$f" ] || continue
+    [ "$(basename "$f")" = "README.md" ] && continue
+    line=$(head -1 "$f")
+    [ -n "$line" ] && entries="${entries}  * ${line}\n"
+done
+
+if [ -z "$entries" ]; then
+    echo "No changelog fragments found in $FRAGMENTS_DIR/" >&2
+    exit 1
+fi
+
+# Insert entries after the first line (version heading) of ChangeLog
+tmp=$(mktemp)
+head -1 "$CHANGELOG" > "$tmp"
+printf '%b' "$entries" >> "$tmp"
+tail -n +2 "$CHANGELOG" >> "$tmp"
+mv "$tmp" "$CHANGELOG"
+
+# Delete consumed fragment files (git rm stages the removal for the release commit)
+for f in "$FRAGMENTS_DIR"/*.md; do
+    [ -f "$f" ] || continue
+    [ "$(basename "$f")" = "README.md" ] && continue
+    git rm -f "$f"
+done
+
+count=$(printf '%b' "$entries" | grep -c "^  \* ")
+echo "ChangeLog updated for $version ($count entries added)"


### PR DESCRIPTION
## Summary

Editing `ChangeLog` directly on every branch causes merge conflicts whenever two branches touch the same version heading. This introduces a towncrier-style fragment mechanism to eliminate those conflicts.

Each fix or feature adds one small `.md` file to `changelog.d/` instead of editing `ChangeLog`. At release time, a script collects all fragments and inserts them under the current version heading.

## Changes

- `changelog.d/README.md` — documents the filename convention and file format
- `tools/changelog-release.sh` — collects fragments and inserts them into `ChangeLog`, then deletes the fragment files

## Usage

```
# During development: add a file like changelog.d/fix-some-bug.md
echo "FIX: Some bug that was fixed" > changelog.d/fix-some-bug.md

# At release time:
tools/changelog-release.sh
```