### PR TITLE
FIX: Improve popup input field border visibility in light mode

### DIFF
--- a/share/userfiles/templates/default.css
+++ b/share/userfiles/templates/default.css
@@ -509,7 +509,7 @@ div#popupWindow h1 {
 #popupWindowContent input, select {
     color: #555555;
     background-color: #fbfbfb;
-    border: 1px solid #e5e5e5;
+    border: 1px solid #bbb;
 }
 
 /* Header styling */


### PR DESCRIPTION
## Summary

The `#e5e5e5` border on a `#fbfbfb` input background against a `#fff` popup background is nearly invisible. Changed to `#bbb` for sufficient contrast.

## Steps to reproduce

1. Open Options → Manage Maps (or any popup dialog)
2. Observe the input field borders are barely visible against the background