### PR TITLE
Feat: Add Prettier and ESLint JS formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,15 @@ jobs:
         name: PHPStan Static Analysis
         with:
           path: .
+
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Prettier format check
+        run: npm run format:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,15 @@ jobs:
       - run: npm ci
       - name: Prettier format check
         run: npm run format:check
+
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: ESLint
+        run: npm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ var/*
 # Exclude IDE directories
 .idea/
 .vscode
+node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Vendor / third-party JS bundled with NagVis — do not reformat
+share/frontend/nagvis-js/js/Ext*.js

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "tabWidth": 4,
+    "singleQuote": false,
+    "semi": true,
+    "printWidth": 120,
+    "trailingComma": "none"
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,7 +24,9 @@ export default [
             // rules produce too many false positives without explicit per-file global
             // declarations. Enable them again once the codebase is modularised.
             "no-undef": "off",
-            "no-unused-vars": "off"
+            "no-unused-vars": "off",
+            "no-var": "error",
+            "prefer-const": "error"
         }
     }
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,11 +24,7 @@ export default [
             // rules produce too many false positives without explicit per-file global
             // declarations. Enable them again once the codebase is modularised.
             "no-undef": "off",
-            "no-unused-vars": "off",
-            // ES5 var redeclaration within the same function scope is valid syntax and
-            // is used extensively throughout the codebase. Disable until the codebase
-            // moves to let/const.
-            "no-redeclare": "off"
+            "no-unused-vars": "off"
         }
     }
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,34 @@
+import js from "@eslint/js";
+import globals from "globals";
+import prettier from "eslint-config-prettier";
+
+export default [
+    {
+        ignores: [
+            "share/frontend/nagvis-js/js/Ext*.js"
+        ]
+    },
+    js.configs.recommended,
+    prettier,
+    {
+        languageOptions: {
+            ecmaVersion: 2015,
+            sourceType: "script",
+            globals: {
+                ...globals.browser
+            }
+        },
+        rules: {
+            // The JS codebase runs in a shared global browser scope across many files.
+            // Variables defined in one file are freely referenced from others, so these
+            // rules produce too many false positives without explicit per-file global
+            // declarations. Enable them again once the codebase is modularised.
+            "no-undef": "off",
+            "no-unused-vars": "off",
+            // ES5 var redeclaration within the same function scope is valid syntax and
+            // is used extensively throughout the codebase. Disable until the codebase
+            // moves to let/const.
+            "no-redeclare": "off"
+        }
+    }
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,968 @@
     "packages": {
         "": {
             "devDependencies": {
+                "@eslint/js": "^9.0.0",
+                "eslint": "^9.0.0",
+                "eslint-config-prettier": "^10.0.0",
+                "globals": "^16.0.0",
                 "prettier": "^3.0.0"
+            }
+        },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-visitor-keys": "^3.4.3"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@eslint/config-array": {
+            "version": "0.21.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+            "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/object-schema": "^2.1.7",
+                "debug": "^4.3.1",
+                "minimatch": "^3.1.5"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/config-helpers": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+            "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.17.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/core": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+            "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/eslintrc": {
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+            "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^6.14.0",
+                "debug": "^4.3.2",
+                "espree": "^10.0.1",
+                "globals": "^14.0.0",
+                "ignore": "^5.2.0",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^4.1.1",
+                "minimatch": "^3.1.5",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "9.39.4",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+            "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            }
+        },
+        "node_modules/@eslint/object-schema": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/plugin-kit": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+            "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.17.0",
+                "levn": "^0.4.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@humanfs/core": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node": {
+            "version": "0.16.7",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/core": "^0.19.1",
+                "@humanwhocodes/retry": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.22"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@humanwhocodes/retry": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/acorn": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-jsx": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/deep-is": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint": {
+            "version": "9.39.4",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+            "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.8.0",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.21.2",
+                "@eslint/config-helpers": "^0.4.2",
+                "@eslint/core": "^0.17.0",
+                "@eslint/eslintrc": "^3.3.5",
+                "@eslint/js": "9.39.4",
+                "@eslint/plugin-kit": "^0.4.1",
+                "@humanfs/node": "^0.16.6",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@humanwhocodes/retry": "^0.4.2",
+                "@types/estree": "^1.0.6",
+                "ajv": "^6.14.0",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.6",
+                "debug": "^4.3.2",
+                "escape-string-regexp": "^4.0.0",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
+                "esquery": "^1.5.0",
+                "esutils": "^2.0.2",
+                "fast-deep-equal": "^3.1.3",
+                "file-entry-cache": "^8.0.0",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "ignore": "^5.2.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "lodash.merge": "^4.6.2",
+                "minimatch": "^3.1.5",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.3"
+            },
+            "bin": {
+                "eslint": "bin/eslint.js"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "jiti": "*"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-config-prettier": {
+            "version": "10.1.8",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+            "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "eslint-config-prettier": "bin/cli.js"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-config-prettier"
+            },
+            "peerDependencies": {
+                "eslint": ">=7.0.0"
+            }
+        },
+        "node_modules/eslint-scope": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/espree": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/esquery": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+            "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "estraverse": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/file-entry-cache": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flat-cache": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/flat-cache": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.4"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/flatted": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/globals": {
+            "version": "16.5.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+            "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ignore": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.19"
+            }
+        },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
+        },
+        "node_modules/levn": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/optionator": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/prelude-ls": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
         "node_modules/prettier": {
@@ -22,6 +983,137 @@
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/type-check": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prelude-ls": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+    "name": "nagvis",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "devDependencies": {
+                "prettier": "^3.0.0"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+            "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "private": true,
+    "scripts": {
+        "format": "prettier --write 'share/**/*.js'",
+        "format:check": "prettier --check 'share/**/*.js'"
+    },
+    "devDependencies": {
+        "prettier": "^3.0.0"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,15 @@
     "private": true,
     "scripts": {
         "format": "prettier --write 'share/**/*.js'",
-        "format:check": "prettier --check 'share/**/*.js'"
+        "format:check": "prettier --check 'share/**/*.js'",
+        "lint": "eslint 'share/**/*.js'",
+        "lint:fix": "eslint --fix 'share/**/*.js'"
     },
     "devDependencies": {
+        "@eslint/js": "^9.0.0",
+        "eslint": "^9.0.0",
+        "eslint-config-prettier": "^10.0.0",
+        "globals": "^16.0.0",
         "prettier": "^3.0.0"
     }
 }

--- a/share/frontend/nagvis-js/js/Element.js
+++ b/share/frontend/nagvis-js/js/Element.js
@@ -21,6 +21,7 @@
  *
  *****************************************************************************/
 
+// eslint-disable-next-line no-redeclare
 var Element = Base.extend({
     // Holds the NagVis object which this element is associated with
     obj: null,
@@ -111,7 +112,7 @@ var Element = Base.extend({
         } else if (!enable) {
             if (this.obj.trigger_obj.parentNode.tagName == "A") {
                 this.obj.trigger_obj.parentNode.onclick = function (event) {
-                    var event = !event ? window.event : event;
+                    event = !event ? window.event : event;
                     if (event.stopPropagation) event.stopPropagation();
                     event.cancelBubble = true;
                     return false;

--- a/share/frontend/nagvis-js/js/Element.js
+++ b/share/frontend/nagvis-js/js/Element.js
@@ -22,7 +22,7 @@
  *****************************************************************************/
 
 // eslint-disable-next-line no-redeclare
-var Element = Base.extend({
+const Element = Base.extend({
     // Holds the NagVis object which this element is associated with
     obj: null,
     // Holds the root dom object of this element

--- a/share/frontend/nagvis-js/js/Element.js
+++ b/share/frontend/nagvis-js/js/Element.js
@@ -23,28 +23,27 @@
 
 var Element = Base.extend({
     // Holds the NagVis object which this element is associated with
-    obj     : null,
+    obj: null,
     // Holds the root dom object of this element
-    dom_obj : null,
+    dom_obj: null,
 
-    constructor: function(obj) {
+    constructor: function (obj) {
         this.obj = obj;
     },
 
     // Is called once when the object is being initialized and
     // on every time the config has changed. It's task is to
     // initialize this element and all eventual sub elements
-    update: function() {},
+    update: function () {},
 
     // Is called on every state/config update. For the most objects
     // this re-renders the element on each non state update.
-    updateAttrs: function(only_state, is_locked) {
+    updateAttrs: function (only_state, is_locked) {
         if (!only_state) {
             this.erase();
             this.render();
 
-            if (!is_locked)
-                this.unlock();
+            if (!is_locked) this.unlock();
 
             this.draw();
         }
@@ -53,50 +52,48 @@ var Element = Base.extend({
     // Is called to draw this elements DOM nodes this is called
     // once during initializaton and whenever the parent element
     // is redrawn, for example during a state update.
-    render: function() {},
+    render: function () {},
 
     // Is called to update the position of this elements DOM node.
     // It is called during movements of the objects and some of
     // the objects call it within the render() function to place
     // the objects during render() processing.
-    place: function() {},
+    place: function () {},
 
     // Is called by the parent element to add this elements DOM
     // object to the parent elements DOM object
-    draw: function() {
-        if (this.dom_obj && !this.dom_obj.parentNode)
-            this.obj.dom_obj.appendChild(this.dom_obj);
+    draw: function () {
+        if (this.dom_obj && !this.dom_obj.parentNode) this.obj.dom_obj.appendChild(this.dom_obj);
     },
 
     // Is called by the parent element to remove this elements DOM
     // object from the parent elements DOM object. This is the counterpart
     // of the draw() method.
-    erase: function() {
+    erase: function () {
         // FIXME: Remove all possible event handlers. Just to be
         // sure to prevent memory leaks
 
-        if (this.dom_obj && this.dom_obj.parentNode)
-            this.obj.dom_obj.removeChild(this.dom_obj);
+        if (this.dom_obj && this.dom_obj.parentNode) this.obj.dom_obj.removeChild(this.dom_obj);
     },
 
     // When the object is intially locked this is called once
     // during initialization and whenever the object shal be
     // locked
-    lock: function() {},
+    lock: function () {},
 
     // When the object is intially unlocked this is called once
     // during initialization and whenever the object shal be
     // unlocked
-    unlock: function() {},
+    unlock: function () {},
 
     // Is called to add this element to the parent element
-    addTo: function(obj) {
+    addTo: function (obj) {
         obj.addElement(this);
         return this;
     },
 
     // Is called to remove this element from the parent element
-    removeFrom: function(obj) {
+    removeFrom: function (obj) {
         obj.removeElement(this);
         return this;
     },
@@ -106,21 +103,20 @@ var Element = Base.extend({
     //
 
     // This enables/disables the the object left click action (link)
-    toggleLink: function(enable) {
-	if (enable) {
-            if (this.obj.trigger_obj.parentNode.tagName == 'A') {
+    toggleLink: function (enable) {
+        if (enable) {
+            if (this.obj.trigger_obj.parentNode.tagName == "A") {
                 this.obj.trigger_obj.parentNode.onclick = null;
             }
-	} else if (!enable) {
-            if (this.obj.trigger_obj.parentNode.tagName == 'A') {
-                this.obj.trigger_obj.parentNode.onclick = function(event) {
+        } else if (!enable) {
+            if (this.obj.trigger_obj.parentNode.tagName == "A") {
+                this.obj.trigger_obj.parentNode.onclick = function (event) {
                     var event = !event ? window.event : event;
-                    if(event.stopPropagation)
-                        event.stopPropagation();
+                    if (event.stopPropagation) event.stopPropagation();
                     event.cancelBubble = true;
                     return false;
                 };
             }
-	}
+        }
     }
 });

--- a/share/frontend/nagvis-js/js/ElementBox.js
+++ b/share/frontend/nagvis-js/js/ElementBox.js
@@ -22,25 +22,30 @@
  *****************************************************************************/
 
 var ElementBox = Element.extend({
-    render: function() {
+    render: function () {
         let scale = 1;
-        if (g_map && usesSource('worldmap') && this.obj.conf.scale_to_zoom == '1') {
+        if (g_map && usesSource("worldmap") && this.obj.conf.scale_to_zoom == "1") {
             let currentZoom = g_map.getZoom();
-            let one2oneZoom = Number(this.obj.conf.normal_size_at_zoom) || 19
+            let one2oneZoom = Number(this.obj.conf.normal_size_at_zoom) || 19;
             if (currentZoom < one2oneZoom) {
-                scale = 1 / Math.pow(2, one2oneZoom-currentZoom)
+                scale = 1 / Math.pow(2, one2oneZoom - currentZoom);
             }
             if (currentZoom > one2oneZoom) {
-                scale = Math.pow(2, currentZoom-one2oneZoom)
+                scale = Math.pow(2, currentZoom - one2oneZoom);
             }
         }
 
         this.dom_obj = renderNagVisTextbox(
-            this.obj.conf.object_id+'-label',
-            this.obj.conf.background_color, this.obj.conf.border_color,
-            0, 0, // coords are set by this.place()
-            this.obj.conf.z, this.obj.conf.w,
-            this.obj.conf.h, this.obj.getText(), this.obj.conf.style,
+            this.obj.conf.object_id + "-label",
+            this.obj.conf.background_color,
+            this.obj.conf.border_color,
+            0,
+            0, // coords are set by this.place()
+            this.obj.conf.z,
+            this.obj.conf.w,
+            this.obj.conf.h,
+            this.obj.getText(),
+            this.obj.conf.style,
             scale
         );
         this.obj.trigger_obj = this.dom_obj;
@@ -55,13 +60,13 @@ var ElementBox = Element.extend({
     lock: function () {
         // when locking the object while the cursor is a resize cursor,
         // it will stay as it is, when not removing them.
-        this.dom_obj.style.cursor = '';
+        this.dom_obj.style.cursor = "";
         makeUndragable(this.dom_obj);
         makeUnresizeable(this.dom_obj);
     },
 
     place: function () {
-        this.dom_obj.style.top  = this.obj.parseCoord(this.obj.conf.y, 'y') + 'px';
-        this.dom_obj.style.left = this.obj.parseCoord(this.obj.conf.x, 'x') + 'px';
+        this.dom_obj.style.top = this.obj.parseCoord(this.obj.conf.y, "y") + "px";
+        this.dom_obj.style.left = this.obj.parseCoord(this.obj.conf.x, "x") + "px";
     }
 });

--- a/share/frontend/nagvis-js/js/ElementBox.js
+++ b/share/frontend/nagvis-js/js/ElementBox.js
@@ -21,12 +21,12 @@
  *
  *****************************************************************************/
 
-var ElementBox = Element.extend({
+const ElementBox = Element.extend({
     render: function () {
         let scale = 1;
         if (g_map && usesSource("worldmap") && this.obj.conf.scale_to_zoom == "1") {
-            let currentZoom = g_map.getZoom();
-            let one2oneZoom = Number(this.obj.conf.normal_size_at_zoom) || 19;
+            const currentZoom = g_map.getZoom();
+            const one2oneZoom = Number(this.obj.conf.normal_size_at_zoom) || 19;
             if (currentZoom < one2oneZoom) {
                 scale = 1 / Math.pow(2, one2oneZoom - currentZoom);
             }

--- a/share/frontend/nagvis-js/js/ElementContext.js
+++ b/share/frontend/nagvis-js/js/ElementContext.js
@@ -363,7 +363,7 @@ var ElementContext = Element.extend({
         oSectionMacros["actions"] = "<!--\\sBEGIN\\saction_.+?\\s-->.+?<!--\\sEND\\saction_.+?\\s-->";
 
         // Loop and replace all unwanted section macros
-        for (var key in oSectionMacros) {
+        for (key in oSectionMacros) {
             var regex = getRegEx("section-" + key, oSectionMacros[key], "gm");
             this.template_html = this.template_html.replace(regex, "");
             regex = null;

--- a/share/frontend/nagvis-js/js/ElementContext.js
+++ b/share/frontend/nagvis-js/js/ElementContext.js
@@ -22,88 +22,85 @@
  *****************************************************************************/
 
 var g_context_templates = {};
-var g_context_open      = null;
+var g_context_open = null;
 
 // Hides the currently open context menu
 function contextHide() {
-    if (g_context_open !== null)
-        g_context_open.hide();
+    if (g_context_open !== null) g_context_open.hide();
 }
 
 function context_handle_global_mousedown(event) {
     event = event ? event : window.event; // IE FIX
-    if (usesSource('worldmap'))
-        event = event.originalEvent;
+    if (usesSource("worldmap")) event = event.originalEvent;
     var target = getTargetRaw(event);
 
-    while (target && !has_class(target, 'context'))
-        target = target.parentNode;
+    while (target && !has_class(target, "context")) target = target.parentNode;
 
     if (target === null) {
         // when not clicked on the context menu, hide it
         contextHide();
-    }
-    else {
+    } else {
         // Check for click on the context menu and do nothing in this case
-        var object_id = target.id.split('-')[0];
-        if (g_context_open && object_id == g_context_open.obj.conf.object_id)
-            return preventDefaultEvents(event);
+        var object_id = target.id.split("-")[0];
+        if (g_context_open && object_id == g_context_open.obj.conf.object_id) return preventDefaultEvents(event);
     }
 }
 
 var ElementContext = Element.extend({
-    template_html : null,
-    spacing       : 5,    // px from screen border
-    coords        : null, // list of x, y coordinates of the hover menu top left corner
+    template_html: null,
+    spacing: 5, // px from screen border
+    coords: null, // list of x, y coordinates of the hover menu top left corner
 
-    update: function() {
+    update: function () {
         this.getTemplate();
     },
 
-    render: function() {
+    render: function () {
         this.getTemplate();
-        if (this.template_html === null || this.template_html === true)
-            return false; // template not available yet, skip rendering
+        if (this.template_html === null || this.template_html === true) return false; // template not available yet, skip rendering
 
         this.renderMenu();
     },
 
-    draw: function() {
+    draw: function () {
         // Not rendered yet, e.g. because template was not fetched yet during
         // initial rendering. Re-try rendering now
-        if (this.dom_obj === null)
-            this.render();
+        if (this.dom_obj === null) this.render();
 
         this.base();
 
-        addEvent(this.obj.trigger_obj, 'contextmenu', function(element_obj) {
-            return function(event) {
-                // During render/drawing calls the template was not ready, so the menu
-                // has not been drawn yet. Do it now.
-                if (element_obj.dom_obj === null) {
-                    element_obj.draw();
-                }
-                element_obj.coords = [event.clientX, event.clientY];
-                element_obj.show();
-                return preventDefaultEvents(event);
-            };
-        }(this));
+        addEvent(
+            this.obj.trigger_obj,
+            "contextmenu",
+            (function (element_obj) {
+                return function (event) {
+                    // During render/drawing calls the template was not ready, so the menu
+                    // has not been drawn yet. Do it now.
+                    if (element_obj.dom_obj === null) {
+                        element_obj.draw();
+                    }
+                    element_obj.coords = [event.clientX, event.clientY];
+                    element_obj.show();
+                    return preventDefaultEvents(event);
+                };
+            })(this)
+        );
     },
 
-    erase: function() {
-        removeEvent(this.obj.trigger_obj, 'mousedown');
-        removeEvent(this.obj.trigger_obj, 'contextmenu');
+    erase: function () {
+        removeEvent(this.obj.trigger_obj, "mousedown");
+        removeEvent(this.obj.trigger_obj, "contextmenu");
         this.base();
     },
 
-    lock: function() {
+    lock: function () {
         // FIXME: Re-render for new content
         this.erase();
         this.render();
         this.draw();
     },
 
-    unlock: function() {
+    unlock: function () {
         // FIXME: Re-render for new content
         this.erase();
         this.render();
@@ -114,88 +111,89 @@ var ElementContext = Element.extend({
     // END OF PUBLIC METHODS
     //
 
-    getTemplate: function() {
+    getTemplate: function () {
         var name = this.obj.conf.context_template;
         if (!isset(g_context_templates[name])) {
             this.requestTemplate();
-        }
-        else if (g_context_templates[name] !== true) {
+        } else if (g_context_templates[name] !== true) {
             this.template_html = g_context_templates[name];
             this.replaceStaticMacros();
         }
     },
 
     handleTemplate: function (templates) {
-        var name = templates[0]['name'];
-        var code = templates[0]['code'];
+        var name = templates[0]["name"];
+        var code = templates[0]["code"];
 
         g_context_templates[name] = code;
 
         this.getTemplate(); // assign template to the object
 
         // Load css file is one is available
-        if (isset(templates[0]['css_file'])) {
+        if (isset(templates[0]["css_file"])) {
             // This is needed for some old browsers which do no load css files
             // which are included in such fetched html code
-            var oLink = document.createElement('link');
-            oLink.href = templates[0]['css_file'];
-            oLink.rel = 'stylesheet';
-            oLink.type = 'text/css';
+            var oLink = document.createElement("link");
+            oLink.href = templates[0]["css_file"];
+            oLink.rel = "stylesheet";
+            oLink.type = "text/css";
             document.getElementsByTagName("head")[0].appendChild(oLink);
         }
     },
 
     requestTemplate: function () {
-        call_ajax(oGeneralProperties.path_server+'?mod=General&act=getContextTemplate'
-                  +'&name[]='+escapeUrlValues(this.obj.conf.context_template), {
-            response_handler: this.handleTemplate.bind(this)
-        });
+        call_ajax(
+            oGeneralProperties.path_server +
+                "?mod=General&act=getContextTemplate" +
+                "&name[]=" +
+                escapeUrlValues(this.obj.conf.context_template),
+            {
+                response_handler: this.handleTemplate.bind(this)
+            }
+        );
         g_context_templates[this.obj.conf.context_template] = true; // mark as already requested
     },
 
-    show: function() {
+    show: function () {
         hoverHide();
 
         // document.body.scrollTop does not work in IE
-        var scrollTop = document.body.scrollTop ? document.body.scrollTop :
-                                                  document.documentElement.scrollTop;
-        var scrollLeft = document.body.scrollLeft ? document.body.scrollLeft :
-                                                    document.documentElement.scrollLeft;
-    
+        var scrollTop = document.body.scrollTop ? document.body.scrollTop : document.documentElement.scrollTop;
+        var scrollLeft = document.body.scrollLeft ? document.body.scrollLeft : document.documentElement.scrollLeft;
+
         // hide the menu first to avoid an "up-then-over" visual effect
-        this.dom_obj.style.display = 'none';
-        this.dom_obj.style.left = this.coords[0] + this.spacing + scrollLeft - getSidebarWidth() + 'px';
-        this.dom_obj.style.top = this.coords[1] + this.spacing + scrollTop - getHeaderHeight() + 'px';
-        this.dom_obj.style.display = '';
-    
+        this.dom_obj.style.display = "none";
+        this.dom_obj.style.left = this.coords[0] + this.spacing + scrollLeft - getSidebarWidth() + "px";
+        this.dom_obj.style.top = this.coords[1] + this.spacing + scrollTop - getHeaderHeight() + "px";
+        this.dom_obj.style.display = "";
+
         // Check if the context menu is "in screen".
         // When not: reposition
-        var contextLeft = parseInt(this.dom_obj.style.left.replace('px', ''));
-        if(contextLeft+this.dom_obj.clientWidth > pageWidth()) {
+        var contextLeft = parseInt(this.dom_obj.style.left.replace("px", ""));
+        if (contextLeft + this.dom_obj.clientWidth > pageWidth()) {
             // move the context menu to the left
-            this.dom_obj.style.left = contextLeft - this.dom_obj.clientWidth + 'px';
+            this.dom_obj.style.left = contextLeft - this.dom_obj.clientWidth + "px";
         }
-    
-        var contextTop = parseInt(this.dom_obj.style.top.replace('px', ''));
-        if(contextTop+this.dom_obj.clientHeight > pageHeight()) {
+
+        var contextTop = parseInt(this.dom_obj.style.top.replace("px", ""));
+        if (contextTop + this.dom_obj.clientHeight > pageHeight()) {
             // Only move the context menu to the top when the new top will not be
             // out of sight
-            if(contextTop - this.dom_obj.clientHeight >= 0) {
-                this.dom_obj.style.top = contextTop - this.dom_obj.clientHeight + 'px';
+            if (contextTop - this.dom_obj.clientHeight >= 0) {
+                this.dom_obj.style.top = contextTop - this.dom_obj.clientHeight + "px";
             }
         }
 
         g_context_open = this;
     },
 
-    hide: function() {
+    hide: function () {
         if (this.dom_obj) {
-            this.dom_obj.style.display = 'none';
+            this.dom_obj.style.display = "none";
         }
-        if(g_context_open) {
-            const context_obj = document.getElementById(g_context_open.obj.conf.object_id+'-context');
-            if (context_obj)
-                context_obj.style.display = 'none';
+        if (g_context_open) {
+            const context_obj = document.getElementById(g_context_open.obj.conf.object_id + "-context");
+            if (context_obj) context_obj.style.display = "none";
             g_context_open = null;
         }
     },
@@ -203,106 +201,107 @@ var ElementContext = Element.extend({
     renderMenu: function () {
         // Only create a new div when the context menu does not exist
         // Create context menu div
-        var contextMenu = document.createElement('div');
+        var contextMenu = document.createElement("div");
         this.dom_obj = contextMenu;
-        contextMenu.setAttribute('id', this.obj.conf.object_id+'-context');
-        contextMenu.className = 'context';
-        contextMenu.style.display = 'none';
+        contextMenu.setAttribute("id", this.obj.conf.object_id + "-context");
+        contextMenu.className = "context";
+        contextMenu.style.display = "none";
 
         // Append template code to context menu div
         contextMenu.innerHTML = this.template_html;
     },
 
     // Replaces object configuration specific macros in the template code
-    replaceStaticMacros: function() {
+    replaceStaticMacros: function () {
         var oSectionMacros = {};
 
         // Break when no template code found
-        if(!this.template_html || this.template_html === '') {
+        if (!this.template_html || this.template_html === "") {
             return false;
         }
 
         var oMacros = {
-            'obj_id':      this.obj.conf.object_id,
-            'type':        this.obj.conf.type,
-            'name':        this.obj.conf.name,
-            'alias':       this.obj.conf.alias,
-            'address':     this.obj.conf.address,
-            'html_cgi':    this.obj.conf.htmlcgi,
-            'backend_id':  this.obj.conf.backend_id,
-            'custom_1':    this.obj.conf.custom_1,
-            'custom_2':    this.obj.conf.custom_2,
-            'custom_3':    this.obj.conf.custom_3
+            obj_id: this.obj.conf.object_id,
+            type: this.obj.conf.type,
+            name: this.obj.conf.name,
+            alias: this.obj.conf.alias,
+            address: this.obj.conf.address,
+            html_cgi: this.obj.conf.htmlcgi,
+            backend_id: this.obj.conf.backend_id,
+            custom_1: this.obj.conf.custom_1,
+            custom_2: this.obj.conf.custom_2,
+            custom_3: this.obj.conf.custom_3
         };
 
-        if (g_view.type === 'map')
-            oMacros.map_name = g_view.id;
+        if (g_view.type === "map") oMacros.map_name = g_view.id;
 
-        if(this.obj.conf.type === 'service') {
+        if (this.obj.conf.type === "service") {
             oMacros.service_description = escapeUrlValues(this.obj.conf.service_description);
 
-            oMacros.pnp_hostname = this.obj.conf.name.replace(/\s/g,'%20');
-            oMacros.pnp_service_description = this.obj.conf.service_description.replace(/\s/g,'%20');
-        } else
-            oSectionMacros.service = '<!--\\sBEGIN\\sservice\\s-->.+?<!--\\sEND\\sservice\\s-->';
+            oMacros.pnp_hostname = this.obj.conf.name.replace(/\s/g, "%20");
+            oMacros.pnp_service_description = this.obj.conf.service_description.replace(/\s/g, "%20");
+        } else oSectionMacros.service = "<!--\\sBEGIN\\sservice\\s-->.+?<!--\\sEND\\sservice\\s-->";
 
         // Macros which are only for hosts
-        if(this.obj.conf.type === 'host')
-            oMacros.pnp_hostname = this.obj.conf.name.replace(/\s/g,'%20');
-        else
-            oSectionMacros.host = '<!--\\sBEGIN\\shost\\s-->.+?<!--\\sEND\\shost\\s-->';
+        if (this.obj.conf.type === "host") oMacros.pnp_hostname = this.obj.conf.name.replace(/\s/g, "%20");
+        else oSectionMacros.host = "<!--\\sBEGIN\\shost\\s-->.+?<!--\\sEND\\shost\\s-->";
 
-        if(this.obj.conf.type !== 'host' && this.obj.conf.type !== 'shape')
-            oSectionMacros.host_or_shape = '<!--\\sBEGIN\\shost_or_shape\\s-->.+?<!--\\sEND\\shost_or_shape\\s-->';
+        if (this.obj.conf.type !== "host" && this.obj.conf.type !== "shape")
+            oSectionMacros.host_or_shape = "<!--\\sBEGIN\\shost_or_shape\\s-->.+?<!--\\sEND\\shost_or_shape\\s-->";
 
-        if(this.obj.conf.type === 'line' || this.obj.conf.type == 'shape'
-           || this.obj.conf.type == 'textbox' || this.obj.conf.type === 'container')
-            oSectionMacros.stateful = '<!--\\sBEGIN\\sstateful\\s-->.+?<!--\\sEND\\sstateful\\s-->';
+        if (
+            this.obj.conf.type === "line" ||
+            this.obj.conf.type == "shape" ||
+            this.obj.conf.type == "textbox" ||
+            this.obj.conf.type === "container"
+        )
+            oSectionMacros.stateful = "<!--\\sBEGIN\\sstateful\\s-->.+?<!--\\sEND\\sstateful\\s-->";
 
         // Remove unlocked section for locked objects
-        if(this.obj.bIsLocked)
-            oSectionMacros.unlocked = '<!--\\sBEGIN\\sunlocked\\s-->.+?<!--\\sEND\\sunlocked\\s-->';
-        else
-            oSectionMacros.locked = '<!--\\sBEGIN\\slocked\\s-->.+?<!--\\sEND\\slocked\\s-->';
+        if (this.obj.bIsLocked) oSectionMacros.unlocked = "<!--\\sBEGIN\\sunlocked\\s-->.+?<!--\\sEND\\sunlocked\\s-->";
+        else oSectionMacros.locked = "<!--\\sBEGIN\\slocked\\s-->.+?<!--\\sEND\\slocked\\s-->";
 
-        if(!oViewProperties || !oViewProperties.permitted_edit)
-            oSectionMacros.permitted_edit = '<!--\\sBEGIN\\spermitted_edit\\s-->.+?<!--\\sEND\\spermitted_edit\\s-->';
+        if (!oViewProperties || !oViewProperties.permitted_edit)
+            oSectionMacros.permitted_edit = "<!--\\sBEGIN\\spermitted_edit\\s-->.+?<!--\\sEND\\spermitted_edit\\s-->";
 
-        if(!oViewProperties || !oViewProperties.permitted_perform)
-            oSectionMacros.permitted_perform = '<!--\\sBEGIN\\spermitted_perform\\s-->.+?<!--\\sEND\\spermitted_perform\\s-->';
+        if (!oViewProperties || !oViewProperties.permitted_perform)
+            oSectionMacros.permitted_perform =
+                "<!--\\sBEGIN\\spermitted_perform\\s-->.+?<!--\\sEND\\spermitted_perform\\s-->";
 
-        if(usesSource('automap')) {
-            oSectionMacros.not_automap = '<!--\\sBEGIN\\snot_automap\\s-->.+?<!--\\sEND\\snot_automap\\s-->';
-	    // Skip the root change link for the root host
-            if(this.obj.conf.name === getUrlParam('root'))
-		oSectionMacros.automap_not_root = '<!--\\sBEGIN\\sautomap_not_root\\s-->.+?<!--\\sEND\\sautomap_not_root\\s-->';
+        if (usesSource("automap")) {
+            oSectionMacros.not_automap = "<!--\\sBEGIN\\snot_automap\\s-->.+?<!--\\sEND\\snot_automap\\s-->";
+            // Skip the root change link for the root host
+            if (this.obj.conf.name === getUrlParam("root"))
+                oSectionMacros.automap_not_root =
+                    "<!--\\sBEGIN\\sautomap_not_root\\s-->.+?<!--\\sEND\\sautomap_not_root\\s-->";
         } else {
-	    oSectionMacros.automap_not_root = '<!--\\sBEGIN\\sautomap_not_root\\s-->.+?<!--\\sEND\\sautomap_not_root\\s-->';
-            oSectionMacros.automap = '<!--\\sBEGIN\\sautomap\\s-->.+?<!--\\sEND\\sautomap\\s-->';
+            oSectionMacros.automap_not_root =
+                "<!--\\sBEGIN\\sautomap_not_root\\s-->.+?<!--\\sEND\\sautomap_not_root\\s-->";
+            oSectionMacros.automap = "<!--\\sBEGIN\\sautomap\\s-->.+?<!--\\sEND\\sautomap\\s-->";
         }
-        if(this.obj.conf.view_type !== 'line')
-            oSectionMacros.line = '<!--\\sBEGIN\\sline\\s-->.+?<!--\\sEND\\sline\\s-->';
-        if(this.obj.conf.view_type !== 'line'
-           || (this.obj.conf.line_type == 11 || this.obj.conf.line_type == 12))
-            oSectionMacros.line_type = '<!--\\sBEGIN\\sline_two_parts\\s-->.+?<!--\\sEND\\sline_two_parts\\s-->';
+        if (this.obj.conf.view_type !== "line")
+            oSectionMacros.line = "<!--\\sBEGIN\\sline\\s-->.+?<!--\\sEND\\sline\\s-->";
+        if (this.obj.conf.view_type !== "line" || this.obj.conf.line_type == 11 || this.obj.conf.line_type == 12)
+            oSectionMacros.line_type = "<!--\\sBEGIN\\sline_two_parts\\s-->.+?<!--\\sEND\\sline_two_parts\\s-->";
 
         // Replace hostgroup range macros when not in a hostgroup
-        if(this.obj.conf.type !== 'hostgroup')
-            oSectionMacros.hostgroup = '<!--\\sBEGIN\\shostgroup\\s-->.+?<!--\\sEND\\shostgroup\\s-->';
+        if (this.obj.conf.type !== "hostgroup")
+            oSectionMacros.hostgroup = "<!--\\sBEGIN\\shostgroup\\s-->.+?<!--\\sEND\\shostgroup\\s-->";
 
         // Replace servicegroup range macros when not in a servicegroup
-        if(this.obj.conf.type !== 'servicegroup' && !(this.obj.conf.type === 'dyngroup' && this.obj.conf.object_types == 'service'))
-            oSectionMacros.servicegroup = '<!--\\sBEGIN\\sservicegroup\\s-->.+?<!--\\sEND\\sservicegroup\\s-->';
+        if (
+            this.obj.conf.type !== "servicegroup" &&
+            !(this.obj.conf.type === "dyngroup" && this.obj.conf.object_types == "service")
+        )
+            oSectionMacros.servicegroup = "<!--\\sBEGIN\\sservicegroup\\s-->.+?<!--\\sEND\\sservicegroup\\s-->";
 
         // Replace map range macros when not in a hostgroup
-        if(this.obj.conf.type !== 'map')
-            oSectionMacros.map = '<!--\\sBEGIN\\smap\\s-->.+?<!--\\sEND\\smap\\s-->';
+        if (this.obj.conf.type !== "map") oSectionMacros.map = "<!--\\sBEGIN\\smap\\s-->.+?<!--\\sEND\\smap\\s-->";
 
         // Loop all registered actions, check wether or not this action should be shown for this object
         // and either add the replacement section or not
         for (var key in oGeneralProperties.actions) {
-            if(key == "indexOf")
-                continue; // skip indexOf prototype (seems to be looped in IE)
+            if (key == "indexOf") continue; // skip indexOf prototype (seems to be looped in IE)
             var action = oGeneralProperties.actions[key];
             var hide = false;
 
@@ -310,44 +309,41 @@ var ElementContext = Element.extend({
             hide = action.obj_type.indexOf(this.obj.conf.type) == -1;
 
             // Only check the condition when not already hidden by another check before
-            if(!hide && isset(action.client_os) && action.client_os.length > 0) {
+            if (!hide && isset(action.client_os) && action.client_os.length > 0) {
                 // Check the client os
                 var os = navigator.platform.toLowerCase();
-                if (os.indexOf('win') !== -1)
-                    os = 'win';
-                else if (os.indexOf('linux') !== -1)
-                    os = 'lnx';
-                else if (os.indexOf('mac') !== -1)
-                    os = 'mac';
+                if (os.indexOf("win") !== -1) os = "win";
+                else if (os.indexOf("linux") !== -1) os = "lnx";
+                else if (os.indexOf("mac") !== -1) os = "mac";
 
                 hide = action.client_os.indexOf(os) == -1;
             }
 
             // Only check the condition when not already hidden by another check before
-            if(!hide && isset(action.condition) && action.condition !== '') {
+            if (!hide && isset(action.condition) && action.condition !== "") {
                 var cond = action.condition;
 
-                var op = '';
-                if (cond.indexOf('~') != -1) {
-                    op = '~';
-                } else if (cond.indexOf('=') != -1) {
-                    op = '=';
+                var op = "";
+                if (cond.indexOf("~") != -1) {
+                    op = "~";
+                } else if (cond.indexOf("=") != -1) {
+                    op = "=";
                 }
 
                 var parts = cond.split(op);
-                var attr  = parts[0];
-                var val   = parts[1];
+                var attr = parts[0];
+                var val = parts[1];
                 var to_be_checked;
                 if (isset(this.obj.conf.custom_variables) && isset(this.obj.conf.custom_variables[attr])) {
                     to_be_checked = this.obj.conf.custom_variables[attr];
-                } else if(isset(this.obj.conf[attr])) {
+                } else if (isset(this.obj.conf[attr])) {
                     to_be_checked = this.obj.conf[attr];
                 }
 
                 if (to_be_checked) {
-                    if (op == '=' && to_be_checked != val) {
+                    if (op == "=" && to_be_checked != val) {
                         hide = true;
-                    } else if (op == '~' && to_be_checked.indexOf(val) == -1) {
+                    } else if (op == "~" && to_be_checked.indexOf(val) == -1) {
                         hide = true;
                     }
                 } else {
@@ -356,28 +352,28 @@ var ElementContext = Element.extend({
             }
 
             // Remove the section macros of not hidden actions
-            if(!hide) {
-                oSectionMacros['action_'+key] = '<!--\\s(BEGIN|END)\\saction_'+key+'\\s-->';
+            if (!hide) {
+                oSectionMacros["action_" + key] = "<!--\\s(BEGIN|END)\\saction_" + key + "\\s-->";
             }
             cond = null;
             action = null;
         }
 
         // Remove all not hidden actions
-        oSectionMacros['actions'] = '<!--\\sBEGIN\\saction_.+?\\s-->.+?<!--\\sEND\\saction_.+?\\s-->';
+        oSectionMacros["actions"] = "<!--\\sBEGIN\\saction_.+?\\s-->.+?<!--\\sEND\\saction_.+?\\s-->";
 
         // Loop and replace all unwanted section macros
         for (var key in oSectionMacros) {
-            var regex = getRegEx('section-'+key, oSectionMacros[key], 'gm');
-            this.template_html = this.template_html.replace(regex, '');
+            var regex = getRegEx("section-" + key, oSectionMacros[key], "gm");
+            this.template_html = this.template_html.replace(regex, "");
             regex = null;
         }
         oSectionMacros = null;
 
         // Loop and replace all normal macros
-        this.template_html = this.template_html.replace(/\[(\w*)\]/g,
-                                     function(){ return oMacros[ arguments[1] ] || '';});
+        this.template_html = this.template_html.replace(/\[(\w*)\]/g, function () {
+            return oMacros[arguments[1]] || "";
+        });
         oMacros = null;
     }
-
 });

--- a/share/frontend/nagvis-js/js/ElementContext.js
+++ b/share/frontend/nagvis-js/js/ElementContext.js
@@ -21,8 +21,8 @@
  *
  *****************************************************************************/
 
-var g_context_templates = {};
-var g_context_open = null;
+const g_context_templates = {};
+let g_context_open = null;
 
 // Hides the currently open context menu
 function contextHide() {
@@ -32,7 +32,7 @@ function contextHide() {
 function context_handle_global_mousedown(event) {
     event = event ? event : window.event; // IE FIX
     if (usesSource("worldmap")) event = event.originalEvent;
-    var target = getTargetRaw(event);
+    let target = getTargetRaw(event);
 
     while (target && !has_class(target, "context")) target = target.parentNode;
 
@@ -41,12 +41,12 @@ function context_handle_global_mousedown(event) {
         contextHide();
     } else {
         // Check for click on the context menu and do nothing in this case
-        var object_id = target.id.split("-")[0];
+        const object_id = target.id.split("-")[0];
         if (g_context_open && object_id == g_context_open.obj.conf.object_id) return preventDefaultEvents(event);
     }
 }
 
-var ElementContext = Element.extend({
+const ElementContext = Element.extend({
     template_html: null,
     spacing: 5, // px from screen border
     coords: null, // list of x, y coordinates of the hover menu top left corner
@@ -112,7 +112,7 @@ var ElementContext = Element.extend({
     //
 
     getTemplate: function () {
-        var name = this.obj.conf.context_template;
+        const name = this.obj.conf.context_template;
         if (!isset(g_context_templates[name])) {
             this.requestTemplate();
         } else if (g_context_templates[name] !== true) {
@@ -122,8 +122,8 @@ var ElementContext = Element.extend({
     },
 
     handleTemplate: function (templates) {
-        var name = templates[0]["name"];
-        var code = templates[0]["code"];
+        const name = templates[0]["name"];
+        const code = templates[0]["code"];
 
         g_context_templates[name] = code;
 
@@ -133,7 +133,7 @@ var ElementContext = Element.extend({
         if (isset(templates[0]["css_file"])) {
             // This is needed for some old browsers which do no load css files
             // which are included in such fetched html code
-            var oLink = document.createElement("link");
+            const oLink = document.createElement("link");
             oLink.href = templates[0]["css_file"];
             oLink.rel = "stylesheet";
             oLink.type = "text/css";
@@ -158,8 +158,8 @@ var ElementContext = Element.extend({
         hoverHide();
 
         // document.body.scrollTop does not work in IE
-        var scrollTop = document.body.scrollTop ? document.body.scrollTop : document.documentElement.scrollTop;
-        var scrollLeft = document.body.scrollLeft ? document.body.scrollLeft : document.documentElement.scrollLeft;
+        const scrollTop = document.body.scrollTop ? document.body.scrollTop : document.documentElement.scrollTop;
+        const scrollLeft = document.body.scrollLeft ? document.body.scrollLeft : document.documentElement.scrollLeft;
 
         // hide the menu first to avoid an "up-then-over" visual effect
         this.dom_obj.style.display = "none";
@@ -169,13 +169,13 @@ var ElementContext = Element.extend({
 
         // Check if the context menu is "in screen".
         // When not: reposition
-        var contextLeft = parseInt(this.dom_obj.style.left.replace("px", ""));
+        const contextLeft = parseInt(this.dom_obj.style.left.replace("px", ""));
         if (contextLeft + this.dom_obj.clientWidth > pageWidth()) {
             // move the context menu to the left
             this.dom_obj.style.left = contextLeft - this.dom_obj.clientWidth + "px";
         }
 
-        var contextTop = parseInt(this.dom_obj.style.top.replace("px", ""));
+        const contextTop = parseInt(this.dom_obj.style.top.replace("px", ""));
         if (contextTop + this.dom_obj.clientHeight > pageHeight()) {
             // Only move the context menu to the top when the new top will not be
             // out of sight
@@ -201,7 +201,7 @@ var ElementContext = Element.extend({
     renderMenu: function () {
         // Only create a new div when the context menu does not exist
         // Create context menu div
-        var contextMenu = document.createElement("div");
+        const contextMenu = document.createElement("div");
         this.dom_obj = contextMenu;
         contextMenu.setAttribute("id", this.obj.conf.object_id + "-context");
         contextMenu.className = "context";
@@ -213,14 +213,14 @@ var ElementContext = Element.extend({
 
     // Replaces object configuration specific macros in the template code
     replaceStaticMacros: function () {
-        var oSectionMacros = {};
+        let oSectionMacros = {};
 
         // Break when no template code found
         if (!this.template_html || this.template_html === "") {
             return false;
         }
 
-        var oMacros = {
+        let oMacros = {
             obj_id: this.obj.conf.object_id,
             type: this.obj.conf.type,
             name: this.obj.conf.name,
@@ -300,10 +300,10 @@ var ElementContext = Element.extend({
 
         // Loop all registered actions, check wether or not this action should be shown for this object
         // and either add the replacement section or not
-        for (var key in oGeneralProperties.actions) {
+        for (const key in oGeneralProperties.actions) {
             if (key == "indexOf") continue; // skip indexOf prototype (seems to be looped in IE)
-            var action = oGeneralProperties.actions[key];
-            var hide = false;
+            let action = oGeneralProperties.actions[key];
+            let hide = false;
 
             // Check object type
             hide = action.obj_type.indexOf(this.obj.conf.type) == -1;
@@ -311,7 +311,7 @@ var ElementContext = Element.extend({
             // Only check the condition when not already hidden by another check before
             if (!hide && isset(action.client_os) && action.client_os.length > 0) {
                 // Check the client os
-                var os = navigator.platform.toLowerCase();
+                let os = navigator.platform.toLowerCase();
                 if (os.indexOf("win") !== -1) os = "win";
                 else if (os.indexOf("linux") !== -1) os = "lnx";
                 else if (os.indexOf("mac") !== -1) os = "mac";
@@ -321,19 +321,19 @@ var ElementContext = Element.extend({
 
             // Only check the condition when not already hidden by another check before
             if (!hide && isset(action.condition) && action.condition !== "") {
-                var cond = action.condition;
+                const cond = action.condition;
 
-                var op = "";
+                let op = "";
                 if (cond.indexOf("~") != -1) {
                     op = "~";
                 } else if (cond.indexOf("=") != -1) {
                     op = "=";
                 }
 
-                var parts = cond.split(op);
-                var attr = parts[0];
-                var val = parts[1];
-                var to_be_checked;
+                const parts = cond.split(op);
+                const attr = parts[0];
+                const val = parts[1];
+                let to_be_checked;
                 if (isset(this.obj.conf.custom_variables) && isset(this.obj.conf.custom_variables[attr])) {
                     to_be_checked = this.obj.conf.custom_variables[attr];
                 } else if (isset(this.obj.conf[attr])) {
@@ -355,7 +355,6 @@ var ElementContext = Element.extend({
             if (!hide) {
                 oSectionMacros["action_" + key] = "<!--\\s(BEGIN|END)\\saction_" + key + "\\s-->";
             }
-            cond = null;
             action = null;
         }
 
@@ -363,8 +362,8 @@ var ElementContext = Element.extend({
         oSectionMacros["actions"] = "<!--\\sBEGIN\\saction_.+?\\s-->.+?<!--\\sEND\\saction_.+?\\s-->";
 
         // Loop and replace all unwanted section macros
-        for (key in oSectionMacros) {
-            var regex = getRegEx("section-" + key, oSectionMacros[key], "gm");
+        for (const key in oSectionMacros) {
+            let regex = getRegEx("section-" + key, oSectionMacros[key], "gm");
             this.template_html = this.template_html.replace(regex, "");
             regex = null;
         }

--- a/share/frontend/nagvis-js/js/ElementGadget.js
+++ b/share/frontend/nagvis-js/js/ElementGadget.js
@@ -69,6 +69,7 @@ var ElementGadget = Element.extend({
 
     detectGadgetType: function (param_str) {
         var content = this.requestGadget(param_str);
+        // eslint-disable-next-line no-control-regex
         if (content.substring(0, 4) === "GIF8" || !/^[\x00-\x7F]*$/.test(content[0])) this.gadget_type = "img";
         else this.gadget_type = "html";
     },
@@ -99,7 +100,7 @@ var ElementGadget = Element.extend({
         if (this.obj.conf.type == "dyngroup") sParams += "&object_types=" + this.obj.conf.object_types;
 
         if (this.obj.conf.perfdata && this.obj.conf.perfdata != "")
-            sParams += "&perfdata=" + this.obj.conf.perfdata.replace(/\&quot\;|\&\#145\;/g, "%22");
+            sParams += "&perfdata=" + this.obj.conf.perfdata.replace(/&quot;|&#145;/g, "%22");
 
         // Process the optional gadget_opts param
         if (this.obj.conf.gadget_opts && this.obj.conf.gadget_opts != "")

--- a/share/frontend/nagvis-js/js/ElementGadget.js
+++ b/share/frontend/nagvis-js/js/ElementGadget.js
@@ -135,7 +135,7 @@ var ElementGadget = Element.extend({
             if (this.obj.conf.type == "service") alt += "-" + this.obj.conf.service_description;
             oGadget.alt = alt;
         } else {
-            var oGadget = document.createElement("div");
+            oGadget = document.createElement("div");
             oGadget.innerHTML = this.requestGadget(sParams);
         }
         oGadget.setAttribute("id", this.obj.conf.object_id + "-icon");

--- a/share/frontend/nagvis-js/js/ElementGadget.js
+++ b/share/frontend/nagvis-js/js/ElementGadget.js
@@ -22,9 +22,9 @@
  *****************************************************************************/
 
 var ElementGadget = Element.extend({
-    gadget_type : null,
+    gadget_type: null,
 
-    updateAttrs: function(only_state) {
+    updateAttrs: function (only_state) {
         // update the gadget on every state update where at least the output or perfdata changed
         if (!only_state || (!this.obj.stateChanged() && this.obj.outputOrPerfdataChanged())) {
             this.erase();
@@ -33,7 +33,7 @@ var ElementGadget = Element.extend({
         }
     },
 
-    render: function() {
+    render: function () {
         this.renderGadget();
         this.place();
     },
@@ -48,9 +48,9 @@ var ElementGadget = Element.extend({
         makeUndragable(this.dom_obj);
     },
 
-    place: function() {
-        this.dom_obj.style.top  = this.obj.parseCoord(this.obj.conf.y, 'y') + 'px';
-        this.dom_obj.style.left = this.obj.parseCoord(this.obj.conf.x, 'x') + 'px';
+    place: function () {
+        this.dom_obj.style.top = this.obj.parseCoord(this.obj.conf.y, "y") + "px";
+        this.dom_obj.style.left = this.obj.parseCoord(this.obj.conf.x, "x") + "px";
     },
 
     //
@@ -58,92 +58,97 @@ var ElementGadget = Element.extend({
     //
 
     requestGadget: function (param_str) {
-        var data = 'members='+escape(JSON.stringify(this.obj.conf.members));
+        var data = "members=" + escape(JSON.stringify(this.obj.conf.members));
         // FIXME: Change to async?
         return call_ajax(this.obj.conf.gadget_url + param_str, {
-            method       : "POST",
-            post_data    : data,
-            sync         : true,
+            method: "POST",
+            post_data: data,
+            sync: true
         }).responseText;
     },
 
     detectGadgetType: function (param_str) {
         var content = this.requestGadget(param_str);
-        if (content.substring(0, 4) === 'GIF8' || ! /^[\x00-\x7F]*$/.test(content[0]))
-            this.gadget_type = 'img';
-        else
-            this.gadget_type = 'html';
+        if (content.substring(0, 4) === "GIF8" || !/^[\x00-\x7F]*$/.test(content[0])) this.gadget_type = "img";
+        else this.gadget_type = "html";
     },
 
     /**
      * Parses the object as gadget
      */
     renderGadget: function () {
-        var sParams = 'name1=' + this.obj.conf.name;
-        if (this.obj.conf.type == 'service')
-            sParams += '&name2=' + escapeUrlValues(this.obj.conf.service_description);
+        var sParams = "name1=" + this.obj.conf.name;
+        if (this.obj.conf.type == "service") sParams += "&name2=" + escapeUrlValues(this.obj.conf.service_description);
 
-        sParams += '&type=' + this.obj.conf.type
-                 + '&object_id=' + this.obj.conf.object_id
-                 + '&scale=' + escapeUrlValues(this.obj.conf.gadget_scale.toString())
-                 + '&state=' + this.obj.conf.summary_state
-                 + '&stateType=' + this.obj.conf.state_type
-                 + '&ack=' + this.obj.conf.summary_problem_has_been_acknowledged
-                 + '&downtime=' + this.obj.conf.summary_in_downtime;
+        sParams +=
+            "&type=" +
+            this.obj.conf.type +
+            "&object_id=" +
+            this.obj.conf.object_id +
+            "&scale=" +
+            escapeUrlValues(this.obj.conf.gadget_scale.toString()) +
+            "&state=" +
+            this.obj.conf.summary_state +
+            "&stateType=" +
+            this.obj.conf.state_type +
+            "&ack=" +
+            this.obj.conf.summary_problem_has_been_acknowledged +
+            "&downtime=" +
+            this.obj.conf.summary_in_downtime;
 
-        if (this.obj.conf.type == 'dyngroup')
-            sParams += '&object_types=' + this.obj.conf.object_types;
+        if (this.obj.conf.type == "dyngroup") sParams += "&object_types=" + this.obj.conf.object_types;
 
-        if (this.obj.conf.perfdata && this.obj.conf.perfdata != '')
-            sParams += '&perfdata=' + this.obj.conf.perfdata.replace(/\&quot\;|\&\#145\;/g,'%22');
+        if (this.obj.conf.perfdata && this.obj.conf.perfdata != "")
+            sParams += "&perfdata=" + this.obj.conf.perfdata.replace(/\&quot\;|\&\#145\;/g, "%22");
 
         // Process the optional gadget_opts param
-        if (this.obj.conf.gadget_opts && this.obj.conf.gadget_opts != '')
-            sParams += '&opts=' + escapeUrlValues(this.obj.conf.gadget_opts.toString());
+        if (this.obj.conf.gadget_opts && this.obj.conf.gadget_opts != "")
+            sParams += "&opts=" + escapeUrlValues(this.obj.conf.gadget_opts.toString());
 
         // Append with leading "?" or "&" to build a correct url
-        if (this.obj.conf.gadget_url.indexOf('?') == -1)
-            sParams = '?' + sParams;
-        else
-            sParams = '&' + sParams;
+        if (this.obj.conf.gadget_url.indexOf("?") == -1) sParams = "?" + sParams;
+        else sParams = "&" + sParams;
 
         this.detectGadgetType(sParams);
-        if (this.gadget_type === 'img') {
-            var oGadget = document.createElement('img');
+        if (this.gadget_type === "img") {
+            var oGadget = document.createElement("img");
 
             // Register controls reposition handler to handle resizes during
             // loading the image (from alt="" text to the real image)
-            addEvent(oGadget, 'load', function(obj) {
-                return function() {
-                    obj.place();
-                    obj = null;
-                };
-            }(this.obj));
+            addEvent(
+                oGadget,
+                "load",
+                (function (obj) {
+                    return function () {
+                        obj.place();
+                        obj = null;
+                    };
+                })(this.obj)
+            );
 
             addZoomHandler(oGadget);
 
             oGadget.src = this.obj.conf.gadget_url + sParams + "&cache=" + new Date().getTime();
 
-            var alt = this.obj.conf.type + '-' + this.obj.conf.name;
-            if (this.obj.conf.type == 'service')
-                alt += '-'+this.obj.conf.service_description;
+            var alt = this.obj.conf.type + "-" + this.obj.conf.name;
+            if (this.obj.conf.type == "service") alt += "-" + this.obj.conf.service_description;
             oGadget.alt = alt;
         } else {
-            var oGadget = document.createElement('div');
+            var oGadget = document.createElement("div");
             oGadget.innerHTML = this.requestGadget(sParams);
         }
-        oGadget.setAttribute('id', this.obj.conf.object_id + '-icon');
+        oGadget.setAttribute("id", this.obj.conf.object_id + "-icon");
         this.obj.trigger_obj = oGadget;
 
-        var oIconDiv = document.createElement('div');
+        var oIconDiv = document.createElement("div");
         this.dom_obj = oIconDiv;
-        oIconDiv.setAttribute('id', this.obj.conf.object_id + '-icondiv');
-        oIconDiv.className = 'icondiv';
-        oIconDiv.style.zIndex   = this.obj.conf.z;
+        oIconDiv.setAttribute("id", this.obj.conf.object_id + "-icondiv");
+        oIconDiv.className = "icondiv";
+        oIconDiv.style.zIndex = this.obj.conf.z;
 
         // Parse link only when set
-        if(this.obj.conf.url && this.obj.conf.url !== '') {
-            var oIconLink = document.createElement('a');
+        if (this.obj.conf.url && this.obj.conf.url !== "") {
+            var oIconLink = document.createElement("a");
             oIconLink.href = this.obj.conf.url;
             oIconLink.target = this.obj.conf.url_target;
             oIconLink.appendChild(oGadget);

--- a/share/frontend/nagvis-js/js/ElementGadget.js
+++ b/share/frontend/nagvis-js/js/ElementGadget.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var ElementGadget = Element.extend({
+const ElementGadget = Element.extend({
     gadget_type: null,
 
     updateAttrs: function (only_state) {
@@ -58,7 +58,7 @@ var ElementGadget = Element.extend({
     //
 
     requestGadget: function (param_str) {
-        var data = "members=" + escape(JSON.stringify(this.obj.conf.members));
+        const data = "members=" + escape(JSON.stringify(this.obj.conf.members));
         // FIXME: Change to async?
         return call_ajax(this.obj.conf.gadget_url + param_str, {
             method: "POST",
@@ -68,7 +68,7 @@ var ElementGadget = Element.extend({
     },
 
     detectGadgetType: function (param_str) {
-        var content = this.requestGadget(param_str);
+        const content = this.requestGadget(param_str);
         // eslint-disable-next-line no-control-regex
         if (content.substring(0, 4) === "GIF8" || !/^[\x00-\x7F]*$/.test(content[0])) this.gadget_type = "img";
         else this.gadget_type = "html";
@@ -78,7 +78,7 @@ var ElementGadget = Element.extend({
      * Parses the object as gadget
      */
     renderGadget: function () {
-        var sParams = "name1=" + this.obj.conf.name;
+        let sParams = "name1=" + this.obj.conf.name;
         if (this.obj.conf.type == "service") sParams += "&name2=" + escapeUrlValues(this.obj.conf.service_description);
 
         sParams +=
@@ -112,7 +112,7 @@ var ElementGadget = Element.extend({
 
         this.detectGadgetType(sParams);
         if (this.gadget_type === "img") {
-            var oGadget = document.createElement("img");
+            const oGadget = document.createElement("img");
 
             // Register controls reposition handler to handle resizes during
             // loading the image (from alt="" text to the real image)
@@ -131,7 +131,7 @@ var ElementGadget = Element.extend({
 
             oGadget.src = this.obj.conf.gadget_url + sParams + "&cache=" + new Date().getTime();
 
-            var alt = this.obj.conf.type + "-" + this.obj.conf.name;
+            let alt = this.obj.conf.type + "-" + this.obj.conf.name;
             if (this.obj.conf.type == "service") alt += "-" + this.obj.conf.service_description;
             oGadget.alt = alt;
         } else {
@@ -141,7 +141,7 @@ var ElementGadget = Element.extend({
         oGadget.setAttribute("id", this.obj.conf.object_id + "-icon");
         this.obj.trigger_obj = oGadget;
 
-        var oIconDiv = document.createElement("div");
+        const oIconDiv = document.createElement("div");
         this.dom_obj = oIconDiv;
         oIconDiv.setAttribute("id", this.obj.conf.object_id + "-icondiv");
         oIconDiv.className = "icondiv";
@@ -149,7 +149,7 @@ var ElementGadget = Element.extend({
 
         // Parse link only when set
         if (this.obj.conf.url && this.obj.conf.url !== "") {
-            var oIconLink = document.createElement("a");
+            const oIconLink = document.createElement("a");
             oIconLink.href = this.obj.conf.url;
             oIconLink.target = this.obj.conf.url_target;
             oIconLink.appendChild(oGadget);

--- a/share/frontend/nagvis-js/js/ElementHover.js
+++ b/share/frontend/nagvis-js/js/ElementHover.js
@@ -21,83 +21,79 @@
  *
  *****************************************************************************/
 
-var g_hover_templates       = {};
+var g_hover_templates = {};
 var g_hover_template_childs = {};
-var g_hover_urls            = {};
-var g_hover_open            = null;
+var g_hover_urls = {};
+var g_hover_open = null;
 
 // Hides the currently open hover menu
 function hoverHide() {
-    if (g_hover_open !== null)
-        g_hover_open.hide();
+    if (g_hover_open !== null) g_hover_open.hide();
 }
 
 var ElementHover = Element.extend({
-    hover_url      : null,  // configured url with eventual replaced macros
-    template_html  : null,  // hover HTML code with replaced config related macros
-    coords         : null,  // list of x, y coordinates of the hover menu top left corner
-    show_timer     : null,  // JS timer when hover delay is used
-    spacing        : 5,     // px from screen border
-    min_width      : 400,   // px minimum width
-    enabled        : false, // when true the event handlers are enabled
+    hover_url: null, // configured url with eventual replaced macros
+    template_html: null, // hover HTML code with replaced config related macros
+    coords: null, // list of x, y coordinates of the hover menu top left corner
+    show_timer: null, // JS timer when hover delay is used
+    spacing: 5, // px from screen border
+    min_width: 400, // px minimum width
+    enabled: false, // when true the event handlers are enabled
 
-    update: function() {
+    update: function () {
         this.hover_url = this.obj.conf.hover_url;
 
-        if (this.hover_url && this.hover_url !== '') {
-            this.hover_url = this.hover_url.replace(getRegEx(name,
-                                                    '\\['+name+'\\]', 'g'), this.obj.conf.name);
+        if (this.hover_url && this.hover_url !== "") {
+            this.hover_url = this.hover_url.replace(getRegEx(name, "\\[" + name + "\\]", "g"), this.obj.conf.name);
 
-            if (this.obj.conf.type == 'service')
-                this.hover_url = this.hover_url.replace(getRegEx('service_description',
-                                    '\\[service_description\\]', 'g'), this.obj.conf.service_description);
+            if (this.obj.conf.type == "service")
+                this.hover_url = this.hover_url.replace(
+                    getRegEx("service_description", "\\[service_description\\]", "g"),
+                    this.obj.conf.service_description
+                );
         }
         this.getTemplate();
     },
 
-    updateAttrs: function(only_state) {
+    updateAttrs: function (only_state) {
         this.render();
     },
 
-    render: function() {
+    render: function () {
         this.getTemplate();
 
-        if (this.obj.bIsLocked)
-            this.enable();
+        if (this.obj.bIsLocked) this.enable();
 
-        if (this.template_html === null || this.template_html === true)
-            return false; // template not available yet, skip rendering
+        if (this.template_html === null || this.template_html === true) return false; // template not available yet, skip rendering
 
         // don't render during normal render calls. We
         // want to keep the number of DOM objects low, so only render
         // them when being unlocked for the first time
         // But when the object has already been rendered, re-render the object
         // during all render() calls
-        if (this.dom_obj)
-            this._render();
+        if (this.dom_obj) this._render();
     },
 
-    draw: function() {
+    draw: function () {
         if (this.obj.bIsLocked) {
             // Not rendered yet, e.g. because template was not fetched yet during
             // initial rendering. Re-try rendering now
-            if (!this.dom_obj)
-                this._render();
+            if (!this.dom_obj) this._render();
 
             this.base();
         }
     },
 
-    erase: function() {
+    erase: function () {
         this.disable();
         this.base();
     },
 
-    lock: function() {
+    lock: function () {
         this.enable();
     },
 
-    unlock: function() {
+    unlock: function () {
         this.disable();
     },
 
@@ -105,7 +101,7 @@ var ElementHover = Element.extend({
     // END OF PUBLIC METHODS
     //
 
-    _render: function() {
+    _render: function () {
         this.getTemplate();
         if (this.template_html === null || this.template_html === true) {
             return false; // template not available yet, skip rendering
@@ -113,21 +109,18 @@ var ElementHover = Element.extend({
         this.renderMenu();
     },
 
-    getTemplate: function() {
-        if (this.hover_url && this.hover_url !== '') {
+    getTemplate: function () {
+        if (this.hover_url && this.hover_url !== "") {
             if (!isset(g_hover_urls[this.hover_url])) {
                 this.requestUrl();
-            }
-            else {
+            } else {
                 this.template_html = g_hover_urls[this.hover_url];
             }
-        }
-        else {
+        } else {
             var name = this.obj.conf.hover_template;
             if (!isset(g_hover_templates[name])) {
                 this.requestTemplate();
-            }
-            else if (g_hover_templates[name] !== true) {
+            } else if (g_hover_templates[name] !== true) {
                 this.template_html = g_hover_templates[name];
                 this.replaceStaticMacros();
             }
@@ -135,31 +128,34 @@ var ElementHover = Element.extend({
     },
 
     handleUrl: function (urls) {
-        g_hover_urls[urls[0]['url']] = urls[0]['code'];
+        g_hover_urls[urls[0]["url"]] = urls[0]["code"];
         this.getTemplate(); // assign template to the object
     },
 
     requestUrl: function () {
-        call_ajax(oGeneralProperties.path_server+'?mod=General&act=getHoverUrl'
-                  +'&url[]='+escapeUrlValues(this.hover_url), {
-            response_handler: this.handleUrl.bind(this)
-        });
+        call_ajax(
+            oGeneralProperties.path_server +
+                "?mod=General&act=getHoverUrl" +
+                "&url[]=" +
+                escapeUrlValues(this.hover_url),
+            {
+                response_handler: this.handleUrl.bind(this)
+            }
+        );
         g_hover_urls[this.hover_url] = true; // mark as already requested
     },
 
     // Extracts the childs code from the hover templates
     getChildCode: function (template_html) {
-        var regex = getRegEx('loopChild', "<!--\\sBEGIN\\sloop_child\\s-->(.+?)<!--\\sEND\\sloop_child\\s-->");
+        var regex = getRegEx("loopChild", "<!--\\sBEGIN\\sloop_child\\s-->(.+?)<!--\\sEND\\sloop_child\\s-->");
         var results = regex.exec(template_html);
-        if (results !== null)
-            return results[1];
-        else
-            return '';
+        if (results !== null) return results[1];
+        else return "";
     },
 
     handleTemplate: function (templates) {
-        var name = templates[0]['name'];
-        var code = templates[0]['code'];
+        var name = templates[0]["name"];
+        var code = templates[0]["code"];
 
         g_hover_templates[name] = code;
         g_hover_template_childs[name] = this.getChildCode(code);
@@ -167,56 +163,60 @@ var ElementHover = Element.extend({
         this.getTemplate(); // assign template to the object
 
         // Load css file is one is available
-        if (isset(templates[0]['css_file'])) {
+        if (isset(templates[0]["css_file"])) {
             // This is needed for some old browsers which do no load css files
             // which are included in such fetched html code
-            var oLink = document.createElement('link');
-            oLink.href = templates[0]['css_file'];
-            oLink.rel = 'stylesheet';
-            oLink.type = 'text/css';
+            var oLink = document.createElement("link");
+            oLink.href = templates[0]["css_file"];
+            oLink.rel = "stylesheet";
+            oLink.type = "text/css";
             document.getElementsByTagName("head")[0].appendChild(oLink);
         }
     },
 
     requestTemplate: function () {
-        call_ajax(oGeneralProperties.path_server+'?mod=General&act=getHoverTemplate'
-                  +'&name[]='+escapeUrlValues(this.obj.conf.hover_template), {
-            response_handler: this.handleTemplate.bind(this)
-        });
+        call_ajax(
+            oGeneralProperties.path_server +
+                "?mod=General&act=getHoverTemplate" +
+                "&name[]=" +
+                escapeUrlValues(this.obj.conf.hover_template),
+            {
+                response_handler: this.handleTemplate.bind(this)
+            }
+        );
         g_hover_templates[this.obj.conf.hover_template] = true; // mark as already requested
     },
 
-    enable: function() {
+    enable: function () {
         if (!this.enabled) {
-            this._handleMouseMove = this.handleMouseMove.bind(this); 
-            this._handleMouseOut  = this.handleMouseOut.bind(this);
-            addEvent(this.obj.trigger_obj, 'mousemove', this._handleMouseMove);
-            addEvent(this.obj.trigger_obj, 'mouseout', this._handleMouseOut);
-            addEvent(this.obj.trigger_obj, 'mousedown', this._handleMouseOut);
+            this._handleMouseMove = this.handleMouseMove.bind(this);
+            this._handleMouseOut = this.handleMouseOut.bind(this);
+            addEvent(this.obj.trigger_obj, "mousemove", this._handleMouseMove);
+            addEvent(this.obj.trigger_obj, "mouseout", this._handleMouseOut);
+            addEvent(this.obj.trigger_obj, "mousedown", this._handleMouseOut);
             this.enabled = true;
         }
     },
 
-    disable: function() {
+    disable: function () {
         if (this.enabled) {
-            removeEvent(this.obj.trigger_obj, 'mousemove', this._handleMouseMove);
-            removeEvent(this.obj.trigger_obj, 'mouseout', this._handleMouseOut);
-            removeEvent(this.obj.trigger_obj, 'mousedown', this._handleMouseOut);
+            removeEvent(this.obj.trigger_obj, "mousemove", this._handleMouseMove);
+            removeEvent(this.obj.trigger_obj, "mouseout", this._handleMouseOut);
+            removeEvent(this.obj.trigger_obj, "mousedown", this._handleMouseOut);
             this.enabled = false;
         }
     },
 
-    handleMouseOut: function(event) {
+    handleMouseOut: function (event) {
         this.hide();
     },
 
-    handleMouseMove: function(event) {
+    handleMouseMove: function (event) {
         event = event ? event : window.event; // IE FIX
 
         // During render/drawing calls the template was not ready, so the hover menu
         // has not been drawn yet. Do it now.
-        if (this.dom_obj === null)
-            this.draw();
+        if (this.dom_obj === null) this.draw();
 
         var hover_delay = parseInt(this.obj.conf.hover_delay);
 
@@ -226,31 +226,32 @@ var ElementHover = Element.extend({
         if (!dragging() && g_context_open === null && this.show_timer === null) {
             this.coords = [event.clientX, event.clientY];
             if (hover_delay && !this.isVisible()) {
-                this.show_timer = setTimeout(function(obj) {
-                    return function() {
-                        obj.show();
-                    };
-                }(this), hover_delay*1000);
-            }
-            else {
+                this.show_timer = setTimeout(
+                    (function (obj) {
+                        return function () {
+                            obj.show();
+                        };
+                    })(this),
+                    hover_delay * 1000
+                );
+            } else {
                 this.show();
             }
         }
     },
 
     // Is the menu currently visible to the user?
-    isVisible: function() {
-        return this.dom_obj.style.display !== 'none';
+    isVisible: function () {
+        return this.dom_obj.style.display !== "none";
     },
 
-    show: function() {
+    show: function () {
         // when the hover template is not loaded yet and the menu not
         // executed draw(), the menu can not be shown yet. Skip it.
-        if (this.dom_obj)
-            this.showAndPositionMenu();
+        if (this.dom_obj) this.showAndPositionMenu();
     },
 
-    hide: function() {
+    hide: function () {
         // Abort eventual running show timer
         if (this.show_timer !== null) {
             clearTimeout(this.show_timer);
@@ -258,39 +259,35 @@ var ElementHover = Element.extend({
         }
 
         // Might be called even when nothing has been rendered yet
-        if (this.dom_obj)
-            this.dom_obj.style.display = 'none';
+        if (this.dom_obj) this.dom_obj.style.display = "none";
         this.coords = null;
         g_hover_open = null;
     },
 
-    showAndPositionMenu: function() {
+    showAndPositionMenu: function () {
         // document.body.scrollTop does not work in IE
-        var scrollTop = document.body.scrollTop ? document.body.scrollTop :
-                                                  document.documentElement.scrollTop;
-        var scrollLeft = document.body.scrollLeft ? document.body.scrollLeft :
-                                                    document.documentElement.scrollLeft;
+        var scrollTop = document.body.scrollTop ? document.body.scrollTop : document.documentElement.scrollTop;
+        var scrollLeft = document.body.scrollLeft ? document.body.scrollLeft : document.documentElement.scrollLeft;
 
         var x = this.coords[0],
             y = this.coords[1];
 
         // hide the menu first to avoid an "up-then-over" visual effect
-        this.dom_obj.style.display = 'none';
-        this.dom_obj.style.left = (x + scrollLeft + this.spacing - getSidebarWidth()) + 'px';
-        this.dom_obj.style.top = (y + scrollTop + this.spacing - getHeaderHeight()) + 'px';
-        if(isIE) {
-            this.dom_obj.style.width = '0px';
+        this.dom_obj.style.display = "none";
+        this.dom_obj.style.left = x + scrollLeft + this.spacing - getSidebarWidth() + "px";
+        this.dom_obj.style.top = y + scrollTop + this.spacing - getHeaderHeight() + "px";
+        if (isIE) {
+            this.dom_obj.style.width = "0px";
         } else {
-            this.dom_obj.style.width = 'auto';
+            this.dom_obj.style.width = "auto";
         }
-        this.dom_obj.style.display = '';
+        this.dom_obj.style.display = "";
         g_hover_open = this;
 
         // Set the width but leave some border at the screens edge
-        if(this.dom_obj.clientWidth - this.spacing > this.min_width)
-            this.dom_obj.style.width = this.dom_obj.clientWidth - this.spacing + 'px';
-        else
-            this.dom_obj.style.width = this.min_width + 'px';
+        if (this.dom_obj.clientWidth - this.spacing > this.min_width)
+            this.dom_obj.style.width = this.dom_obj.clientWidth - this.spacing + "px";
+        else this.dom_obj.style.width = this.min_width + "px";
 
         /**
          * Check if the menu is "in screen" or too large.
@@ -299,22 +296,21 @@ var ElementHover = Element.extend({
          *  - If that is not possible try to reposition the hover menu
          */
 
-        var hoverLeft = parseInt(this.dom_obj.style.left.replace('px', ''));
+        var hoverLeft = parseInt(this.dom_obj.style.left.replace("px", ""));
         var screenWidth = pageWidth();
         var hoverPosAndSizeOk = true;
         if (!this.isOnScreen()) {
             hoverPosAndSizeOk = false;
-            if (this.tryResize())
-                hoverPosAndSizeOk = true;
+            if (this.tryResize()) hoverPosAndSizeOk = true;
         }
 
         // Resizing was not enough so try to reposition the menu now
         if (!hoverPosAndSizeOk) {
             // First reposition by real size or by min width
             if (this.dom_obj.clientWidth < this.min_width) {
-                this.dom_obj.style.left = (x - this.min_width - this.spacing + scrollLeft) + 'px';
+                this.dom_obj.style.left = x - this.min_width - this.spacing + scrollLeft + "px";
             } else {
-                this.dom_obj.style.left = (x - this.dom_obj.clientWidth - this.spacing + scrollLeft) + 'px';
+                this.dom_obj.style.left = x - this.dom_obj.clientWidth - this.spacing + scrollLeft + "px";
             }
 
             if (this.isOnScreen()) {
@@ -330,63 +326,55 @@ var ElementHover = Element.extend({
         // And if the hover menu is still not on the screen move it to the left edge
         // and fill the whole screen width
         if (!this.isOnScreen()) {
-            this.dom_obj.style.left = this.spacing + scrollLeft + 'px';
-            this.dom_obj.style.width = pageWidth() - (2*this.spacing) + 'px';
+            this.dom_obj.style.left = this.spacing + scrollLeft + "px";
+            this.dom_obj.style.width = pageWidth() - 2 * this.spacing + "px";
         }
 
-        var hoverTop = parseInt(this.dom_obj.style.top.replace('px', ''));
+        var hoverTop = parseInt(this.dom_obj.style.top.replace("px", ""));
         // Only move the menu to the top when the new top will not be
         // out of sight
-        if(hoverTop + this.dom_obj.clientHeight > pageHeight() && hoverTop - this.dom_obj.clientHeight >= 0)
-            this.dom_obj.style.top = hoverTop - this.dom_obj.clientHeight - this.spacing - 5 + 'px';
+        if (hoverTop + this.dom_obj.clientHeight > pageHeight() && hoverTop - this.dom_obj.clientHeight >= 0)
+            this.dom_obj.style.top = hoverTop - this.dom_obj.clientHeight - this.spacing - 5 + "px";
         hoverTop = null;
     },
 
-    isOnScreen: function() {
-        var hoverLeft = parseInt(this.dom_obj.style.left.replace('px', ''));
-        var scrollLeft = document.body.scrollLeft ? document.body.scrollLeft :
-                         document.documentElement.scrollLeft;
-    
-        if (hoverLeft < scrollLeft)
-            return false;
-    
+    isOnScreen: function () {
+        var hoverLeft = parseInt(this.dom_obj.style.left.replace("px", ""));
+        var scrollLeft = document.body.scrollLeft ? document.body.scrollLeft : document.documentElement.scrollLeft;
+
+        if (hoverLeft < scrollLeft) return false;
+
         // The most right px of the hover menu
         var hoverRight = hoverLeft + this.dom_obj.clientWidth - scrollLeft;
         // The most right px of the viewport
-        var viewRight  = pageWidth();
-    
-        if (hoverRight > viewRight)
-            return false;
-    
+        var viewRight = pageWidth();
+
+        if (hoverRight > viewRight) return false;
+
         // There is not enough spacing at the left viewport border
-        if (hoverLeft - this.spacing < 0)
-            return false;
-    
+        if (hoverLeft - this.spacing < 0) return false;
+
         return true;
     },
 
-    tryResize: function(rightSide) {
-        if (!isset(rightSide))
-            var reposition = false;
-    
-        var hoverLeft = parseInt(this.dom_obj.style.left.replace('px', ''));
-    
-        if (rightSide)
-            var overhead = hoverLeft + this.dom_obj.clientWidth + this.spacing - pageWidth();
-        else
-            var overhead = hoverLeft;
+    tryResize: function (rightSide) {
+        if (!isset(rightSide)) var reposition = false;
+
+        var hoverLeft = parseInt(this.dom_obj.style.left.replace("px", ""));
+
+        if (rightSide) var overhead = hoverLeft + this.dom_obj.clientWidth + this.spacing - pageWidth();
+        else var overhead = hoverLeft;
         var widthAfterResize = this.dom_obj.clientWidth - overhead;
-    
+
         // If width is larger than this.min_width resize it
         if (widthAfterResize > this.min_width) {
-            this.dom_obj.style.width = widthAfterResize + 'px';
-    
+            this.dom_obj.style.width = widthAfterResize + "px";
+
             if (rightSide) {
-                if(overhead < 0)
-                    overhead *= -1
-                this.dom_obj.style.left = (hoverLeft + overhead) + 'px';
+                if (overhead < 0) overhead *= -1;
+                this.dom_obj.style.left = hoverLeft + overhead + "px";
             }
-    
+
             return true;
         } else {
             return false;
@@ -395,42 +383,42 @@ var ElementHover = Element.extend({
 
     renderMenu: function () {
         var template_html = this.template_html;
-        if (!this.obj.conf.hover_url || this.obj.conf.hover_url === '') {
+        if (!this.obj.conf.hover_url || this.obj.conf.hover_url === "") {
             // Replace dynamic (state dependent) macros
-            if (isset(this.obj.conf.hover_template))
-                template_html = this.replaceDynamicMacros(template_html);
+            if (isset(this.obj.conf.hover_template)) template_html = this.replaceDynamicMacros(template_html);
         }
 
         // Only create a new div when the hover menu does not exist
-        var hoverMenu = document.getElementById(this.obj.conf.object_id+'-hover');
-        if(!hoverMenu) {
-            var hoverMenu = document.createElement('div');
+        var hoverMenu = document.getElementById(this.obj.conf.object_id + "-hover");
+        if (!hoverMenu) {
+            var hoverMenu = document.createElement("div");
             this.dom_obj = hoverMenu;
-            hoverMenu.setAttribute('id', this.obj.conf.object_id+'-hover');
-            hoverMenu.className = 'hover';
-            hoverMenu.style.display = 'none';
+            hoverMenu.setAttribute("id", this.obj.conf.object_id + "-hover");
+            hoverMenu.className = "hover";
+            hoverMenu.style.display = "none";
         }
 
         // Append template code to hover menu div
         hoverMenu.innerHTML = template_html;
 
         // Display the hover menu again, when it was open before re-rendering
-        if (this.coords !== null)
-            this.show();
+        if (this.coords !== null) this.show();
     },
 
     replaceChildMacros: function (template_html) {
-        var childs_html = '';
-        var regex = '';
+        var childs_html = "";
+        var regex = "";
 
         var row_tmpl = g_hover_template_childs[this.obj.conf.hover_template];
         var stateful_members = this.obj.getStatefulMembers();
-        if(typeof(row_tmpl) != 'undefined' && row_tmpl != '' && stateful_members.length > 0) {
+        if (typeof row_tmpl != "undefined" && row_tmpl != "" && stateful_members.length > 0) {
             // Loop all child objects until all looped or the child limit is reached
-            for(var i = 0, len1 = this.obj.conf.hover_childs_limit, len2 = stateful_members.length;
-                (len1 == -1 || (len1 >= 0 && i <= len1)) && i < len2; i++) {
-
-                if(len1 == -1 || (len1 >= 0 && i < len1)) {
+            for (
+                var i = 0, len1 = this.obj.conf.hover_childs_limit, len2 = stateful_members.length;
+                (len1 == -1 || (len1 >= 0 && i <= len1)) && i < len2;
+                i++
+            ) {
+                if (len1 == -1 || (len1 >= 0 && i < len1)) {
                     // Children need to know where they belong
                     stateful_members[i].parent_type = this.obj.conf.type;
                     stateful_members[i].parent_name = this.obj.conf.name;
@@ -439,12 +427,13 @@ var ElementHover = Element.extend({
                 } else {
                     // Create an end line which shows the number of hidden child items
                     var member = {
-                        'conf': {
-                            'type': 'host',
-                            'name': '',
-                            'summary_state': '',
-                            'summary_output': (this.obj.conf.num_members - this.obj.conf.hover_childs_limit) + ' ' + _('more items...'),
-                            '<!--\\sBEGIN\\sservicegroup_child\\s-->.+?<!--\\sEND\\sservicegroup_child\\s-->': ''
+                        conf: {
+                            type: "host",
+                            name: "",
+                            summary_state: "",
+                            summary_output:
+                                this.obj.conf.num_members - this.obj.conf.hover_childs_limit + " " + _("more items..."),
+                            "<!--\\sBEGIN\\sservicegroup_child\\s-->.+?<!--\\sEND\\sservicegroup_child\\s-->": ""
                         }
                     };
 
@@ -453,10 +442,9 @@ var ElementHover = Element.extend({
             }
         }
 
-        if(childs_html != '')
-            regex = getRegEx('loopChild', "<!--\\sBEGIN\\sloop_child\\s-->(.+?)<!--\\sEND\\sloop_child\\s-->");
-        else
-            regex = getRegEx('loopChildEmpty', '<!--\\sBEGIN\\schilds\\s-->.+?<!--\\sEND\\schilds\\s-->');
+        if (childs_html != "")
+            regex = getRegEx("loopChild", "<!--\\sBEGIN\\sloop_child\\s-->(.+?)<!--\\sEND\\sloop_child\\s-->");
+        else regex = getRegEx("loopChildEmpty", "<!--\\sBEGIN\\schilds\\s-->.+?<!--\\sEND\\schilds\\s-->");
 
         template_html = template_html.replace(regex, childs_html);
         return template_html;
@@ -464,77 +452,81 @@ var ElementHover = Element.extend({
 
     replaceMacrosOfChild: function (member_obj, template_html) {
         var oMacros = {
-            'obj_summary_state'  : member_obj.conf.summary_state,
-            'obj_summary_output' : member_obj.conf.summary_output,
-            'obj_display_name'   : member_obj.conf.display_name
-        }
+            obj_summary_state: member_obj.conf.summary_state,
+            obj_summary_output: member_obj.conf.summary_output,
+            obj_display_name: member_obj.conf.display_name
+        };
 
-        if (member_obj.conf.summary_problem_has_been_acknowledged && member_obj.conf.summary_problem_has_been_acknowledged == 1)
-            oMacros.obj_summary_acknowledged = '(Acknowledged)';
+        if (
+            member_obj.conf.summary_problem_has_been_acknowledged &&
+            member_obj.conf.summary_problem_has_been_acknowledged == 1
+        )
+            oMacros.obj_summary_acknowledged = "(Acknowledged)";
 
         if (member_obj.conf.summary_in_downtime && member_obj.conf.summary_in_downtime == 1)
-            oMacros.obj_summary_in_downtime = '(Downtime)';
+            oMacros.obj_summary_in_downtime = "(Downtime)";
 
-        if (member_obj.conf.summary_stale)
-            oMacros.obj_summary_stale = '(Stale)';
+        if (member_obj.conf.summary_stale) oMacros.obj_summary_stale = "(Stale)";
 
         // On child service objects in hover menu replace obj_name with
         // service_description
-        if (member_obj.conf.type === 'service')
-            oMacros.obj_name = member_obj.conf.service_description;
-        else
-            oMacros.obj_name = member_obj.conf.name;
+        if (member_obj.conf.type === "service") oMacros.obj_name = member_obj.conf.service_description;
+        else oMacros.obj_name = member_obj.conf.name;
 
-        if ((member_obj.parent_type === 'servicegroup' || member_obj.parent_type === 'dyngroup')
-            && member_obj.conf.type === 'service')
+        if (
+            (member_obj.parent_type === "servicegroup" || member_obj.parent_type === "dyngroup") &&
+            member_obj.conf.type === "service"
+        )
             oMacros.obj_name1 = member_obj.conf.name;
         else {
-            var regex = getRegEx('section-sgchild', '<!--\\sBEGIN\\sservicegroup_child\\s-->.+?<!--\\sEND\\sservicegroup_child\\s-->', 'gm');
-            if (template_html.search(regex) !== -1)
-                template_html = template_html.replace(regex, '');
+            var regex = getRegEx(
+                "section-sgchild",
+                "<!--\\sBEGIN\\sservicegroup_child\\s-->.+?<!--\\sEND\\sservicegroup_child\\s-->",
+                "gm"
+            );
+            if (template_html.search(regex) !== -1) template_html = template_html.replace(regex, "");
         }
 
         // Replace all normal macros
-        template_html = template_html.replace(/\[(\w*)\]/g, function() {
-            return htmlspecialchars(oMacros[ arguments[1] ] || "");
+        template_html = template_html.replace(/\[(\w*)\]/g, function () {
+            return htmlspecialchars(oMacros[arguments[1]] || "");
         });
         return template_html;
     },
 
     replaceDynamicMacros: function (template_html) {
         var oMacros = {};
-    
-        if (g_view.type === 'map')
-            oMacros.map_name = oPageProperties.map_name;
-    
+
+        if (g_view.type === "map") oMacros.map_name = oPageProperties.map_name;
+
         oMacros.last_status_refresh = date(oGeneralProperties.date_format, this.obj.lastUpdate);
-    
+
         oMacros.obj_state = this.obj.conf.state;
         oMacros.obj_summary_state = this.obj.conf.summary_state;
-    
-        if (this.obj.conf.summary_problem_has_been_acknowledged && this.obj.conf.summary_problem_has_been_acknowledged == 1)
-            oMacros.obj_summary_acknowledged = '(Acknowledged)';
-    
+
+        if (
+            this.obj.conf.summary_problem_has_been_acknowledged &&
+            this.obj.conf.summary_problem_has_been_acknowledged == 1
+        )
+            oMacros.obj_summary_acknowledged = "(Acknowledged)";
+
         if (this.obj.conf.problem_has_been_acknowledged && this.obj.conf.problem_has_been_acknowledged == 1)
-            oMacros.obj_acknowledged = '(Acknowledged)';
-    
+            oMacros.obj_acknowledged = "(Acknowledged)";
+
         if (this.obj.conf.summary_in_downtime && this.obj.conf.summary_in_downtime == 1)
-            oMacros.obj_summary_in_downtime = '(Downtime)';
-    
-        if (this.obj.conf.in_downtime && this.obj.conf.in_downtime == 1)
-            oMacros.obj_in_downtime = '(Downtime)';
-    
-        if (this.obj.conf.summary_stale)
-            oMacros.obj_summary_stale = '(Stale)';
-    
-        if (this.obj.conf.stale)
-            oMacros.obj_stale = '(Stale)';
-    
+            oMacros.obj_summary_in_downtime = "(Downtime)";
+
+        if (this.obj.conf.in_downtime && this.obj.conf.in_downtime == 1) oMacros.obj_in_downtime = "(Downtime)";
+
+        if (this.obj.conf.summary_stale) oMacros.obj_summary_stale = "(Stale)";
+
+        if (this.obj.conf.stale) oMacros.obj_stale = "(Stale)";
+
         oMacros.obj_output = this.obj.conf.output;
         oMacros.obj_summary_output = this.obj.conf.summary_output;
-    
+
         // Macros which are only for services and hosts
-        if (this.obj.conf.type === 'host' || this.obj.conf.type === 'service') {
+        if (this.obj.conf.type === "host" || this.obj.conf.type === "service") {
             oMacros.obj_last_check = this.obj.conf.last_check;
             oMacros.obj_next_check = this.obj.conf.next_check;
             oMacros.obj_state_type = this.obj.conf.state_type;
@@ -545,85 +537,80 @@ var ElementHover = Element.extend({
             oMacros.obj_state_duration = this.obj.conf.state_duration;
             oMacros.obj_perfdata = this.obj.conf.perfdata;
         }
-    
+
         // On a update the image url replacement is easier. Just replace the old
         // timestamp with the current
         if (this.obj.firstUpdate !== null) {
-            var regex = getRegEx('img_timestamp', '_t='+this.obj.firstUpdate, 'g');
+            var regex = getRegEx("img_timestamp", "_t=" + this.obj.firstUpdate, "g");
             // Search before matching - saves some time
-            if(template_html.search(regex) !== -1)
-                template_html = template_html.replace(regex, '_t='+this.obj.lastUpdate);
+            if (template_html.search(regex) !== -1)
+                template_html = template_html.replace(regex, "_t=" + this.obj.lastUpdate);
         }
-    
+
         // Replace child macros
-        if (this.obj.conf.hover_childs_show && this.obj.conf.hover_childs_show == '1')
+        if (this.obj.conf.hover_childs_show && this.obj.conf.hover_childs_show == "1")
             template_html = this.replaceChildMacros(template_html);
-    
+
         // Replace all normal macros
-        template_html = template_html.replace(/\[(\w*)\]/g, function() {
-            return oMacros[ arguments[1] ] || "";
+        template_html = template_html.replace(/\[(\w*)\]/g, function () {
+            return oMacros[arguments[1]] || "";
         });
         return template_html;
     },
 
-    replaceStaticMacros: function() {
+    replaceStaticMacros: function () {
         var oMacros = {};
         var oSectionMacros = {};
-    
-        if(this.obj.conf.type && this.obj.conf.type != '')
-            oMacros.obj_type = this.obj.conf.type;
-    
+
+        if (this.obj.conf.type && this.obj.conf.type != "") oMacros.obj_type = this.obj.conf.type;
+
         // Replace language strings
         oMacros.lang_obj_type = _(this.obj.conf.type);
-        if (this.obj.conf.type == 'host') {
-            oMacros.lang_name        = _('hostname');
-            oMacros.lang_child_name  = _('servicename');
-        } else if (this.obj.conf.type == 'service') {
-            oMacros.lang_name        = _('hostname');
-        } else if (this.obj.conf.type == 'hostgroup') {
-            oMacros.lang_name        = _('hostgroupname');
-            oMacros.lang_child_name  = _('hostname');
-        } else if (this.obj.conf.type == 'servicegroup') {
-            oMacros.lang_name        = _('servicegroupname');
-            oMacros.lang_child_name  = _('servicename');
-            oMacros.lang_child_name1 = _('hostname');
-        } else if (this.obj.conf.type == 'dyngroup') {
-            oMacros.lang_name        = _('Dynamic Group Name');
-            oMacros.lang_child_name  = _('Object Name');
-            if (this.obj.conf.object_types == 'service')
-                oMacros.lang_child_name1 = _('hostname');
-        } else if (this.obj.conf.type == 'aggr') {
-            oMacros.lang_name        = _('Aggregation Name');
-            oMacros.lang_child_name  = _('Name');
-            oMacros.lang_child_name1 = _('Name');
-        } else if (this.obj.conf.type == 'map') {
-            oMacros.lang_name        = _('mapname');
-            oMacros.lang_child_name  = _('objectname');
+        if (this.obj.conf.type == "host") {
+            oMacros.lang_name = _("hostname");
+            oMacros.lang_child_name = _("servicename");
+        } else if (this.obj.conf.type == "service") {
+            oMacros.lang_name = _("hostname");
+        } else if (this.obj.conf.type == "hostgroup") {
+            oMacros.lang_name = _("hostgroupname");
+            oMacros.lang_child_name = _("hostname");
+        } else if (this.obj.conf.type == "servicegroup") {
+            oMacros.lang_name = _("servicegroupname");
+            oMacros.lang_child_name = _("servicename");
+            oMacros.lang_child_name1 = _("hostname");
+        } else if (this.obj.conf.type == "dyngroup") {
+            oMacros.lang_name = _("Dynamic Group Name");
+            oMacros.lang_child_name = _("Object Name");
+            if (this.obj.conf.object_types == "service") oMacros.lang_child_name1 = _("hostname");
+        } else if (this.obj.conf.type == "aggr") {
+            oMacros.lang_name = _("Aggregation Name");
+            oMacros.lang_child_name = _("Name");
+            oMacros.lang_child_name1 = _("Name");
+        } else if (this.obj.conf.type == "map") {
+            oMacros.lang_name = _("mapname");
+            oMacros.lang_child_name = _("objectname");
         }
 
         // On child service objects in hover menu replace obj_name with
         // service_description
         oMacros.obj_name = this.obj.conf.name;
-    
-        if(this.obj.conf.alias && this.obj.conf.alias !== '') {
-            oMacros.obj_alias        = this.obj.conf.alias;
-            oMacros.obj_alias_braces = ' (' +this.obj.conf.alias + ')';
+
+        if (this.obj.conf.alias && this.obj.conf.alias !== "") {
+            oMacros.obj_alias = this.obj.conf.alias;
+            oMacros.obj_alias_braces = " (" + this.obj.conf.alias + ")";
         } else {
-            oMacros.obj_alias        = '';
-            oMacros.obj_alias_braces = '';
+            oMacros.obj_alias = "";
+            oMacros.obj_alias_braces = "";
         }
-    
-        if(this.obj.conf.display_name && this.obj.conf.display_name !== '')
+
+        if (this.obj.conf.display_name && this.obj.conf.display_name !== "")
             oMacros.obj_display_name = this.obj.conf.display_name;
-        else
-            oMacros.obj_display_name = '';
-    
-        if(this.obj.conf.notes && this.obj.conf.notes !== '')
-            oMacros.obj_notes = this.obj.conf.notes;
-        else
-            oMacros.obj_notes = '';
-    
-        if(this.obj.conf.type !== 'map') {
+        else oMacros.obj_display_name = "";
+
+        if (this.obj.conf.notes && this.obj.conf.notes !== "") oMacros.obj_notes = this.obj.conf.notes;
+        else oMacros.obj_notes = "";
+
+        if (this.obj.conf.type !== "map") {
             oMacros.obj_backendid = this.obj.conf.backend_id;
             oMacros.obj_backend_instancename = this.obj.conf.backend_instancename;
             oMacros.html_cgi = this.obj.conf.htmlcgi;
@@ -632,102 +619,105 @@ var ElementHover = Element.extend({
             oMacros.custom_3 = this.obj.conf.custom_3;
         } else {
             // Remove the macros in map objects
-            oMacros.obj_backendid = '';
-            oMacros.obj_backend_instancename = '';
-            oMacros.html_cgi = '';
-            oMacros.custom_1 = '';
-            oMacros.custom_2 = '';
-            oMacros.custom_3 = '';
+            oMacros.obj_backendid = "";
+            oMacros.obj_backend_instancename = "";
+            oMacros.html_cgi = "";
+            oMacros.custom_1 = "";
+            oMacros.custom_2 = "";
+            oMacros.custom_3 = "";
         }
-    
+
         // Macros which are only for services and hosts
-        if(this.obj.conf.type === 'host' || this.obj.conf.type === 'service') {
+        if (this.obj.conf.type === "host" || this.obj.conf.type === "service") {
             oMacros.obj_address = this.obj.conf.address;
-            oMacros.obj_tags    = this.obj.conf.tags.join(', ');
-    
+            oMacros.obj_tags = this.obj.conf.tags.join(", ");
+
             // Add taggroup information
             for (var group_id in this.obj.conf.taggroups) {
                 var group = this.obj.conf.taggroups[group_id];
-                oMacros['obj_taggroup_' + group_id + '_title'] = group.title;
-                oMacros['obj_taggroup_' + group_id + '_topic'] = group.topic;
+                oMacros["obj_taggroup_" + group_id + "_title"] = group.title;
+                oMacros["obj_taggroup_" + group_id + "_topic"] = group.topic;
                 if (group.value) {
-                    oMacros['obj_taggroup_' + group_id + '_value']       = group.value[0];
-                    oMacros['obj_taggroup_' + group_id + '_value_title'] = group.value[1];
+                    oMacros["obj_taggroup_" + group_id + "_value"] = group.value[0];
+                    oMacros["obj_taggroup_" + group_id + "_value_title"] = group.value[1];
                 } else {
-                    oMacros['obj_taggroup_' + group_id + '_value']       = '';
-                    oMacros['obj_taggroup_' + group_id + '_value_title'] = '';
+                    oMacros["obj_taggroup_" + group_id + "_value"] = "";
+                    oMacros["obj_taggroup_" + group_id + "_value_title"] = "";
                 }
             }
         } else {
-            oMacros.obj_address = '';
-            oMacros.obj_tags    = '';
+            oMacros.obj_address = "";
+            oMacros.obj_tags = "";
         }
-    
-        if (oMacros.obj_tags == '') {
-            oSectionMacros.has_tags = '<!--\\sBEGIN\\shas_tags\\s-->.+?<!--\\sEND\\shas_tags\\s-->';
+
+        if (oMacros.obj_tags == "") {
+            oSectionMacros.has_tags = "<!--\\sBEGIN\\shas_tags\\s-->.+?<!--\\sEND\\shas_tags\\s-->";
         }
-    
-        if(this.obj.conf.type === 'service') {
+
+        if (this.obj.conf.type === "service") {
             oMacros.service_description = this.obj.conf.service_description;
-            oMacros.pnp_hostname = this.obj.conf.name.replace(/\s/g,'%20');
-            oMacros.pnp_service_description = this.obj.conf.service_description.replace(/\s/g,'%20').replace(/#/g, '%23');
-        } else
-            oSectionMacros.service = '<!--\\sBEGIN\\sservice\\s-->.+?<!--\\sEND\\sservice\\s-->';
-    
+            oMacros.pnp_hostname = this.obj.conf.name.replace(/\s/g, "%20");
+            oMacros.pnp_service_description = this.obj.conf.service_description
+                .replace(/\s/g, "%20")
+                .replace(/#/g, "%23");
+        } else oSectionMacros.service = "<!--\\sBEGIN\\sservice\\s-->.+?<!--\\sEND\\sservice\\s-->";
+
         // Macros which are only for hosts
-        if(this.obj.conf.type === 'host')
-            oMacros.pnp_hostname = this.obj.conf.name.replace(' ','%20');
-        else
-            oSectionMacros.host = '<!--\\sBEGIN\\shost\\s-->.+?<!--\\sEND\\shost\\s-->';
-    
+        if (this.obj.conf.type === "host") oMacros.pnp_hostname = this.obj.conf.name.replace(" ", "%20");
+        else oSectionMacros.host = "<!--\\sBEGIN\\shost\\s-->.+?<!--\\sEND\\shost\\s-->";
+
         // Replace servicegroup sections when not servicegroup object
-        if(this.obj.conf.type !== 'servicegroup' && !(this.obj.conf.type === 'dyngroup' && this.obj.conf.object_types == 'service')) {
-            oSectionMacros.servicegroup = '<!--\\sBEGIN\\sservicegroup\\s-->.+?<!--\\sEND\\sservicegroup\\s-->';
+        if (
+            this.obj.conf.type !== "servicegroup" &&
+            !(this.obj.conf.type === "dyngroup" && this.obj.conf.object_types == "service")
+        ) {
+            oSectionMacros.servicegroup = "<!--\\sBEGIN\\sservicegroup\\s-->.+?<!--\\sEND\\sservicegroup\\s-->";
         }
-    
+
         // Replace hostgroup sections when not hostgroup object
-        if(this.obj.conf.type !== 'hostgroup')
-            oSectionMacros.hostgroup = '<!--\\sBEGIN\\shostgroup\\s-->.+?<!--\\sEND\\shostgroup\\s-->';
-    
+        if (this.obj.conf.type !== "hostgroup")
+            oSectionMacros.hostgroup = "<!--\\sBEGIN\\shostgroup\\s-->.+?<!--\\sEND\\shostgroup\\s-->";
+
         // Replace map sections when not map object
-        if(this.obj.conf.type !== 'map')
-            oSectionMacros.map = '<!--\\sBEGIN\\smap\\s-->.+?<!--\\sEND\\smap\\s-->';
-    
+        if (this.obj.conf.type !== "map") oSectionMacros.map = "<!--\\sBEGIN\\smap\\s-->.+?<!--\\sEND\\smap\\s-->";
+
         // Replace child section when unwanted
-        if(this.obj.conf.hover_childs_show && this.obj.conf.hover_childs_show != '1')
-            oSectionMacros.childs = '<!--\\sBEGIN\\schilds\\s-->.+?<!--\\sEND\\schilds\\s-->';
-    
+        if (this.obj.conf.hover_childs_show && this.obj.conf.hover_childs_show != "1")
+            oSectionMacros.childs = "<!--\\sBEGIN\\schilds\\s-->.+?<!--\\sEND\\schilds\\s-->";
+
         // Loop and replace all unwanted section macros
         for (var key in oSectionMacros) {
-            var regex = getRegEx('section-'+key, oSectionMacros[key], 'gm');
-            if (this.template_html.search(regex) !== -1)
-                this.template_html = this.template_html.replace(regex, '');
+            var regex = getRegEx("section-" + key, oSectionMacros[key], "gm");
+            if (this.template_html.search(regex) !== -1) this.template_html = this.template_html.replace(regex, "");
             regex = null;
         }
-    
+
         // Loop and replace all normal macros
-        this.template_html = this.template_html.replace(/\[(\w*)\]/g, function() {
-            return oMacros[ arguments[1] ] || '['+arguments[1]+']';
+        this.template_html = this.template_html.replace(/\[(\w*)\]/g, function () {
+            return oMacros[arguments[1]] || "[" + arguments[1] + "]";
         });
-    
+
         // Re-add the clean child code
         // This workaround is needed cause the obj_name macro is replaced
         // by the parent objects macro in current progress
-        var regex = getRegEx('loopChild', "<!--\\sBEGIN\\sloop_child\\s-->(.+?)<!--\\sEND\\sloop_child\\s-->");
-        if(this.template_html.search(regex) !== -1)
-            this.template_html = this.template_html.replace(regex, '<!-- BEGIN loop_child -->'
-                                                                   + g_hover_template_childs[this.obj.conf.hover_template]
-                                                                   + '<!-- END loop_child -->');
-    
+        var regex = getRegEx("loopChild", "<!--\\sBEGIN\\sloop_child\\s-->(.+?)<!--\\sEND\\sloop_child\\s-->");
+        if (this.template_html.search(regex) !== -1)
+            this.template_html = this.template_html.replace(
+                regex,
+                "<!-- BEGIN loop_child -->" +
+                    g_hover_template_childs[this.obj.conf.hover_template] +
+                    "<!-- END loop_child -->"
+            );
+
         // Search for images and append current timestamp to src (prevent caching of
         // images e.a. when some graphs should be fresh)
-        var regex = getRegEx('img', "<img.*src=['\"]?([^>'\"]*)['\"]?");
+        var regex = getRegEx("img", "<img.*src=['\"]?([^>'\"]*)['\"]?");
         var results = regex.exec(this.template_html);
-        if(results !== null) {
-            for(var i = 0, len = results.length; i < len; i=i+2) {
+        if (results !== null) {
+            for (var i = 0, len = results.length; i < len; i = i + 2) {
                 // Replace src value
-                var sTmp = results[i].replace(results[i+1], results[i+1]+"&_t="+this.obj.firstUpdate);
-    
+                var sTmp = results[i].replace(results[i + 1], results[i + 1] + "&_t=" + this.obj.firstUpdate);
+
                 // replace image code
                 this.template_html = this.template_html.replace(results[i], sTmp);
             }

--- a/share/frontend/nagvis-js/js/ElementHover.js
+++ b/share/frontend/nagvis-js/js/ElementHover.js
@@ -21,17 +21,17 @@
  *
  *****************************************************************************/
 
-var g_hover_templates = {};
-var g_hover_template_childs = {};
-var g_hover_urls = {};
-var g_hover_open = null;
+const g_hover_templates = {};
+const g_hover_template_childs = {};
+const g_hover_urls = {};
+let g_hover_open = null;
 
 // Hides the currently open hover menu
 function hoverHide() {
     if (g_hover_open !== null) g_hover_open.hide();
 }
 
-var ElementHover = Element.extend({
+const ElementHover = Element.extend({
     hover_url: null, // configured url with eventual replaced macros
     template_html: null, // hover HTML code with replaced config related macros
     coords: null, // list of x, y coordinates of the hover menu top left corner
@@ -117,7 +117,7 @@ var ElementHover = Element.extend({
                 this.template_html = g_hover_urls[this.hover_url];
             }
         } else {
-            var name = this.obj.conf.hover_template;
+            const name = this.obj.conf.hover_template;
             if (!isset(g_hover_templates[name])) {
                 this.requestTemplate();
             } else if (g_hover_templates[name] !== true) {
@@ -147,15 +147,15 @@ var ElementHover = Element.extend({
 
     // Extracts the childs code from the hover templates
     getChildCode: function (template_html) {
-        var regex = getRegEx("loopChild", "<!--\\sBEGIN\\sloop_child\\s-->(.+?)<!--\\sEND\\sloop_child\\s-->");
-        var results = regex.exec(template_html);
+        const regex = getRegEx("loopChild", "<!--\\sBEGIN\\sloop_child\\s-->(.+?)<!--\\sEND\\sloop_child\\s-->");
+        const results = regex.exec(template_html);
         if (results !== null) return results[1];
         else return "";
     },
 
     handleTemplate: function (templates) {
-        var name = templates[0]["name"];
-        var code = templates[0]["code"];
+        const name = templates[0]["name"];
+        const code = templates[0]["code"];
 
         g_hover_templates[name] = code;
         g_hover_template_childs[name] = this.getChildCode(code);
@@ -166,7 +166,7 @@ var ElementHover = Element.extend({
         if (isset(templates[0]["css_file"])) {
             // This is needed for some old browsers which do no load css files
             // which are included in such fetched html code
-            var oLink = document.createElement("link");
+            const oLink = document.createElement("link");
             oLink.href = templates[0]["css_file"];
             oLink.rel = "stylesheet";
             oLink.type = "text/css";
@@ -218,7 +218,7 @@ var ElementHover = Element.extend({
         // has not been drawn yet. Do it now.
         if (this.dom_obj === null) this.draw();
 
-        var hover_delay = parseInt(this.obj.conf.hover_delay);
+        const hover_delay = parseInt(this.obj.conf.hover_delay);
 
         // Only show up hover menu when no context menu is opened
         // and only handle the events when no timer is in schedule at the moment to
@@ -266,10 +266,10 @@ var ElementHover = Element.extend({
 
     showAndPositionMenu: function () {
         // document.body.scrollTop does not work in IE
-        var scrollTop = document.body.scrollTop ? document.body.scrollTop : document.documentElement.scrollTop;
-        var scrollLeft = document.body.scrollLeft ? document.body.scrollLeft : document.documentElement.scrollLeft;
+        const scrollTop = document.body.scrollTop ? document.body.scrollTop : document.documentElement.scrollTop;
+        const scrollLeft = document.body.scrollLeft ? document.body.scrollLeft : document.documentElement.scrollLeft;
 
-        var x = this.coords[0],
+        const x = this.coords[0],
             y = this.coords[1];
 
         // hide the menu first to avoid an "up-then-over" visual effect
@@ -296,9 +296,9 @@ var ElementHover = Element.extend({
          *  - If that is not possible try to reposition the hover menu
          */
 
-        var hoverLeft = parseInt(this.dom_obj.style.left.replace("px", ""));
-        var screenWidth = pageWidth();
-        var hoverPosAndSizeOk = true;
+        const hoverLeft = parseInt(this.dom_obj.style.left.replace("px", ""));
+        const screenWidth = pageWidth();
+        let hoverPosAndSizeOk = true;
         if (!this.isOnScreen()) {
             hoverPosAndSizeOk = false;
             if (this.tryResize()) hoverPosAndSizeOk = true;
@@ -330,7 +330,7 @@ var ElementHover = Element.extend({
             this.dom_obj.style.width = pageWidth() - 2 * this.spacing + "px";
         }
 
-        var hoverTop = parseInt(this.dom_obj.style.top.replace("px", ""));
+        let hoverTop = parseInt(this.dom_obj.style.top.replace("px", ""));
         // Only move the menu to the top when the new top will not be
         // out of sight
         if (hoverTop + this.dom_obj.clientHeight > pageHeight() && hoverTop - this.dom_obj.clientHeight >= 0)
@@ -339,15 +339,15 @@ var ElementHover = Element.extend({
     },
 
     isOnScreen: function () {
-        var hoverLeft = parseInt(this.dom_obj.style.left.replace("px", ""));
-        var scrollLeft = document.body.scrollLeft ? document.body.scrollLeft : document.documentElement.scrollLeft;
+        const hoverLeft = parseInt(this.dom_obj.style.left.replace("px", ""));
+        const scrollLeft = document.body.scrollLeft ? document.body.scrollLeft : document.documentElement.scrollLeft;
 
         if (hoverLeft < scrollLeft) return false;
 
         // The most right px of the hover menu
-        var hoverRight = hoverLeft + this.dom_obj.clientWidth - scrollLeft;
+        const hoverRight = hoverLeft + this.dom_obj.clientWidth - scrollLeft;
         // The most right px of the viewport
-        var viewRight = pageWidth();
+        const viewRight = pageWidth();
 
         if (hoverRight > viewRight) return false;
 
@@ -358,13 +358,15 @@ var ElementHover = Element.extend({
     },
 
     tryResize: function (rightSide) {
-        if (!isset(rightSide)) var reposition = false;
+        let reposition;
+        if (!isset(rightSide)) reposition = false;
 
-        var hoverLeft = parseInt(this.dom_obj.style.left.replace("px", ""));
+        const hoverLeft = parseInt(this.dom_obj.style.left.replace("px", ""));
 
-        if (rightSide) var overhead = hoverLeft + this.dom_obj.clientWidth + this.spacing - pageWidth();
+        let overhead;
+        if (rightSide) overhead = hoverLeft + this.dom_obj.clientWidth + this.spacing - pageWidth();
         else overhead = hoverLeft;
-        var widthAfterResize = this.dom_obj.clientWidth - overhead;
+        const widthAfterResize = this.dom_obj.clientWidth - overhead;
 
         // If width is larger than this.min_width resize it
         if (widthAfterResize > this.min_width) {
@@ -382,14 +384,14 @@ var ElementHover = Element.extend({
     },
 
     renderMenu: function () {
-        var template_html = this.template_html;
+        let template_html = this.template_html;
         if (!this.obj.conf.hover_url || this.obj.conf.hover_url === "") {
             // Replace dynamic (state dependent) macros
             if (isset(this.obj.conf.hover_template)) template_html = this.replaceDynamicMacros(template_html);
         }
 
         // Only create a new div when the hover menu does not exist
-        var hoverMenu = document.getElementById(this.obj.conf.object_id + "-hover");
+        let hoverMenu = document.getElementById(this.obj.conf.object_id + "-hover");
         if (!hoverMenu) {
             hoverMenu = document.createElement("div");
             this.dom_obj = hoverMenu;
@@ -406,15 +408,15 @@ var ElementHover = Element.extend({
     },
 
     replaceChildMacros: function (template_html) {
-        var childs_html = "";
-        var regex = "";
+        let childs_html = "";
+        let regex = "";
 
-        var row_tmpl = g_hover_template_childs[this.obj.conf.hover_template];
-        var stateful_members = this.obj.getStatefulMembers();
+        const row_tmpl = g_hover_template_childs[this.obj.conf.hover_template];
+        const stateful_members = this.obj.getStatefulMembers();
         if (typeof row_tmpl != "undefined" && row_tmpl != "" && stateful_members.length > 0) {
             // Loop all child objects until all looped or the child limit is reached
             for (
-                var i = 0, len1 = this.obj.conf.hover_childs_limit, len2 = stateful_members.length;
+                let i = 0, len1 = this.obj.conf.hover_childs_limit, len2 = stateful_members.length;
                 (len1 == -1 || (len1 >= 0 && i <= len1)) && i < len2;
                 i++
             ) {
@@ -426,7 +428,7 @@ var ElementHover = Element.extend({
                     childs_html += this.replaceMacrosOfChild(stateful_members[i], row_tmpl);
                 } else {
                     // Create an end line which shows the number of hidden child items
-                    var member = {
+                    const member = {
                         conf: {
                             type: "host",
                             name: "",
@@ -451,7 +453,7 @@ var ElementHover = Element.extend({
     },
 
     replaceMacrosOfChild: function (member_obj, template_html) {
-        var oMacros = {
+        const oMacros = {
             obj_summary_state: member_obj.conf.summary_state,
             obj_summary_output: member_obj.conf.summary_output,
             obj_display_name: member_obj.conf.display_name
@@ -479,7 +481,7 @@ var ElementHover = Element.extend({
         )
             oMacros.obj_name1 = member_obj.conf.name;
         else {
-            var regex = getRegEx(
+            const regex = getRegEx(
                 "section-sgchild",
                 "<!--\\sBEGIN\\sservicegroup_child\\s-->.+?<!--\\sEND\\sservicegroup_child\\s-->",
                 "gm"
@@ -495,7 +497,7 @@ var ElementHover = Element.extend({
     },
 
     replaceDynamicMacros: function (template_html) {
-        var oMacros = {};
+        const oMacros = {};
 
         if (g_view.type === "map") oMacros.map_name = oPageProperties.map_name;
 
@@ -541,7 +543,7 @@ var ElementHover = Element.extend({
         // On a update the image url replacement is easier. Just replace the old
         // timestamp with the current
         if (this.obj.firstUpdate !== null) {
-            var regex = getRegEx("img_timestamp", "_t=" + this.obj.firstUpdate, "g");
+            const regex = getRegEx("img_timestamp", "_t=" + this.obj.firstUpdate, "g");
             // Search before matching - saves some time
             if (template_html.search(regex) !== -1)
                 template_html = template_html.replace(regex, "_t=" + this.obj.lastUpdate);
@@ -559,8 +561,8 @@ var ElementHover = Element.extend({
     },
 
     replaceStaticMacros: function () {
-        var oMacros = {};
-        var oSectionMacros = {};
+        const oMacros = {};
+        const oSectionMacros = {};
 
         if (this.obj.conf.type && this.obj.conf.type != "") oMacros.obj_type = this.obj.conf.type;
 
@@ -633,8 +635,8 @@ var ElementHover = Element.extend({
             oMacros.obj_tags = this.obj.conf.tags.join(", ");
 
             // Add taggroup information
-            for (var group_id in this.obj.conf.taggroups) {
-                var group = this.obj.conf.taggroups[group_id];
+            for (const group_id in this.obj.conf.taggroups) {
+                const group = this.obj.conf.taggroups[group_id];
                 oMacros["obj_taggroup_" + group_id + "_title"] = group.title;
                 oMacros["obj_taggroup_" + group_id + "_topic"] = group.topic;
                 if (group.value) {
@@ -686,8 +688,8 @@ var ElementHover = Element.extend({
             oSectionMacros.childs = "<!--\\sBEGIN\\schilds\\s-->.+?<!--\\sEND\\schilds\\s-->";
 
         // Loop and replace all unwanted section macros
-        for (var key in oSectionMacros) {
-            var regex = getRegEx("section-" + key, oSectionMacros[key], "gm");
+        for (const key in oSectionMacros) {
+            let regex = getRegEx("section-" + key, oSectionMacros[key], "gm");
             if (this.template_html.search(regex) !== -1) this.template_html = this.template_html.replace(regex, "");
             regex = null;
         }
@@ -700,10 +702,13 @@ var ElementHover = Element.extend({
         // Re-add the clean child code
         // This workaround is needed cause the obj_name macro is replaced
         // by the parent objects macro in current progress
-        regex = getRegEx("loopChild", "<!--\\sBEGIN\\sloop_child\\s-->(.+?)<!--\\sEND\\sloop_child\\s-->");
-        if (this.template_html.search(regex) !== -1)
+        const regexLoopChild = getRegEx(
+            "loopChild",
+            "<!--\\sBEGIN\\sloop_child\\s-->(.+?)<!--\\sEND\\sloop_child\\s-->"
+        );
+        if (this.template_html.search(regexLoopChild) !== -1)
             this.template_html = this.template_html.replace(
-                regex,
+                regexLoopChild,
                 "<!-- BEGIN loop_child -->" +
                     g_hover_template_childs[this.obj.conf.hover_template] +
                     "<!-- END loop_child -->"
@@ -711,12 +716,12 @@ var ElementHover = Element.extend({
 
         // Search for images and append current timestamp to src (prevent caching of
         // images e.a. when some graphs should be fresh)
-        regex = getRegEx("img", "<img.*src=['\"]?([^>'\"]*)['\"]?");
-        var results = regex.exec(this.template_html);
+        const regexImg = getRegEx("img", "<img.*src=['\"]?([^>'\"]*)['\"]?");
+        const results = regexImg.exec(this.template_html);
         if (results !== null) {
-            for (var i = 0, len = results.length; i < len; i = i + 2) {
+            for (let i = 0, len = results.length; i < len; i = i + 2) {
                 // Replace src value
-                var sTmp = results[i].replace(results[i + 1], results[i + 1] + "&_t=" + this.obj.firstUpdate);
+                const sTmp = results[i].replace(results[i + 1], results[i + 1] + "&_t=" + this.obj.firstUpdate);
 
                 // replace image code
                 this.template_html = this.template_html.replace(results[i], sTmp);

--- a/share/frontend/nagvis-js/js/ElementHover.js
+++ b/share/frontend/nagvis-js/js/ElementHover.js
@@ -363,7 +363,7 @@ var ElementHover = Element.extend({
         var hoverLeft = parseInt(this.dom_obj.style.left.replace("px", ""));
 
         if (rightSide) var overhead = hoverLeft + this.dom_obj.clientWidth + this.spacing - pageWidth();
-        else var overhead = hoverLeft;
+        else overhead = hoverLeft;
         var widthAfterResize = this.dom_obj.clientWidth - overhead;
 
         // If width is larger than this.min_width resize it
@@ -391,7 +391,7 @@ var ElementHover = Element.extend({
         // Only create a new div when the hover menu does not exist
         var hoverMenu = document.getElementById(this.obj.conf.object_id + "-hover");
         if (!hoverMenu) {
-            var hoverMenu = document.createElement("div");
+            hoverMenu = document.createElement("div");
             this.dom_obj = hoverMenu;
             hoverMenu.setAttribute("id", this.obj.conf.object_id + "-hover");
             hoverMenu.className = "hover";
@@ -700,7 +700,7 @@ var ElementHover = Element.extend({
         // Re-add the clean child code
         // This workaround is needed cause the obj_name macro is replaced
         // by the parent objects macro in current progress
-        var regex = getRegEx("loopChild", "<!--\\sBEGIN\\sloop_child\\s-->(.+?)<!--\\sEND\\sloop_child\\s-->");
+        regex = getRegEx("loopChild", "<!--\\sBEGIN\\sloop_child\\s-->(.+?)<!--\\sEND\\sloop_child\\s-->");
         if (this.template_html.search(regex) !== -1)
             this.template_html = this.template_html.replace(
                 regex,
@@ -711,7 +711,7 @@ var ElementHover = Element.extend({
 
         // Search for images and append current timestamp to src (prevent caching of
         // images e.a. when some graphs should be fresh)
-        var regex = getRegEx("img", "<img.*src=['\"]?([^>'\"]*)['\"]?");
+        regex = getRegEx("img", "<img.*src=['\"]?([^>'\"]*)['\"]?");
         var results = regex.exec(this.template_html);
         if (results !== null) {
             for (var i = 0, len = results.length; i < len; i = i + 2) {

--- a/share/frontend/nagvis-js/js/ElementIcon.js
+++ b/share/frontend/nagvis-js/js/ElementIcon.js
@@ -66,8 +66,8 @@ var ElementIcon = Element.extend({
                 var w = parseInt(size),
                     h = parseInt(size);
             } else {
-                var w = parseInt(size[0]),
-                    h = parseInt(size[1]);
+                w = parseInt(size[0]);
+                h = parseInt(size[1]);
             }
             oIcon.style.width = w + "px";
             oIcon.style.height = h + "px";

--- a/share/frontend/nagvis-js/js/ElementIcon.js
+++ b/share/frontend/nagvis-js/js/ElementIcon.js
@@ -22,14 +22,14 @@
  *****************************************************************************/
 
 var ElementIcon = Element.extend({
-    render: function() {
+    render: function () {
         this.renderIcon();
     },
 
     // Moves the icon to it's location as described by this js object
     place: function () {
-        this.dom_obj.style.top  = this.obj.parseCoord(this.obj.conf.y, 'y') + 'px';
-        this.dom_obj.style.left = this.obj.parseCoord(this.obj.conf.x, 'x') + 'px';
+        this.dom_obj.style.top = this.obj.parseCoord(this.obj.conf.y, "y") + "px";
+        this.dom_obj.style.left = this.obj.parseCoord(this.obj.conf.x, "x") + "px";
     },
 
     unlock: function () {
@@ -48,15 +48,13 @@ var ElementIcon = Element.extend({
 
     // Renders the object as icon and returns the icon container js object
     renderIcon: function () {
-        var alt = '';
-        if(this.obj.conf.type == 'service')
-            alt = this.obj.conf.name+'-'+this.obj.conf.service_description;
-        else
-            alt = this.obj.conf.name;
+        var alt = "";
+        if (this.obj.conf.type == "service") alt = this.obj.conf.name + "-" + this.obj.conf.service_description;
+        else alt = this.obj.conf.name;
 
-        var oIcon = document.createElement('img');
-        oIcon.setAttribute('id', this.obj.conf.object_id+'-icon');
-        oIcon.className = 'icon';
+        var oIcon = document.createElement("img");
+        oIcon.setAttribute("id", this.obj.conf.object_id + "-icon");
+        oIcon.className = "icon";
         this.obj.trigger_obj = oIcon;
 
         // When no icon size is configured, the native size of the image is used.
@@ -71,35 +69,39 @@ var ElementIcon = Element.extend({
                 var w = parseInt(size[0]),
                     h = parseInt(size[1]);
             }
-            oIcon.style.width = w + 'px';
-            oIcon.style.height = h + 'px';
+            oIcon.style.width = w + "px";
+            oIcon.style.height = h + "px";
         }
 
         // Register controls reposition handler to handle resizes during
         // loading the image (from alt="" text to the real image)
-        addEvent(oIcon, 'load', function(obj) {
-            return function() {
-                obj.place();
-                obj = null;
-            };
-        }(this.obj));
+        addEvent(
+            oIcon,
+            "load",
+            (function (obj) {
+                return function () {
+                    obj.place();
+                    obj = null;
+                };
+            })(this.obj)
+        );
 
         addZoomHandler(oIcon);
 
-        var oIconDiv = document.createElement('div');
+        var oIconDiv = document.createElement("div");
         this.dom_obj = oIconDiv;
         this.place();
 
-        oIconDiv.setAttribute('id', this.obj.conf.object_id+'-icondiv');
-        oIconDiv.className = 'icondiv';
+        oIconDiv.setAttribute("id", this.obj.conf.object_id + "-icondiv");
+        oIconDiv.className = "icondiv";
         oIconDiv.style.zIndex = this.obj.conf.z;
 
         oIcon.src = oGeneralProperties.path_iconsets + this.obj.conf.icon;
-        oIcon.alt = this.obj.conf.type + '-' + alt;
+        oIcon.alt = this.obj.conf.type + "-" + alt;
 
         // Parse link only when set
-        if (this.obj.conf.url && this.obj.conf.url !== '' && this.obj.conf.url !== '#') {
-            var oIconLink = document.createElement('a');
+        if (this.obj.conf.url && this.obj.conf.url !== "" && this.obj.conf.url !== "#") {
+            var oIconLink = document.createElement("a");
             oIconLink.href = this.obj.conf.url;
             oIconLink.target = this.obj.conf.url_target;
             oIconLink.appendChild(oIcon);
@@ -108,5 +110,4 @@ var ElementIcon = Element.extend({
             oIconDiv.appendChild(oIcon);
         }
     }
-
 });

--- a/share/frontend/nagvis-js/js/ElementIcon.js
+++ b/share/frontend/nagvis-js/js/ElementIcon.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var ElementIcon = Element.extend({
+const ElementIcon = Element.extend({
     render: function () {
         this.renderIcon();
     },
@@ -48,11 +48,11 @@ var ElementIcon = Element.extend({
 
     // Renders the object as icon and returns the icon container js object
     renderIcon: function () {
-        var alt = "";
+        let alt = "";
         if (this.obj.conf.type == "service") alt = this.obj.conf.name + "-" + this.obj.conf.service_description;
         else alt = this.obj.conf.name;
 
-        var oIcon = document.createElement("img");
+        const oIcon = document.createElement("img");
         oIcon.setAttribute("id", this.obj.conf.object_id + "-icon");
         oIcon.className = "icon";
         this.obj.trigger_obj = oIcon;
@@ -61,10 +61,11 @@ var ElementIcon = Element.extend({
         // An icon size might be either one integer for even sized images or
         // two integers for differen height/width images
         if (this.obj.conf.icon_size) {
-            var size = this.obj.conf.icon_size;
+            const size = this.obj.conf.icon_size;
+            let w, h;
             if (size.length == 1) {
-                var w = parseInt(size),
-                    h = parseInt(size);
+                w = parseInt(size);
+                h = parseInt(size);
             } else {
                 w = parseInt(size[0]);
                 h = parseInt(size[1]);
@@ -88,7 +89,7 @@ var ElementIcon = Element.extend({
 
         addZoomHandler(oIcon);
 
-        var oIconDiv = document.createElement("div");
+        const oIconDiv = document.createElement("div");
         this.dom_obj = oIconDiv;
         this.place();
 
@@ -101,7 +102,7 @@ var ElementIcon = Element.extend({
 
         // Parse link only when set
         if (this.obj.conf.url && this.obj.conf.url !== "" && this.obj.conf.url !== "#") {
-            var oIconLink = document.createElement("a");
+            const oIconLink = document.createElement("a");
             oIconLink.href = this.obj.conf.url;
             oIconLink.target = this.obj.conf.url_target;
             oIconLink.appendChild(oIcon);

--- a/share/frontend/nagvis-js/js/ElementLabel.js
+++ b/share/frontend/nagvis-js/js/ElementLabel.js
@@ -24,29 +24,32 @@
 var ElementLabel = Element.extend({
     label_text: null,
 
-    update: function() {
-        this.label_text = this.obj.conf.label_text || '';
+    update: function () {
+        this.label_text = this.obj.conf.label_text || "";
 
         // Replace configuration based macros in label_text when needed
-        if (this.label_text && this.label_text !== '') {
+        if (this.label_text && this.label_text !== "") {
             var objName;
             // For maps use the alias as display string
-            if (this.obj.conf.type == 'map') {
+            if (this.obj.conf.type == "map") {
                 objName = this.obj.conf.alias;
             } else {
                 objName = this.obj.conf.name;
             }
 
-            this.label_text = this.label_text.replace(getRegEx('name', '\\[name\\]', 'g'), objName);
-            this.label_text = this.label_text.replace(getRegEx('alias', '\\[alias\\]', 'g'), this.obj.conf.alias);
+            this.label_text = this.label_text.replace(getRegEx("name", "\\[name\\]", "g"), objName);
+            this.label_text = this.label_text.replace(getRegEx("alias", "\\[alias\\]", "g"), this.obj.conf.alias);
 
-            if (this.obj.conf.type == 'service') {
-                this.label_text = this.label_text.replace(getRegEx('service_description', '\\[service_description\\]', 'g'), this.obj.conf.service_description);
+            if (this.obj.conf.type == "service") {
+                this.label_text = this.label_text.replace(
+                    getRegEx("service_description", "\\[service_description\\]", "g"),
+                    this.obj.conf.service_description
+                );
             }
         }
     },
 
-    updateAttrs: function(only_state) {
+    updateAttrs: function (only_state) {
         // update the label on every state update where at least the output or perfdata changed
         if (!only_state || (!this.obj.stateChanged() && this.obj.outputOrPerfdataChanged())) {
             this.erase();
@@ -67,33 +70,37 @@ var ElementLabel = Element.extend({
         }
     },
 
-    render: function() {
+    render: function () {
         this.dom_obj = renderNagVisTextbox(
-            this.obj.conf.object_id + '-label',
-            this.obj.conf.label_background, this.obj.conf.label_border,
-            0, 0,
+            this.obj.conf.object_id + "-label",
+            this.obj.conf.label_background,
+            this.obj.conf.label_border,
+            0,
+            0,
             this.obj.conf.z,
-            this.obj.conf.label_width, '', this.getText(),
+            this.obj.conf.label_width,
+            "",
+            this.getText(),
             this.obj.conf.label_style
         );
     },
 
     unlock: function () {
-        addEvent(this.dom_obj, 'mouseover', function() {
-            document.body.style.cursor = 'move';
+        addEvent(this.dom_obj, "mouseover", function () {
+            document.body.style.cursor = "move";
         });
-        addEvent(this.dom_obj, 'mouseout', function() {
-            document.body.style.cursor = 'auto';
+        addEvent(this.dom_obj, "mouseout", function () {
+            document.body.style.cursor = "auto";
         });
 
-	makeDragable(this.dom_obj, this.obj, this.saveLabel, this.dragLabel);
+        makeDragable(this.dom_obj, this.obj, this.saveLabel, this.dragLabel);
     },
 
     lock: function () {
         this.dom_obj.onmouseover = null;
         this.dom_obj.onmouseout = null;
 
-	makeUndragable(this.dom_obj);
+        makeUndragable(this.dom_obj);
     },
 
     /**
@@ -103,8 +110,8 @@ var ElementLabel = Element.extend({
      * to realize the center/bottom coordinate definitions.
      */
     place: function () {
-        this.dom_obj.style.left = this.parseLabelCoord('x') + 'px';
-        this.dom_obj.style.top  = this.parseLabelCoord('y') + 'px';
+        this.dom_obj.style.left = this.parseLabelCoord("x") + "px";
+        this.dom_obj.style.top = this.parseLabelCoord("y") + "px";
     },
 
     //
@@ -116,16 +123,16 @@ var ElementLabel = Element.extend({
         var text = this.label_text;
 
         // Replace static macros in label_text when needed
-        if (text && text !== '') {
-            text = text.replace(getRegEx('output', '\\[output\\]', 'g'), this.obj.conf.output);
+        if (text && text !== "") {
+            text = text.replace(getRegEx("output", "\\[output\\]", "g"), this.obj.conf.output);
 
-            if (this.obj.conf.type == 'service' || this.obj.conf.type == 'host') {
-                text = text.replace(getRegEx('perfdata', '\\[perfdata\\]', 'g'), this.obj.conf.perfdata);
+            if (this.obj.conf.type == "service" || this.obj.conf.type == "host") {
+                text = text.replace(getRegEx("perfdata", "\\[perfdata\\]", "g"), this.obj.conf.perfdata);
             }
         }
 
         if (this.obj.conf.label_maxlen > 0 && text.length > this.obj.conf.label_maxlen)
-            text = text.substr(0, this.obj.conf.label_maxlen - 2) + '...';
+            text = text.substr(0, this.obj.conf.label_maxlen - 2) + "...";
 
         return text;
     },
@@ -135,8 +142,8 @@ var ElementLabel = Element.extend({
      * then create a new coord (relative/absolue) and save them in label_x/y attributes
      */
     // Important: It is called from an event handler the 'this.' keyword can not be used here.
-    dragLabel: function(trigger_obj, obj, event) {
-        var isRelative = function(coord) {
+    dragLabel: function (trigger_obj, obj, event) {
+        var isRelative = function (coord) {
             return coord.toString().match(/^(?:\+|\-|center|bottom)/);
         };
 
@@ -144,59 +151,54 @@ var ElementLabel = Element.extend({
         var calcNewLabelCoord = function (labelCoord, coord, newCoord) {
             if (isRelative(labelCoord)) {
                 var ret = newCoord - coord;
-                if(ret >= 0)
-                    return '+' + ret;
+                if (ret >= 0) return "+" + ret;
                 return ret;
-            } else
-                return newCoord;
+            } else return newCoord;
         };
 
-        obj.conf.label_x = calcNewLabelCoord(obj.conf.label_x,
-                                             obj.parseCoord(obj.conf.x, 'x', false), trigger_obj.x);
-        obj.conf.label_y = calcNewLabelCoord(obj.conf.label_y,
-                                             obj.parseCoord(obj.conf.y, 'y', false), trigger_obj.y);
+        obj.conf.label_x = calcNewLabelCoord(obj.conf.label_x, obj.parseCoord(obj.conf.x, "x", false), trigger_obj.x);
+        obj.conf.label_y = calcNewLabelCoord(obj.conf.label_y, obj.parseCoord(obj.conf.y, "y", false), trigger_obj.y);
 
-        if (isRelative(obj.conf.label_x) || isRelative(obj.conf.label_y))
-            obj.highlight(true);
+        if (isRelative(obj.conf.label_x) || isRelative(obj.conf.label_y)) obj.highlight(true);
     },
 
     // Important: It is called from an event handler the 'this.' keyword can not be used here.
-    saveLabel: function(trigger_obj, obj, oParent) {
+    saveLabel: function (trigger_obj, obj, oParent) {
         saveObjectAttr(obj.conf.object_id, {
-            'label_x': obj.conf.label_x,
-            'label_y': obj.conf.label_y
+            label_x: obj.conf.label_x,
+            label_y: obj.conf.label_y
         });
         obj.highlight(false);
     },
 
     parseLabelCoord: function (dir) {
-        if (dir === 'x') {
+        if (dir === "x") {
             var coord = this.obj.conf.label_x;
 
-            if (this.obj.conf.view_type && this.obj.conf.view_type == 'line') {
-                var obj_coord = this.obj.getLineMid(this.obj.conf.x, 'x');
+            if (this.obj.conf.view_type && this.obj.conf.view_type == "line") {
+                var obj_coord = this.obj.getLineMid(this.obj.conf.x, "x");
             } else {
-                var obj_coord = addZoomFactor(this.obj.parseCoords(this.obj.conf.x, 'x', false)[0], true);
+                var obj_coord = addZoomFactor(this.obj.parseCoords(this.obj.conf.x, "x", false)[0], true);
             }
         } else {
             var coord = this.obj.conf.label_y;
-            if (this.obj.conf.view_type && this.obj.conf.view_type == 'line') {
-                var obj_coord = this.obj.getLineMid(this.obj.conf.y, 'y');
+            if (this.obj.conf.view_type && this.obj.conf.view_type == "line") {
+                var obj_coord = this.obj.getLineMid(this.obj.conf.y, "y");
             } else {
-                var obj_coord = addZoomFactor(this.obj.parseCoords(this.obj.conf.y, 'y', false)[0], true);
+                var obj_coord = addZoomFactor(this.obj.parseCoords(this.obj.conf.y, "y", false)[0], true);
             }
         }
 
-        if (dir == 'x' && coord && coord.toString() == 'center') {
+        if (dir == "x" && coord && coord.toString() == "center") {
             var diff = parseInt(parseInt(this.dom_obj.clientWidth) - rmZoomFactor(this.obj.getObjWidth())) / 2;
             coord = obj_coord - diff;
-        } else if (dir == 'y' && coord && coord.toString() == 'bottom') {
+        } else if (dir == "y" && coord && coord.toString() == "bottom") {
             coord = obj_coord + rmZoomFactor(this.obj.getObjHeight());
         } else if (coord && coord.toString().match(/^(?:\+|\-)/)) {
             // If there is a presign it should be relative to the objects x/y
             coord = obj_coord + addZoomFactor(parseFloat(coord));
-        } else if (!coord || coord === '0') {
-           // If no x/y coords set, fallback to object x/y
+        } else if (!coord || coord === "0") {
+            // If no x/y coords set, fallback to object x/y
             coord = obj_coord;
         } else {
             // This must be absolute coordinates, apply zoom factor

--- a/share/frontend/nagvis-js/js/ElementLabel.js
+++ b/share/frontend/nagvis-js/js/ElementLabel.js
@@ -172,20 +172,21 @@ var ElementLabel = Element.extend({
     },
 
     parseLabelCoord: function (dir) {
+        var coord, obj_coord;
         if (dir === "x") {
-            var coord = this.obj.conf.label_x;
+            coord = this.obj.conf.label_x;
 
             if (this.obj.conf.view_type && this.obj.conf.view_type == "line") {
-                var obj_coord = this.obj.getLineMid(this.obj.conf.x, "x");
+                obj_coord = this.obj.getLineMid(this.obj.conf.x, "x");
             } else {
-                var obj_coord = addZoomFactor(this.obj.parseCoords(this.obj.conf.x, "x", false)[0], true);
+                obj_coord = addZoomFactor(this.obj.parseCoords(this.obj.conf.x, "x", false)[0], true);
             }
         } else {
-            var coord = this.obj.conf.label_y;
+            coord = this.obj.conf.label_y;
             if (this.obj.conf.view_type && this.obj.conf.view_type == "line") {
-                var obj_coord = this.obj.getLineMid(this.obj.conf.y, "y");
+                obj_coord = this.obj.getLineMid(this.obj.conf.y, "y");
             } else {
-                var obj_coord = addZoomFactor(this.obj.parseCoords(this.obj.conf.y, "y", false)[0], true);
+                obj_coord = addZoomFactor(this.obj.parseCoords(this.obj.conf.y, "y", false)[0], true);
             }
         }
 

--- a/share/frontend/nagvis-js/js/ElementLabel.js
+++ b/share/frontend/nagvis-js/js/ElementLabel.js
@@ -144,7 +144,7 @@ var ElementLabel = Element.extend({
     // Important: It is called from an event handler the 'this.' keyword can not be used here.
     dragLabel: function (trigger_obj, obj, event) {
         var isRelative = function (coord) {
-            return coord.toString().match(/^(?:\+|\-|center|bottom)/);
+            return coord.toString().match(/^(?:\+|-|center|bottom)/);
         };
 
         // Calculates relative/absolute coords depending on the current configured type
@@ -194,7 +194,7 @@ var ElementLabel = Element.extend({
             coord = obj_coord - diff;
         } else if (dir == "y" && coord && coord.toString() == "bottom") {
             coord = obj_coord + rmZoomFactor(this.obj.getObjHeight());
-        } else if (coord && coord.toString().match(/^(?:\+|\-)/)) {
+        } else if (coord && coord.toString().match(/^(?:\+|-)/)) {
             // If there is a presign it should be relative to the objects x/y
             coord = obj_coord + addZoomFactor(parseFloat(coord));
         } else if (!coord || coord === "0") {

--- a/share/frontend/nagvis-js/js/ElementLabel.js
+++ b/share/frontend/nagvis-js/js/ElementLabel.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var ElementLabel = Element.extend({
+const ElementLabel = Element.extend({
     label_text: null,
 
     update: function () {
@@ -29,7 +29,7 @@ var ElementLabel = Element.extend({
 
         // Replace configuration based macros in label_text when needed
         if (this.label_text && this.label_text !== "") {
-            var objName;
+            let objName;
             // For maps use the alias as display string
             if (this.obj.conf.type == "map") {
                 objName = this.obj.conf.alias;
@@ -120,7 +120,7 @@ var ElementLabel = Element.extend({
 
     // Returns the label with even state based macros replaced
     getText: function () {
-        var text = this.label_text;
+        let text = this.label_text;
 
         // Replace static macros in label_text when needed
         if (text && text !== "") {
@@ -143,14 +143,14 @@ var ElementLabel = Element.extend({
      */
     // Important: It is called from an event handler the 'this.' keyword can not be used here.
     dragLabel: function (trigger_obj, obj, event) {
-        var isRelative = function (coord) {
+        const isRelative = function (coord) {
             return coord.toString().match(/^(?:\+|-|center|bottom)/);
         };
 
         // Calculates relative/absolute coords depending on the current configured type
-        var calcNewLabelCoord = function (labelCoord, coord, newCoord) {
+        const calcNewLabelCoord = function (labelCoord, coord, newCoord) {
             if (isRelative(labelCoord)) {
-                var ret = newCoord - coord;
+                const ret = newCoord - coord;
                 if (ret >= 0) return "+" + ret;
                 return ret;
             } else return newCoord;
@@ -172,7 +172,7 @@ var ElementLabel = Element.extend({
     },
 
     parseLabelCoord: function (dir) {
-        var coord, obj_coord;
+        let coord, obj_coord;
         if (dir === "x") {
             coord = this.obj.conf.label_x;
 
@@ -191,7 +191,7 @@ var ElementLabel = Element.extend({
         }
 
         if (dir == "x" && coord && coord.toString() == "center") {
-            var diff = parseInt(parseInt(this.dom_obj.clientWidth) - rmZoomFactor(this.obj.getObjWidth())) / 2;
+            const diff = parseInt(parseInt(this.dom_obj.clientWidth) - rmZoomFactor(this.obj.getObjWidth())) / 2;
             coord = obj_coord - diff;
         } else if (dir == "y" && coord && coord.toString() == "bottom") {
             coord = obj_coord + rmZoomFactor(this.obj.getObjHeight());

--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -946,10 +946,10 @@ var ElementLine = Element.extend({
         if (!perfdata) return [];
 
         // Clean up perfdata
-        perfdata = perfdata.replace("/\s*=\s*/", "=");
+        perfdata = perfdata.replace(/\s*=\s*/, "=");
 
         // Break perfdata string into array of individual sets
-        var re = /([^=]+)=([\d\.\-]+)([\w%]*);?([\d\.\-:~@]+)?;?([\d\.\-:~@]+)?;?([\d\.\-]+)?;?([\d\.\-]+)?\s*/g;
+        var re = /([^=]+)=([\d\.\-]+)([\w%]*);?([\d\.\-:~@]+)?;?([\d\.\-:~@]+)?;?([\d\.\-]+)?;?([\d\.\-]+)?\s*/g; // eslint-disable-line no-useless-escape
         var perfdataMatches = perfdata.match(re);
 
         // Check for empty perfdata
@@ -959,7 +959,7 @@ var ElementLine = Element.extend({
         for (var i = 0; i < perfdataMatches.length; i++) {
             // Get parts of perfdata from string
             var tmpSetMatches = perfdataMatches[i].match(
-                /(&#145;)?([\w\s\=\'\-]*)(&#145;)?\=([\d\.\-\+]*)([\w%]*)[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-\+]*)[\;|\s]?([\d\.\-\+]*)/
+                /(&#145;)?([\w\s\=\'\-]*)(&#145;)?\=([\d\.\-\+]*)([\w%]*)[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-\+]*)[\;|\s]?([\d\.\-\+]*)/ // eslint-disable-line no-useless-escape
             );
 
             // Check if we got any perfdata

--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -201,8 +201,8 @@ var ElementLineControls = Element.extend({
         }
 
         var parts = g_view.unproject(this.obj.conf.x.toString().split(","), this.obj.conf.y.toString().split(","));
-        var x = parts[0].join(",");
-        var y = parts[1].join(",");
+        x = parts[0].join(",");
+        y = parts[1].join(",");
 
         // send to server
         saveObjectAttr(this.obj.conf.object_id, { x: x, y: y });
@@ -306,7 +306,7 @@ var ElementLine = Element.extend({
             oLink.className = "linelink";
             this.obj.trigger_obj = oLink;
         } else {
-            var oLink = this.obj.trigger_obj;
+            oLink = this.obj.trigger_obj;
             this.clearActionContainer();
         }
         this.dom_obj.appendChild(oLink);
@@ -377,8 +377,8 @@ var ElementLine = Element.extend({
                     var xMid = middle(xStart, xEnd, cut);
                     var yMid = middle(yStart, yEnd, cut);
                 } else {
-                    var xMid = x[1];
-                    var yMid = y[1];
+                    xMid = x[1];
+                    yMid = y[1];
                 }
 
                 this.renderArrow(0, xStart, yStart, xMid, yMid, width);
@@ -509,7 +509,7 @@ var ElementLine = Element.extend({
         ctx.clearRect(0, 0, canvas.width, canvas.height);
 
         var part;
-        for (var i = 0, len = this.parts.length; i < len; i++) {
+        for (i = 0, len = this.parts.length; i < len; i++) {
             part = this.parts[i];
 
             ctx.fillStyle = part[4][0];

--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var ElementLineControls = Element.extend({
+const ElementLineControls = Element.extend({
     render: function () {
         // don't render the controls during normal render calls. We
         // want to keep the number of DOM objects low, so only render
@@ -62,15 +62,15 @@ var ElementLineControls = Element.extend({
     },
 
     _render: function () {
-        var container = document.createElement("div");
+        const container = document.createElement("div");
         container.setAttribute("id", this.obj.conf.object_id + "-controls");
         this.dom_obj = container;
 
-        var x = this.obj.parseCoords(this.obj.conf.x, "x");
-        var y = this.obj.parseCoords(this.obj.conf.y, "y");
-        var size = 10;
+        const x = this.obj.parseCoords(this.obj.conf.x, "x");
+        const y = this.obj.parseCoords(this.obj.conf.y, "y");
+        const size = 10;
 
-        for (var i = 0, l = x.length; i < l; i++) this.renderDragger(i, x[i], y[i], -size / 2, -size / 2, size);
+        for (let i = 0, l = x.length; i < l; i++) this.renderDragger(i, x[i], y[i], -size / 2, -size / 2, size);
 
         if (this.hasTwoParts())
             this.renderMidToggle(
@@ -94,7 +94,7 @@ var ElementLineControls = Element.extend({
     },
 
     renderDragger: function (num, objX, objY, offX, offY, size) {
-        var ctl = document.createElement("div");
+        const ctl = document.createElement("div");
         this.dom_obj.appendChild(ctl);
         ctl.setAttribute("id", this.obj.conf.object_id + "-drag-" + num);
         ctl.className = "control drag";
@@ -108,7 +108,7 @@ var ElementLineControls = Element.extend({
         ctl.objOffsetX = offX;
         ctl.objOffsetY = offY;
 
-        var img = document.createElement("img");
+        const img = document.createElement("img");
         img.src = "../../frontend/nagvis-js/images/internal/control_drag.png";
         img.style.width = addZoomFactor(size) + "px";
         img.style.height = addZoomFactor(size) + "px";
@@ -119,7 +119,7 @@ var ElementLineControls = Element.extend({
 
     // Adds the modify button to the controls including all eventhandlers
     renderMidToggle: function (num, objX, objY, offX, offY, size) {
-        var ctl = document.createElement("div");
+        let ctl = document.createElement("div");
         this.dom_obj.appendChild(ctl);
         ctl.setAttribute("id", this.obj.conf.object_id + "-togglemid-" + num);
         ctl.className = "control togglemid";
@@ -134,7 +134,7 @@ var ElementLineControls = Element.extend({
         ctl.objOffsetX = offX;
         ctl.objOffsetY = offY;
 
-        var img = document.createElement("img");
+        const img = document.createElement("img");
         if (this.isMidLocked()) img.src = "../../frontend/nagvis-js/images/internal/control_locked.png";
         else img.src = "../../frontend/nagvis-js/images/internal/control_unlocked.png";
         img.style.width = addZoomFactor(size) + "px";
@@ -167,8 +167,8 @@ var ElementLineControls = Element.extend({
      */
     toggleMidLock: function () {
         // What is the current state?
-        var x = this.obj.conf.x.split(",");
-        var y = this.obj.conf.y.split(",");
+        let x = this.obj.conf.x.split(",");
+        let y = this.obj.conf.y.split(",");
 
         if (this.isMidLocked()) {
             // The line has 2 coords configured
@@ -200,7 +200,7 @@ var ElementLineControls = Element.extend({
             this.obj.conf.y = [y[0], y[2]].join(",");
         }
 
-        var parts = g_view.unproject(this.obj.conf.x.toString().split(","), this.obj.conf.y.toString().split(","));
+        const parts = g_view.unproject(this.obj.conf.x.toString().split(","), this.obj.conf.y.toString().split(","));
         x = parts[0].join(",");
         y = parts[1].join(",");
 
@@ -212,7 +212,7 @@ var ElementLineControls = Element.extend({
     }
 });
 
-var ElementLine = Element.extend({
+const ElementLine = Element.extend({
     line_container: null,
     parts: null,
     canvas: null,
@@ -244,13 +244,13 @@ var ElementLine = Element.extend({
     render: function () {
         if (this.isWeathermapLine()) this.parsePerfdata();
 
-        var container = document.createElement("div");
+        const container = document.createElement("div");
         container.setAttribute("id", this.obj.conf.object_id + "-linediv");
         container.className = "line";
         this.dom_obj = container;
 
         // Create line div
-        var oLineDiv = document.createElement("div");
+        const oLineDiv = document.createElement("div");
         this.line_container = oLineDiv;
         container.appendChild(oLineDiv);
         oLineDiv.setAttribute("id", this.obj.conf.object_id + "-line");
@@ -284,7 +284,7 @@ var ElementLine = Element.extend({
     redrawLine: function () {
         // Totally redraw the line when moving the line anchors arround. But keep the trigger
         // object because it saves the attached event handlers
-        var trigger_obj = this.obj.trigger_obj;
+        const trigger_obj = this.obj.trigger_obj;
         trigger_obj.parentNode.removeChild(trigger_obj);
         this.clearActionContainer();
 
@@ -300,8 +300,9 @@ var ElementLine = Element.extend({
         // the line is using erase(), render(), draw() within place() which is called while
         // the user moves the object, this dom node must not be re-created, because this
         // would remove all event handlers
+        let oLink;
         if (!this.obj.trigger_obj) {
-            var oLink = document.createElement("a");
+            oLink = document.createElement("a");
             oLink.setAttribute("id", this.obj.conf.object_id + "-linelink");
             oLink.className = "linelink";
             this.obj.trigger_obj = oLink;
@@ -331,21 +332,21 @@ var ElementLine = Element.extend({
     calcLineParts: function () {
         this.parts = [];
 
-        var x = this.obj.parseCoords(this.obj.conf.x, "x");
-        var y = this.obj.parseCoords(this.obj.conf.y, "y");
+        const x = this.obj.parseCoords(this.obj.conf.x, "x");
+        const y = this.obj.parseCoords(this.obj.conf.y, "y");
 
         // Convert all coords to int
-        for (var i = 0; i < x.length; i++) {
+        for (let i = 0; i < x.length; i++) {
             x[i] = parseInt(x[i], 10);
             y[i] = parseInt(y[i], 10);
         }
 
-        var xStart = x[0];
-        var yStart = y[0];
-        var xEnd = x[x.length - 1];
-        var yEnd = y[y.length - 1];
+        let xStart = x[0];
+        let yStart = y[0];
+        let xEnd = x[x.length - 1];
+        let yEnd = y[y.length - 1];
 
-        let adjustedPoints = this.cutLineBeyondViewport(xStart, yStart, xEnd, yEnd);
+        const adjustedPoints = this.cutLineBeyondViewport(xStart, yStart, xEnd, yEnd);
         if (adjustedPoints === null) {
             return; // Line won't be visible -> this.parts left empty -> no rendering
         }
@@ -355,11 +356,11 @@ var ElementLine = Element.extend({
         xEnd = adjustedPoints[2];
         yEnd = adjustedPoints[3];
 
-        var width = addZoomFactor(this.obj.conf.line_width);
+        let width = addZoomFactor(this.obj.conf.line_width);
         if (width <= 0) width = 1; // minimal width for lines
 
         // Lines meeting point position
-        var cut = this.obj.conf.line_cut;
+        const cut = this.obj.conf.line_cut;
 
         switch (this.obj.conf.line_type) {
             case "11": // ---> lines
@@ -371,11 +372,12 @@ var ElementLine = Element.extend({
             case "10":
             case "13":
             case "14":
-            case "15":
+            case "15": {
                 // two part lines
+                let xMid, yMid;
                 if (x.length == 2) {
-                    var xMid = middle(xStart, xEnd, cut);
-                    var yMid = middle(yStart, yEnd, cut);
+                    xMid = middle(xStart, xEnd, cut);
+                    yMid = middle(yStart, yEnd, cut);
                 } else {
                     xMid = x[1];
                     yMid = y[1];
@@ -384,6 +386,7 @@ var ElementLine = Element.extend({
                 this.renderArrow(0, xStart, yStart, xMid, yMid, width);
                 this.renderArrow(1, xEnd, yEnd, xMid, yMid, width);
                 break;
+            }
             default:
                 alert("Error: Unknown line type");
         }
@@ -391,8 +394,8 @@ var ElementLine = Element.extend({
 
     // Calculates the colors of a line part
     calcColors: function (id) {
-        var color = "#FFCC66";
-        var border_color = "#000000";
+        let color = "#FFCC66";
+        const border_color = "#000000";
 
         // Get the fill color depending on the object state
         switch (this.obj.conf.summary_state) {
@@ -441,19 +444,19 @@ var ElementLine = Element.extend({
             return;
         }
 
-        var allX = [],
+        let allX = [],
             allY = [];
-        for (var i = 0, len = this.parts.length; i < len; i++) {
+        for (let i = 0, len = this.parts.length; i < len; i++) {
             allX = allX.concat(this.parts[i][2]);
             allY = allY.concat(this.parts[i][3]);
         }
-        var xMin = min(allX);
-        var yMin = min(allY);
-        var xMax = max(allX);
-        var yMax = max(allY);
-        var border = 5;
+        const xMin = min(allX);
+        const yMin = min(allY);
+        const xMax = max(allX);
+        const yMax = max(allY);
+        const border = 5;
 
-        var canvas = document.createElement("canvas");
+        const canvas = document.createElement("canvas");
         this.canvas = canvas;
 
         if (!canvas.getContext) return; // FIXME: Show an error message?
@@ -472,25 +475,25 @@ var ElementLine = Element.extend({
 
         addEvent(canvas, "mousemove", this.handleMouseMove.bind(this));
 
-        var ctx = canvas.getContext("2d");
+        const ctx = canvas.getContext("2d");
         if (!ctx) return; // silently skip
 
         // On high resolution devices like e.g. 4k screens where
         // the page is not rendered 1:1 but instead shown scaled,
         // the renderd lines look bad if they had been rendered 1:1.
         // Fix this by scaling the whole canvas.
-        var devicePixelRatio = window.devicePixelRatio || 1;
-        var backingStoreRatio =
+        const devicePixelRatio = window.devicePixelRatio || 1;
+        const backingStoreRatio =
             ctx.webkitBackingStorePixelRatio ||
             ctx.mozBackingStorePixelRatio ||
             ctx.msBackingStorePixelRatio ||
             ctx.oBackingStorePixelRatio ||
             ctx.backingStorePixelRatio ||
             1;
-        var ratio = devicePixelRatio / backingStoreRatio;
+        const ratio = devicePixelRatio / backingStoreRatio;
         if (devicePixelRatio !== backingStoreRatio) {
-            var oldWidth = canvas.width;
-            var oldHeight = canvas.height;
+            const oldWidth = canvas.width;
+            const oldHeight = canvas.height;
 
             canvas.width = oldWidth * ratio;
             canvas.height = oldHeight * ratio;
@@ -508,8 +511,8 @@ var ElementLine = Element.extend({
         // Then start painting the single line parts
         ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-        var part;
-        for (i = 0, len = this.parts.length; i < len; i++) {
+        let part;
+        for (let i = 0, len = this.parts.length; i < len; i++) {
             part = this.parts[i];
 
             ctx.fillStyle = part[4][0];
@@ -517,7 +520,7 @@ var ElementLine = Element.extend({
             ctx.beginPath();
             ctx.moveTo(part[2][0] - xMin + border, part[3][0] - yMin + border);
 
-            for (var a = 1, len2 = part[2].length; a < len2; a++)
+            for (let a = 1, len2 = part[2].length; a < len2; a++)
                 ctx.lineTo(part[2][a] - xMin + border, part[3][a] - yMin + border);
 
             ctx.fill();
@@ -532,7 +535,7 @@ var ElementLine = Element.extend({
     // This function renders an arrow like it is used on NagVis maps
     // It renders following line types: --->
     renderArrow: function (id, x1, y1, x2, y2, w) {
-        var xCoord = [
+        const xCoord = [
             x1 + newX(x2 - x1, y2 - y1, 0, w),
             x2 + newX(x2 - x1, y2 - y1, -4 * w, w),
             x2 + newX(x2 - x1, y2 - y1, -4 * w, 2 * w),
@@ -542,7 +545,7 @@ var ElementLine = Element.extend({
             x1 + newX(x2 - x1, y2 - y1, 0, -w),
             x1 + newX(x2 - x1, y2 - y1, 0, w)
         ];
-        var yCoord = [
+        const yCoord = [
             y1 + newY(x2 - x1, y2 - y1, 0, w),
             y2 + newY(x2 - x1, y2 - y1, -4 * w, w),
             y2 + newY(x2 - x1, y2 - y1, -4 * w, 2 * w),
@@ -558,14 +561,14 @@ var ElementLine = Element.extend({
 
     // This function renders simple lines (without arrow)
     renderSimpleLine: function (id, x1, y1, x2, y2, w) {
-        var xCoord = [
+        const xCoord = [
             x1 + newX(x2 - x1, y2 - y1, 0, w),
             x2 + newX(x2 - x1, y2 - y1, w, w),
             x2 + newX(x2 - x1, y2 - y1, w, -w),
             x1 + newX(x2 - x1, y2 - y1, 0, -w),
             x1 + newX(x2 - x1, y2 - y1, 0, w)
         ];
-        var yCoord = [
+        const yCoord = [
             y1 + newY(x2 - x1, y2 - y1, 0, w),
             y2 + newY(x2 - x1, y2 - y1, w, w),
             y2 + newY(x2 - x1, y2 - y1, w, -w),
@@ -586,16 +589,16 @@ var ElementLine = Element.extend({
         if (getTargetRaw(event).tagName !== "CANVAS") return true;
 
         // document.body.scrollTop does not work in IE
-        var scrollTop = document.body.scrollTop ? document.body.scrollTop : document.documentElement.scrollTop;
-        var scrollLeft = document.body.scrollLeft ? document.body.scrollLeft : document.documentElement.scrollLeft;
+        const scrollTop = document.body.scrollTop ? document.body.scrollTop : document.documentElement.scrollTop;
+        const scrollLeft = document.body.scrollLeft ? document.body.scrollLeft : document.documentElement.scrollLeft;
 
         // Get the mouse position relative to window
-        var x = event.clientX - getSidebarWidth() + scrollLeft;
-        var y = event.clientY - getHeaderHeight() + scrollTop;
+        const x = event.clientX - getSidebarWidth() + scrollLeft;
+        const y = event.clientY - getHeaderHeight() + scrollTop;
 
         // Check whether or not the given coord is within the line part coords
-        var pnpoly = function (nvert, vertx, verty, testx, testy) {
-            var i,
+        const pnpoly = function (nvert, vertx, verty, testx, testy) {
+            let i,
                 j,
                 c = false;
             for (i = 0, j = nvert - 1; i < nvert; j = i++) {
@@ -609,9 +612,9 @@ var ElementLine = Element.extend({
             return c;
         };
 
-        var part = null,
+        let part = null,
             over = false;
-        for (var i = 0, len = this.parts.length; i < len; i++) {
+        for (let i = 0, len = this.parts.length; i < len; i++) {
             part = this.parts[i];
             if (pnpoly(part[2].length, part[2], part[3], x, y)) {
                 over = true;
@@ -653,19 +656,19 @@ var ElementLine = Element.extend({
         if (this.parts.length === 0) return;
         if (this.perfdata === null) return;
 
-        var y_offset = parseInt(this.obj.conf.line_label_y_offset);
+        const y_offset = parseInt(this.obj.conf.line_label_y_offset);
 
-        var x1 = this.parts[id][0][0],
+        const x1 = this.parts[id][0][0],
             y1 = this.parts[id][0][1],
             x2 = this.parts[id][1][0],
             y2 = this.parts[id][1][1];
 
-        var cut = id == 0 ? this.obj.conf.line_label_pos_in : this.obj.conf.line_label_pos_out;
+        const cut = id == 0 ? this.obj.conf.line_label_pos_in : this.obj.conf.line_label_pos_out;
 
-        var x = middle(x1, x2, cut),
+        const x = middle(x1, x2, cut),
             y = middle(y1, y2, cut) + y_offset;
 
-        var txt;
+        let txt;
         if (this.obj.conf.line_type == 13 || this.obj.conf.line_type == 14) {
             // Show percentage label
             txt = this.perfdata[id][1] + this.perfdata[id][2];
@@ -675,8 +678,8 @@ var ElementLine = Element.extend({
         }
 
         // Maybe use function to detect the real height in future
-        var labelHeight = 21,
-            labelWidth = this.getLabelWidth(txt);
+        const labelHeight = 21;
+        let labelWidth = this.getLabelWidth(txt);
 
         this.obj.trigger_obj.appendChild(
             renderNagVisTextbox(
@@ -713,7 +716,7 @@ var ElementLine = Element.extend({
     },
 
     renderLinkArea: function () {
-        var div = document.createElement("div");
+        const div = document.createElement("div");
         this.link_area = div;
         div.setAttribute("id", this.obj.conf.object_id + "-link");
         div.style.position = "absolute";
@@ -739,7 +742,7 @@ var ElementLine = Element.extend({
            5 = minimum
            6 = maximum
         */
-        var perf = this.parsePerfdataString();
+        let perf = this.parsePerfdataString();
 
         if (!perf) {
             this.addWeathermapLineError("Perfdata string is empty");
@@ -802,11 +805,11 @@ var ElementLine = Element.extend({
      * given percentage usage and on the configured options for this object
      */
     getColorFill: function (perc) {
-        var ranges = this.obj.conf.line_weather_colors.split(",");
+        let ranges = this.obj.conf.line_weather_colors.split(",");
         // 0 contains the percentage until this color is used
         // 1 contains the color to be used
-        for (var i = 0; i < ranges.length; i++) {
-            var parts = ranges[i].split(":");
+        for (let i = 0; i < ranges.length; i++) {
+            let parts = ranges[i].split(":");
             if (parseFloat(perc) <= parts[0]) return parts[1];
             parts = null;
         }
@@ -820,14 +823,14 @@ var ElementLine = Element.extend({
      * for calculating the percentage usage and also the current usage.
      */
     calculateUsage: function (oldPerfdata, output) {
-        var newPerfdata = [];
-        var foundNew = false;
-        var line_label_in = "in";
-        var line_label_out = "out";
+        const newPerfdata = [];
+        let foundNew = false;
+        let line_label_in = "in";
+        let line_label_out = "out";
 
         // Checkmk if/if64 checks support switching between bytes/bits.
-        var display_bits = false;
-        var reBits =
+        let display_bits = false;
+        const reBits =
             /\bIn(?:\s+average\s+[^:]+)?:\s*[0-9][0-9.,]*\s*\S*Bit\/s\b[\s\S]*?\bOut(?:\s+average\s+[^:]+)?:\s*[0-9][0-9.,]*\s*\S*Bit\/s\b/i;
 
         if (output.match(reBits)) {
@@ -842,7 +845,7 @@ var ElementLine = Element.extend({
         if (typeof this.obj.conf.line_label_out !== "undefined") {
             line_label_out = this.obj.conf.line_label_out;
         }
-        for (var i = 0; i < oldPerfdata.length; i++) {
+        for (let i = 0; i < oldPerfdata.length; i++) {
             if (oldPerfdata[i][0] == line_label_in && (oldPerfdata[i][2] === null || oldPerfdata[i][2] === "")) {
                 newPerfdata[0] = this.perfdataCalcPerc(oldPerfdata[i]);
                 if (!display_bits) {
@@ -872,9 +875,9 @@ var ElementLine = Element.extend({
      * Transform bits in a perfdata set to a human readable value
      */
     perfdataCalcBitsReadable: function (set, kiloMultiplier = 1000) {
-        var KB = kiloMultiplier;
-        var MB = kiloMultiplier * kiloMultiplier;
-        var GB = kiloMultiplier * kiloMultiplier * kiloMultiplier;
+        const KB = kiloMultiplier;
+        const MB = kiloMultiplier * kiloMultiplier;
+        const GB = kiloMultiplier * kiloMultiplier * kiloMultiplier;
         if (set[1] > GB) {
             set[1] /= GB;
             set[2] = "Gbit/s";
@@ -895,9 +898,9 @@ var ElementLine = Element.extend({
      * Transform bytes in a perfdata set to a human readable value
      */
     perfdataCalcBytesReadable: function (set, kiloMultiplier = 1000) {
-        var KB = kiloMultiplier;
-        var MB = kiloMultiplier * kiloMultiplier;
-        var GB = kiloMultiplier * kiloMultiplier * kiloMultiplier;
+        const KB = kiloMultiplier;
+        const MB = kiloMultiplier * kiloMultiplier;
+        const GB = kiloMultiplier * kiloMultiplier * kiloMultiplier;
         if (set[1] > GB) {
             set[1] /= GB;
             set[2] = "GB/s";
@@ -940,25 +943,25 @@ var ElementLine = Element.extend({
      *
      */
     parsePerfdataString: function () {
-        var parsed = [];
+        const parsed = [];
 
-        var perfdata = this.obj.conf.perfdata;
+        let perfdata = this.obj.conf.perfdata;
         if (!perfdata) return [];
 
         // Clean up perfdata
         perfdata = perfdata.replace(/\s*=\s*/, "=");
 
         // Break perfdata string into array of individual sets
-        var re = /([^=]+)=([\d\.\-]+)([\w%]*);?([\d\.\-:~@]+)?;?([\d\.\-:~@]+)?;?([\d\.\-]+)?;?([\d\.\-]+)?\s*/g; // eslint-disable-line no-useless-escape
-        var perfdataMatches = perfdata.match(re);
+        const re = /([^=]+)=([\d\.\-]+)([\w%]*);?([\d\.\-:~@]+)?;?([\d\.\-:~@]+)?;?([\d\.\-]+)?;?([\d\.\-]+)?\s*/g; // eslint-disable-line no-useless-escape
+        const perfdataMatches = perfdata.match(re);
 
         // Check for empty perfdata
         if (perfdataMatches == null) return [];
 
         // Break perfdata parts into array
-        for (var i = 0; i < perfdataMatches.length; i++) {
+        for (let i = 0; i < perfdataMatches.length; i++) {
             // Get parts of perfdata from string
-            var tmpSetMatches = perfdataMatches[i].match(
+            const tmpSetMatches = perfdataMatches[i].match(
                 /(&#145;)?([\w\s\=\'\-]*)(&#145;)?\=([\d\.\-\+]*)([\w%]*)[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-\+]*)[\;|\s]?([\d\.\-\+]*)/ // eslint-disable-line no-useless-escape
             );
 
@@ -992,7 +995,7 @@ var ElementLine = Element.extend({
     cutLineBeyondViewport: function (xA, yA, xB, yB) {
         if (!g_map) return [xA, yA, xB, yB]; // no viewport - no clipping
 
-        let viewport_size = g_map.getSize();
+        const viewport_size = g_map.getSize();
         const xMax = viewport_size.x; // 1920
         const yMax = viewport_size.y; // 1080
         const xTolerance = xMax * 0.95; // 1824 (95%)
@@ -1014,7 +1017,7 @@ var ElementLine = Element.extend({
         const y_max = yMax + yTolerance;
 
         // Function to compute region code
-        let regionCode = function (x, y) {
+        const regionCode = function (x, y) {
             let code = INSIDE;
 
             if (x < x_min)
@@ -1033,7 +1036,7 @@ var ElementLine = Element.extend({
             return code;
         };
 
-        let cohenSutherlandClip = function (x1, y1, x2, y2) {
+        const cohenSutherlandClip = function (x1, y1, x2, y2) {
             let code1 = regionCode(x1, y1);
             let code2 = regionCode(x2, y2);
 

--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -22,32 +22,29 @@
  *****************************************************************************/
 
 var ElementLineControls = Element.extend({
-    render: function() {
+    render: function () {
         // don't render the controls during normal render calls. We
         // want to keep the number of DOM objects low, so only render
         // them when being unlocked for the first time. But when the
         // element has already been rendered, then re-render it!
-        if (this.dom_obj)
-            this._render();
+        if (this.dom_obj) this._render();
     },
 
-    draw: function() {
+    draw: function () {
         // When locked: Don't draw on regular draw calls (only draw when locked/unlocked)
-        if (!this.obj.bIsLocked)
-            this.base();
+        if (!this.obj.bIsLocked) this.base();
     },
 
-    unlock: function() {
-        if (!this.dom_obj)
-            this._render();
+    unlock: function () {
+        if (!this.dom_obj) this._render();
         this._draw();
     },
 
-    lock: function() {
+    lock: function () {
         this.erase();
     },
 
-    place: function() {
+    place: function () {
         // FIXME: This should be possible without re-rendering everything
         if (!this.obj.bIsLocked) {
             this.erase();
@@ -60,58 +57,61 @@ var ElementLineControls = Element.extend({
     // END OF PUBLIC METHODS
     //
 
-    _draw: function() {
+    _draw: function () {
         Element.prototype.draw.call(this);
     },
 
-    _render: function() {
-        var container = document.createElement('div');
-        container.setAttribute('id', this.obj.conf.object_id+'-controls');
+    _render: function () {
+        var container = document.createElement("div");
+        container.setAttribute("id", this.obj.conf.object_id + "-controls");
         this.dom_obj = container;
 
-        var x = this.obj.parseCoords(this.obj.conf.x, 'x');
-        var y = this.obj.parseCoords(this.obj.conf.y, 'y');
+        var x = this.obj.parseCoords(this.obj.conf.x, "x");
+        var y = this.obj.parseCoords(this.obj.conf.y, "y");
         var size = 10;
 
-        for (var i = 0, l = x.length; i < l; i++)
-            this.renderDragger(i, x[i], y[i], - size / 2, - size / 2, size);
+        for (var i = 0, l = x.length; i < l; i++) this.renderDragger(i, x[i], y[i], -size / 2, -size / 2, size);
 
         if (this.hasTwoParts())
-            this.renderMidToggle(x.length+2,
-                this.obj.getLineMid(this.obj.conf.x, 'x'),
-                this.obj.getLineMid(this.obj.conf.y, 'y'),
+            this.renderMidToggle(
+                x.length + 2,
+                this.obj.getLineMid(this.obj.conf.x, "x"),
+                this.obj.getLineMid(this.obj.conf.y, "y"),
                 20 - size / 2,
                 -size / 2 + 5,
-                size);
+                size
+            );
     },
 
-    hasTwoParts: function() {
-        return this.obj.conf.view_type === 'line'
-               && (this.obj.conf.line_type == 10
-                   || this.obj.conf.line_type == 13
-                   || this.obj.conf.line_type == 14
-                   || this.obj.conf.line_type == 15);
+    hasTwoParts: function () {
+        return (
+            this.obj.conf.view_type === "line" &&
+            (this.obj.conf.line_type == 10 ||
+                this.obj.conf.line_type == 13 ||
+                this.obj.conf.line_type == 14 ||
+                this.obj.conf.line_type == 15)
+        );
     },
 
     renderDragger: function (num, objX, objY, offX, offY, size) {
-        var ctl = document.createElement('div');
+        var ctl = document.createElement("div");
         this.dom_obj.appendChild(ctl);
-        ctl.setAttribute('id', this.obj.conf.object_id+'-drag-' + num);
-        ctl.className = 'control drag';
+        ctl.setAttribute("id", this.obj.conf.object_id + "-drag-" + num);
+        ctl.className = "control drag";
         // FIXME: Multilanguage
-        ctl.title          = 'Move object';
-        ctl.style.zIndex   = parseInt(this.obj.conf.z)+1;
-        ctl.style.width    = addZoomFactor(size) + 'px';
-        ctl.style.height   = addZoomFactor(size) + 'px';
-        ctl.style.left     = (objX + offX) + 'px';
-        ctl.style.top      = (objY + offY) + 'px';
-        ctl.objOffsetX     = offX;
-        ctl.objOffsetY     = offY;
+        ctl.title = "Move object";
+        ctl.style.zIndex = parseInt(this.obj.conf.z) + 1;
+        ctl.style.width = addZoomFactor(size) + "px";
+        ctl.style.height = addZoomFactor(size) + "px";
+        ctl.style.left = objX + offX + "px";
+        ctl.style.top = objY + offY + "px";
+        ctl.objOffsetX = offX;
+        ctl.objOffsetY = offY;
 
-        var img = document.createElement('img');
-        img.src = '../../frontend/nagvis-js/images/internal/control_drag.png';
-        img.style.width    = addZoomFactor(size) + 'px';
-        img.style.height   = addZoomFactor(size) + 'px';
+        var img = document.createElement("img");
+        img.src = "../../frontend/nagvis-js/images/internal/control_drag.png";
+        img.style.width = addZoomFactor(size) + "px";
+        img.style.height = addZoomFactor(size) + "px";
         ctl.appendChild(img);
 
         makeDragable(ctl, this.obj, this.obj.saveObject, this.obj.moveObject);
@@ -119,45 +119,45 @@ var ElementLineControls = Element.extend({
 
     // Adds the modify button to the controls including all eventhandlers
     renderMidToggle: function (num, objX, objY, offX, offY, size) {
-        var ctl = document.createElement('div');
+        var ctl = document.createElement("div");
         this.dom_obj.appendChild(ctl);
-        ctl.setAttribute('id', this.obj.conf.object_id+'-togglemid-' + num);
-        ctl.className = 'control togglemid';
-	// FIXME: Multilanguage
-        if (this.obj.bIsLocked)
-	    ctl.title = 'Unlock line middle';
-        else
-	    ctl.title = 'Lock line middle';
-        ctl.style.zIndex   = parseInt(this.obj.conf.z)+1;
-        ctl.style.width    = addZoomFactor(size) + 'px';
-        ctl.style.height   = addZoomFactor(size) + 'px';
-        ctl.style.left     = (objX + offX) + 'px';
-        ctl.style.top      = (objY + offY) + 'px';
-        ctl.objOffsetX     = offX;
-        ctl.objOffsetY     = offY;
+        ctl.setAttribute("id", this.obj.conf.object_id + "-togglemid-" + num);
+        ctl.className = "control togglemid";
+        // FIXME: Multilanguage
+        if (this.obj.bIsLocked) ctl.title = "Unlock line middle";
+        else ctl.title = "Lock line middle";
+        ctl.style.zIndex = parseInt(this.obj.conf.z) + 1;
+        ctl.style.width = addZoomFactor(size) + "px";
+        ctl.style.height = addZoomFactor(size) + "px";
+        ctl.style.left = objX + offX + "px";
+        ctl.style.top = objY + offY + "px";
+        ctl.objOffsetX = offX;
+        ctl.objOffsetY = offY;
 
-        var img = document.createElement('img');
-        if (this.isMidLocked())
-            img.src = '../../frontend/nagvis-js/images/internal/control_locked.png';
-        else
-            img.src = '../../frontend/nagvis-js/images/internal/control_unlocked.png';
-        img.style.width    = addZoomFactor(size) + 'px';
-        img.style.height   = addZoomFactor(size) + 'px';
+        var img = document.createElement("img");
+        if (this.isMidLocked()) img.src = "../../frontend/nagvis-js/images/internal/control_locked.png";
+        else img.src = "../../frontend/nagvis-js/images/internal/control_unlocked.png";
+        img.style.width = addZoomFactor(size) + "px";
+        img.style.height = addZoomFactor(size) + "px";
         ctl.appendChild(img);
 
-        addEvent(ctl, 'click', function(element_obj) {
-            return function(event) {
-                event = event || window.event;
-                element_obj.toggleMidLock();
-	        contextHide();
-                return preventDefaultEvents(event);
-            };
-        }(this));
+        addEvent(
+            ctl,
+            "click",
+            (function (element_obj) {
+                return function (event) {
+                    event = event || window.event;
+                    element_obj.toggleMidLock();
+                    contextHide();
+                    return preventDefaultEvents(event);
+                };
+            })(this)
+        );
         ctl = null;
     },
 
-    isMidLocked: function() {
-        return this.obj.conf.x.split(',').length == 2;
+    isMidLocked: function () {
+        return this.obj.conf.x.split(",").length == 2;
     },
 
     /**
@@ -165,40 +165,47 @@ var ElementLineControls = Element.extend({
      * can either be the 2nd of three line coords or is automaticaly
      * the middle between two line coords.
      */
-    toggleMidLock: function() {
+    toggleMidLock: function () {
         // What is the current state?
-        var x = this.obj.conf.x.split(',');
-        var y = this.obj.conf.y.split(',')
+        var x = this.obj.conf.x.split(",");
+        var y = this.obj.conf.y.split(",");
 
         if (this.isMidLocked()) {
             // The line has 2 coords configured
             // - Calculate and add the 3rd coord as 2nd
             // - Add a drag control for the 2nd coord
             this.obj.conf.x = [
-              x[0],
-              middle(this.obj.parseCoords(this.obj.conf.x, 'x', false)[0], this.obj.parseCoords(this.obj.conf.x, 'x', false)[1], this.obj.conf.line_cut),
-              x[1],
-            ].join(',');
+                x[0],
+                middle(
+                    this.obj.parseCoords(this.obj.conf.x, "x", false)[0],
+                    this.obj.parseCoords(this.obj.conf.x, "x", false)[1],
+                    this.obj.conf.line_cut
+                ),
+                x[1]
+            ].join(",");
             this.obj.conf.y = [
                 y[0],
-                middle(this.obj.parseCoords(this.obj.conf.y, 'y', false)[0], this.obj.parseCoords(this.obj.conf.y, 'y', false)[1], this.obj.conf.line_cut),
-                y[1],
-            ].join(',');
+                middle(
+                    this.obj.parseCoords(this.obj.conf.y, "y", false)[0],
+                    this.obj.parseCoords(this.obj.conf.y, "y", false)[1],
+                    this.obj.conf.line_cut
+                ),
+                y[1]
+            ].join(",");
         } else {
             // The line has 3 coords configured
             // - Remove the 2nd coord
             // - Remove the drag control for the 2nd coord
-            this.obj.conf.x = [ x[0], x[2] ].join(',');
-            this.obj.conf.y = [ y[0], y[2] ].join(',');
+            this.obj.conf.x = [x[0], x[2]].join(",");
+            this.obj.conf.y = [y[0], y[2]].join(",");
         }
 
-        var parts = g_view.unproject(this.obj.conf.x.toString().split(','),
-                                     this.obj.conf.y.toString().split(','));
-        var x = parts[0].join(',');
-        var y = parts[1].join(',');
+        var parts = g_view.unproject(this.obj.conf.x.toString().split(","), this.obj.conf.y.toString().split(","));
+        var x = parts[0].join(",");
+        var y = parts[1].join(",");
 
         // send to server
-        saveObjectAttr(this.obj.conf.object_id, {'x': x, 'y': y});
+        saveObjectAttr(this.obj.conf.object_id, { x: x, y: y });
 
         // redraw the whole object
         this.obj.render();
@@ -206,49 +213,50 @@ var ElementLineControls = Element.extend({
 });
 
 var ElementLine = Element.extend({
-    line_container : null,
-    parts          : null,
-    canvas         : null,
-    perfdata       : null,
+    line_container: null,
+    parts: null,
+    canvas: null,
+    perfdata: null,
     // The link area is some kind of a hack. The canvas detects whether or not
     // the mouse moves over the line. In the momennt the mouse moves over the
     // line, the link_area div node is moved at the mouse position to give the
     // user all the controls related to the line which is currently hovered.
-    link_area      : null,
+    link_area: null,
 
-    constructor: function(obj) {
+    constructor: function (obj) {
         this.parts = [];
         this.base(obj);
     },
 
-    update: function() {
+    update: function () {
         new ElementLineControls(this.obj).addTo(this.obj);
     },
 
-    updateAttrs: function(only_state) {
-        if (!only_state || (this.isWeathermapLine() &&
-             (this.obj.stateChanged() || this.obj.outputOrPerfdataChanged()))) {
+    updateAttrs: function (only_state) {
+        if (
+            !only_state ||
+            (this.isWeathermapLine() && (this.obj.stateChanged() || this.obj.outputOrPerfdataChanged()))
+        ) {
             this.redrawLine();
         }
     },
 
-    render: function() {
-        if (this.isWeathermapLine())
-            this.parsePerfdata();
+    render: function () {
+        if (this.isWeathermapLine()) this.parsePerfdata();
 
-        var container = document.createElement('div');
-        container.setAttribute('id', this.obj.conf.object_id+'-linediv');
-        container.className = 'line';
+        var container = document.createElement("div");
+        container.setAttribute("id", this.obj.conf.object_id + "-linediv");
+        container.className = "line";
         this.dom_obj = container;
 
         // Create line div
-        var oLineDiv = document.createElement('div');
+        var oLineDiv = document.createElement("div");
         this.line_container = oLineDiv;
         container.appendChild(oLineDiv);
-        oLineDiv.setAttribute('id', this.obj.conf.object_id+'-line');
+        oLineDiv.setAttribute("id", this.obj.conf.object_id + "-line");
         // the objects canvas might hide icons behind it, put it one layer down,
         // because normally icons and lines are on the same z-index
-        oLineDiv.style.zIndex = parseInt(this.obj.conf.z)-1;
+        oLineDiv.style.zIndex = parseInt(this.obj.conf.z) - 1;
 
         this.calcLineParts();
         this.renderLine();
@@ -257,15 +265,15 @@ var ElementLine = Element.extend({
         this.renderLabels();
     },
 
-    place: function() {
+    place: function () {
         this.redrawLine();
     },
 
-    unlock: function() {
+    unlock: function () {
         this.toggleActionContainer();
     },
 
-    lock: function() {
+    lock: function () {
         this.toggleActionContainer();
     },
 
@@ -273,7 +281,7 @@ var ElementLine = Element.extend({
     // END OF PUBLIC METHODS
     //
 
-    redrawLine: function() {
+    redrawLine: function () {
         // Totally redraw the line when moving the line anchors arround. But keep the trigger
         // object because it saves the attached event handlers
         var trigger_obj = this.obj.trigger_obj;
@@ -286,16 +294,16 @@ var ElementLine = Element.extend({
         this.draw();
     },
 
-    renderActionContainer: function() {
+    renderActionContainer: function () {
         // This is only the container for the hover/label elements. The real area or labels
         // are added later. But this container gets all event handlers assigned. Because
         // the line is using erase(), render(), draw() within place() which is called while
         // the user moves the object, this dom node must not be re-created, because this
         // would remove all event handlers
         if (!this.obj.trigger_obj) {
-            var oLink = document.createElement('a');
-            oLink.setAttribute('id', this.obj.conf.object_id+'-linelink');
-            oLink.className = 'linelink';
+            var oLink = document.createElement("a");
+            oLink.setAttribute("id", this.obj.conf.object_id + "-linelink");
+            oLink.className = "linelink";
             this.obj.trigger_obj = oLink;
         } else {
             var oLink = this.obj.trigger_obj;
@@ -306,28 +314,25 @@ var ElementLine = Element.extend({
             oLink.href = this.obj.conf.url;
             oLink.target = this.obj.conf.url_target;
         } else {
-            oLink.href = 'javascript:void(0)';
+            oLink.href = "javascript:void(0)";
         }
     },
 
-    clearActionContainer: function() {
-        while (this.obj.trigger_obj.firstChild)
-            this.obj.trigger_obj.removeChild(this.obj.trigger_obj.firstChild);
+    clearActionContainer: function () {
+        while (this.obj.trigger_obj.firstChild) this.obj.trigger_obj.removeChild(this.obj.trigger_obj.firstChild);
     },
 
-    toggleActionContainer: function() {
+    toggleActionContainer: function () {
         // Hide if not needed, show if needed
-        if (!this.obj.needsLineHoverArea())
-            this.obj.trigger_obj.style.display = 'none';
-        else
-            this.obj.trigger_obj.style.display = 'block';
+        if (!this.obj.needsLineHoverArea()) this.obj.trigger_obj.style.display = "none";
+        else this.obj.trigger_obj.style.display = "block";
     },
 
-    calcLineParts: function() {
+    calcLineParts: function () {
         this.parts = [];
 
-        var x = this.obj.parseCoords(this.obj.conf.x, 'x');
-        var y = this.obj.parseCoords(this.obj.conf.y, 'y');
+        var x = this.obj.parseCoords(this.obj.conf.x, "x");
+        var y = this.obj.parseCoords(this.obj.conf.y, "y");
 
         // Convert all coords to int
         for (var i = 0; i < x.length; i++) {
@@ -337,8 +342,8 @@ var ElementLine = Element.extend({
 
         var xStart = x[0];
         var yStart = y[0];
-        var xEnd   = x[x.length - 1];
-        var yEnd   = y[y.length - 1];
+        var xEnd = x[x.length - 1];
+        var yEnd = y[y.length - 1];
 
         let adjustedPoints = this.cutLineBeyondViewport(xStart, yStart, xEnd, yEnd);
         if (adjustedPoints === null) {
@@ -351,23 +356,22 @@ var ElementLine = Element.extend({
         yEnd = adjustedPoints[3];
 
         var width = addZoomFactor(this.obj.conf.line_width);
-        if (width <= 0)
-            width = 1; // minimal width for lines
+        if (width <= 0) width = 1; // minimal width for lines
 
         // Lines meeting point position
         var cut = this.obj.conf.line_cut;
 
         switch (this.obj.conf.line_type) {
-            case '11': // ---> lines
+            case "11": // ---> lines
                 this.renderArrow(0, xStart, yStart, xEnd, yEnd, width);
-            break;
-            case '12': // --- lines
+                break;
+            case "12": // --- lines
                 this.renderSimpleLine(0, xStart, yStart, xEnd, yEnd, width);
-            break;
-            case '10':
-            case '13':
-            case '14':
-            case '15':
+                break;
+            case "10":
+            case "13":
+            case "14":
+            case "15":
                 // two part lines
                 if (x.length == 2) {
                     var xMid = middle(xStart, xEnd, cut);
@@ -379,64 +383,66 @@ var ElementLine = Element.extend({
 
                 this.renderArrow(0, xStart, yStart, xMid, yMid, width);
                 this.renderArrow(1, xEnd, yEnd, xMid, yMid, width);
-            break;
+                break;
             default:
-                alert('Error: Unknown line type');
+                alert("Error: Unknown line type");
         }
     },
 
     // Calculates the colors of a line part
-    calcColors: function(id) {
-        var color = '#FFCC66';
-        var border_color = '#000000';
+    calcColors: function (id) {
+        var color = "#FFCC66";
+        var border_color = "#000000";
 
         // Get the fill color depending on the object state
         switch (this.obj.conf.summary_state) {
-            case 'UNREACHABLE':
-            case 'DOWN':
-            case 'CRITICAL':
-            case 'WARNING':
-            case 'UNKNOWN':
-            case 'ERROR':
-            case 'UP':
-            case 'OK':
-            case 'PENDING':
+            case "UNREACHABLE":
+            case "DOWN":
+            case "CRITICAL":
+            case "WARNING":
+            case "UNKNOWN":
+            case "ERROR":
+            case "UP":
+            case "OK":
+            case "PENDING":
                 color = oStates[this.obj.conf.summary_state].color;
-            break;
+                break;
         }
 
         // Adjust fill color based on perfdata for weathermap lines
-        if (this.isWeathermapLine())
-            color = this.calcWeathermapColor(id);
+        if (this.isWeathermapLine()) color = this.calcWeathermapColor(id);
 
         // ack/downtime/staleness lighten the color a bit
-        if (this.obj.conf.summary_problem_has_been_acknowledged == 1
-            || this.obj.conf.summary_in_downtime == 1
-            || this.obj.conf.summary_stale) {
-
+        if (
+            this.obj.conf.summary_problem_has_been_acknowledged == 1 ||
+            this.obj.conf.summary_in_downtime == 1 ||
+            this.obj.conf.summary_stale
+        ) {
             color = lightenColor(color, 100, 100, 100);
 
-            if (this.obj.conf.summary_problem_has_been_acknowledged == 1
-                && typeof(oStates[this.obj.conf.summary_state].ack_bgcolor) != 'undefined'
-                && oStates[this.obj.conf.summary_state].ack_bgcolor != '') {
-                    color = oStates[this.obj.conf.summary_state].ack_bgcolor;
+            if (
+                this.obj.conf.summary_problem_has_been_acknowledged == 1 &&
+                typeof oStates[this.obj.conf.summary_state].ack_bgcolor != "undefined" &&
+                oStates[this.obj.conf.summary_state].ack_bgcolor != ""
+            ) {
+                color = oStates[this.obj.conf.summary_state].ack_bgcolor;
             }
         }
 
         return [color, border_color];
     },
 
-    isWeathermapLine: function() {
-        return this.obj.conf.line_type == 13 || this.obj.conf.line_type == 14
-               || this.obj.conf.line_type == 15;
+    isWeathermapLine: function () {
+        return this.obj.conf.line_type == 13 || this.obj.conf.line_type == 14 || this.obj.conf.line_type == 15;
     },
 
-    renderLine: function() {
+    renderLine: function () {
         if (this.parts.length === 0) {
             return;
         }
 
-        var allX = [], allY = [];
+        var allX = [],
+            allY = [];
         for (var i = 0, len = this.parts.length; i < len; i++) {
             allX = allX.concat(this.parts[i][2]);
             allY = allY.concat(this.parts[i][3]);
@@ -447,40 +453,40 @@ var ElementLine = Element.extend({
         var yMax = max(allY);
         var border = 5;
 
-        var canvas = document.createElement('canvas');
+        var canvas = document.createElement("canvas");
         this.canvas = canvas;
 
-        if (!canvas.getContext)
-            return; // FIXME: Show an error message?
+        if (!canvas.getContext) return; // FIXME: Show an error message?
 
-        canvas.setAttribute('id', this.obj.conf.object_id+'-canvas');
-        canvas.style.position = 'absolute';
+        canvas.setAttribute("id", this.obj.conf.object_id + "-canvas");
+        canvas.style.position = "absolute";
         this.line_container.appendChild(canvas);
 
-        canvas.style.left = (xMin-border)+"px";
-        canvas.style.top = (yMin-border)+"px";
-        canvas.width = Math.round(xMax-xMin)+2*border;
-        canvas.height = Math.round(yMax-yMin)+2*border;
+        canvas.style.left = xMin - border + "px";
+        canvas.style.top = yMin - border + "px";
+        canvas.width = Math.round(xMax - xMin) + 2 * border;
+        canvas.height = Math.round(yMax - yMin) + 2 * border;
         // the objects canvas might hide icons behind it, put it one layer down,
         // because normally icons and lines are on the same z-index
-        canvas.style.zIndex = parseInt(this.obj.conf.z)-1;
+        canvas.style.zIndex = parseInt(this.obj.conf.z) - 1;
 
-        addEvent(canvas, 'mousemove', this.handleMouseMove.bind(this));
+        addEvent(canvas, "mousemove", this.handleMouseMove.bind(this));
 
-        var ctx = canvas.getContext('2d');
-        if (!ctx)
-            return; // silently skip
+        var ctx = canvas.getContext("2d");
+        if (!ctx) return; // silently skip
 
         // On high resolution devices like e.g. 4k screens where
         // the page is not rendered 1:1 but instead shown scaled,
         // the renderd lines look bad if they had been rendered 1:1.
         // Fix this by scaling the whole canvas.
         var devicePixelRatio = window.devicePixelRatio || 1;
-        var backingStoreRatio = ctx.webkitBackingStorePixelRatio ||
-                                ctx.mozBackingStorePixelRatio ||
-                                ctx.msBackingStorePixelRatio ||
-                                ctx.oBackingStorePixelRatio ||
-                                ctx.backingStorePixelRatio || 1;
+        var backingStoreRatio =
+            ctx.webkitBackingStorePixelRatio ||
+            ctx.mozBackingStorePixelRatio ||
+            ctx.msBackingStorePixelRatio ||
+            ctx.oBackingStorePixelRatio ||
+            ctx.backingStorePixelRatio ||
+            1;
         var ratio = devicePixelRatio / backingStoreRatio;
         if (devicePixelRatio !== backingStoreRatio) {
             var oldWidth = canvas.width;
@@ -489,8 +495,8 @@ var ElementLine = Element.extend({
             canvas.width = oldWidth * ratio;
             canvas.height = oldHeight * ratio;
 
-            canvas.style.width = oldWidth + 'px';
-            canvas.style.height = oldHeight + 'px';
+            canvas.style.width = oldWidth + "px";
+            canvas.style.height = oldHeight + "px";
 
             // now scale the context to counter
             // the fact that we've manually scaled
@@ -509,10 +515,10 @@ var ElementLine = Element.extend({
             ctx.fillStyle = part[4][0];
 
             ctx.beginPath();
-            ctx.moveTo(part[2][0]-xMin+border, part[3][0]-yMin+border);
+            ctx.moveTo(part[2][0] - xMin + border, part[3][0] - yMin + border);
 
             for (var a = 1, len2 = part[2].length; a < len2; a++)
-                ctx.lineTo(part[2][a]-xMin+border, part[3][a]-yMin+border);
+                ctx.lineTo(part[2][a] - xMin + border, part[3][a] - yMin + border);
 
             ctx.fill();
 
@@ -525,78 +531,79 @@ var ElementLine = Element.extend({
 
     // This function renders an arrow like it is used on NagVis maps
     // It renders following line types: --->
-    renderArrow: function(id, x1, y1, x2, y2, w) {
+    renderArrow: function (id, x1, y1, x2, y2, w) {
         var xCoord = [
-            x1 + newX(x2-x1, y2-y1, 0, w),
-            x2 + newX(x2-x1, y2-y1, -4*w, w),
-            x2 + newX(x2-x1, y2-y1, -4*w, 2*w),
+            x1 + newX(x2 - x1, y2 - y1, 0, w),
+            x2 + newX(x2 - x1, y2 - y1, -4 * w, w),
+            x2 + newX(x2 - x1, y2 - y1, -4 * w, 2 * w),
             x2,
-            x2 + newX(x2-x1, y2-y1, -4*w, -2*w),
-            x2 + newX(x2-x1, y2-y1, -4*w, -w),
-            x1 + newX(x2-x1, y2-y1, 0, -w),
-            x1 + newX(x2-x1, y2-y1, 0, w)
+            x2 + newX(x2 - x1, y2 - y1, -4 * w, -2 * w),
+            x2 + newX(x2 - x1, y2 - y1, -4 * w, -w),
+            x1 + newX(x2 - x1, y2 - y1, 0, -w),
+            x1 + newX(x2 - x1, y2 - y1, 0, w)
         ];
         var yCoord = [
-            y1 + newY(x2-x1, y2-y1, 0, w),
-            y2 + newY(x2-x1, y2-y1, -4*w, w),
-            y2 + newY(x2-x1, y2-y1, -4*w, 2*w),
+            y1 + newY(x2 - x1, y2 - y1, 0, w),
+            y2 + newY(x2 - x1, y2 - y1, -4 * w, w),
+            y2 + newY(x2 - x1, y2 - y1, -4 * w, 2 * w),
             y2,
-            y2 + newY(x2-x1, y2-y1, -4*w, -2*w),
-            y2 + newY(x2-x1, y2-y1, -4*w, -w),
-            y1 + newY(x2-x1, y2-y1, 0, -w),
-            y1 + newY(x2-x1, y2-y1, 0, w)
+            y2 + newY(x2 - x1, y2 - y1, -4 * w, -2 * w),
+            y2 + newY(x2 - x1, y2 - y1, -4 * w, -w),
+            y1 + newY(x2 - x1, y2 - y1, 0, -w),
+            y1 + newY(x2 - x1, y2 - y1, 0, w)
         ];
 
         this.renderLinePart(id, [x1, y1], [x2, y2], xCoord, yCoord);
     },
 
     // This function renders simple lines (without arrow)
-    renderSimpleLine: function(id, x1, y1, x2, y2, w) {
+    renderSimpleLine: function (id, x1, y1, x2, y2, w) {
         var xCoord = [
-            x1 + newX(x2-x1, y2-y1, 0, w),
-            x2 + newX(x2-x1, y2-y1, w, w),
-            x2 + newX(x2-x1, y2-y1, w, -w),
-            x1 + newX(x2-x1, y2-y1, 0, -w),
-            x1 + newX(x2-x1, y2-y1, 0, w)
+            x1 + newX(x2 - x1, y2 - y1, 0, w),
+            x2 + newX(x2 - x1, y2 - y1, w, w),
+            x2 + newX(x2 - x1, y2 - y1, w, -w),
+            x1 + newX(x2 - x1, y2 - y1, 0, -w),
+            x1 + newX(x2 - x1, y2 - y1, 0, w)
         ];
         var yCoord = [
-            y1 + newY(x2-x1, y2-y1, 0, w),
-            y2 + newY(x2-x1, y2-y1, w, w),
-            y2 + newY(x2-x1, y2-y1, w, -w),
-            y1 + newY(x2-x1, y2-y1, 0, -w),
-            y1 + newY(x2-x1, y2-y1, 0, w)
+            y1 + newY(x2 - x1, y2 - y1, 0, w),
+            y2 + newY(x2 - x1, y2 - y1, w, w),
+            y2 + newY(x2 - x1, y2 - y1, w, -w),
+            y1 + newY(x2 - x1, y2 - y1, 0, -w),
+            y1 + newY(x2 - x1, y2 - y1, 0, w)
         ];
 
         this.renderLinePart(id, [x1, y1], [x2, y2], xCoord, yCoord);
     },
 
-    renderLinePart: function(id, start, end, x, y) {
+    renderLinePart: function (id, start, end, x, y) {
         this.parts.push([start, end, x, y, this.calcColors(id)]);
     },
 
-    handleMouseMove: function(event) {
+    handleMouseMove: function (event) {
         event = event || window.event;
 
-        if (getTargetRaw(event).tagName !== 'CANVAS')
-            return true;
+        if (getTargetRaw(event).tagName !== "CANVAS") return true;
 
         // document.body.scrollTop does not work in IE
-        var scrollTop = document.body.scrollTop ? document.body.scrollTop :
-                                                  document.documentElement.scrollTop;
-        var scrollLeft = document.body.scrollLeft ? document.body.scrollLeft :
-                                                    document.documentElement.scrollLeft;
+        var scrollTop = document.body.scrollTop ? document.body.scrollTop : document.documentElement.scrollTop;
+        var scrollLeft = document.body.scrollLeft ? document.body.scrollLeft : document.documentElement.scrollLeft;
 
         // Get the mouse position relative to window
         var x = event.clientX - getSidebarWidth() + scrollLeft;
         var y = event.clientY - getHeaderHeight() + scrollTop;
 
         // Check whether or not the given coord is within the line part coords
-        var pnpoly = function(nvert, vertx, verty, testx, testy) {
-            var i, j, c = false;
-            for ( i = 0, j = nvert-1; i < nvert; j = i++ ) {
-                if ( ( ( verty[i] > testy ) != ( verty[j] > testy ) ) &&
-                    ( testx < ( vertx[j] - vertx[i] ) * ( testy - verty[i] ) / ( verty[j] - verty[i] ) + vertx[i] ) ) {
-                        c = !c;
+        var pnpoly = function (nvert, vertx, verty, testx, testy) {
+            var i,
+                j,
+                c = false;
+            for (i = 0, j = nvert - 1; i < nvert; j = i++) {
+                if (
+                    verty[i] > testy != verty[j] > testy &&
+                    testx < ((vertx[j] - vertx[i]) * (testy - verty[i])) / (verty[j] - verty[i]) + vertx[i]
+                ) {
+                    c = !c;
                 }
             }
             return c;
@@ -613,46 +620,38 @@ var ElementLine = Element.extend({
         }
 
         if (over) {
-            add_class(this.canvas, 'active');
+            add_class(this.canvas, "active");
             // move the link area below the cursor to make actions possible
-            this.link_area.style.display = '';
-            this.link_area.style.left = (x-5) + 'px';
-            this.link_area.style.top = (y-5) + 'px';
+            this.link_area.style.display = "";
+            this.link_area.style.left = x - 5 + "px";
+            this.link_area.style.top = y - 5 + "px";
 
-            if (usesSource('worldmap'))
-                this.obj.marker._bringToFront();
+            if (usesSource("worldmap")) this.obj.marker._bringToFront();
         } else {
-            remove_class(this.canvas, 'active');
-            this.link_area.style.display = 'none';
+            remove_class(this.canvas, "active");
+            this.link_area.style.display = "none";
 
-            if (usesSource('worldmap'))
-               this.obj.marker._resetZIndex();
+            if (usesSource("worldmap")) this.obj.marker._resetZIndex();
         }
     },
 
-    renderLabels: function() {
-        if (!this.isWeathermapLine())
-            return; // Only weathermap lines have labels at the moment
+    renderLabels: function () {
+        if (!this.isWeathermapLine()) return; // Only weathermap lines have labels at the moment
 
-        if (!this.obj.conf.line_label_show || this.obj.conf.line_label_show !== '1')
-            return; // skip over when labels are disabled
+        if (!this.obj.conf.line_label_show || this.obj.conf.line_label_show !== "1") return; // skip over when labels are disabled
 
         this.renderLabel(0);
         this.renderLabel(1);
     },
 
-    getLabelWidth: function(str) {
-        if(str && str.length > 0)
-            return (str.length / 2) * 9;
-        else
-            return 10;
+    getLabelWidth: function (str) {
+        if (str && str.length > 0) return (str.length / 2) * 9;
+        else return 10;
     },
 
-    renderLabel: function(id) {
-	if (this.parts.length === 0)
-	    return;
-	if (this.perfdata === null)
-            return;
+    renderLabel: function (id) {
+        if (this.parts.length === 0) return;
+        if (this.perfdata === null) return;
 
         var y_offset = parseInt(this.obj.conf.line_label_y_offset);
 
@@ -661,8 +660,7 @@ var ElementLine = Element.extend({
             x2 = this.parts[id][1][0],
             y2 = this.parts[id][1][1];
 
-        var cut = id == 0 ? this.obj.conf.line_label_pos_in
-                          : this.obj.conf.line_label_pos_out;
+        var cut = id == 0 ? this.obj.conf.line_label_pos_in : this.obj.conf.line_label_pos_out;
 
         var x = middle(x1, x2, cut),
             y = middle(y1, y2, cut) + y_offset;
@@ -671,46 +669,63 @@ var ElementLine = Element.extend({
         if (this.obj.conf.line_type == 13 || this.obj.conf.line_type == 14) {
             // Show percentage label
             txt = this.perfdata[id][1] + this.perfdata[id][2];
-        }
-        else if (this.obj.conf.line_type == 15) {
+        } else if (this.obj.conf.line_type == 15) {
             // Show only bandwidth label
-            txt = this.perfdata[2+id][1] + this.perfdata[2+id][2];
+            txt = this.perfdata[2 + id][1] + this.perfdata[2 + id][2];
         }
 
         // Maybe use function to detect the real height in future
         var labelHeight = 21,
-            labelWidth  = this.getLabelWidth(txt);
+            labelWidth = this.getLabelWidth(txt);
 
         this.obj.trigger_obj.appendChild(
-            renderNagVisTextbox(this.obj.conf.object_id+'-link'+id,
-                                '#ffffff', '#000000', (x-labelWidth), parseInt(y - labelHeight / 2),
-                                this.obj.conf.z, 'auto', 'auto', '<b>' + txt + '</b>'));
+            renderNagVisTextbox(
+                this.obj.conf.object_id + "-link" + id,
+                "#ffffff",
+                "#000000",
+                x - labelWidth,
+                parseInt(y - labelHeight / 2),
+                this.obj.conf.z,
+                "auto",
+                "auto",
+                "<b>" + txt + "</b>"
+            )
+        );
 
         // Paint the second label in case of line type 14
         if (this.obj.conf.line_type == 14) {
-            txt = this.perfdata[2+id][1] + this.perfdata[2+id][2];
+            txt = this.perfdata[2 + id][1] + this.perfdata[2 + id][2];
             labelWidth = this.getLabelWidth(txt);
             this.obj.trigger_obj.appendChild(
-                renderNagVisTextbox(this.obj.conf.object_id+'-link'+(id+1),
-                                    '#ffffff', '#000000', (x-labelWidth), parseInt(y + labelHeight / 2),
-                                    this.obj.conf.z, 'auto', 'auto', '<b>' + txt + '</b>'));
+                renderNagVisTextbox(
+                    this.obj.conf.object_id + "-link" + (id + 1),
+                    "#ffffff",
+                    "#000000",
+                    x - labelWidth,
+                    parseInt(y + labelHeight / 2),
+                    this.obj.conf.z,
+                    "auto",
+                    "auto",
+                    "<b>" + txt + "</b>"
+                )
+            );
         }
     },
 
-    renderLinkArea: function() {
-        var div = document.createElement('div');
+    renderLinkArea: function () {
+        var div = document.createElement("div");
         this.link_area = div;
-        div.setAttribute('id', this.obj.conf.object_id+'-link');
-        div.style.position = 'absolute';
-        div.style.top = '-100px'; // out of screen by default
-        div.style.zIndex = parseInt(this.obj.conf.z)+1;
-        div.style.width = '10px';
-        div.style.height = '10px';
+        div.setAttribute("id", this.obj.conf.object_id + "-link");
+        div.style.position = "absolute";
+        div.style.top = "-100px"; // out of screen by default
+        div.style.zIndex = parseInt(this.obj.conf.z) + 1;
+        div.style.width = "10px";
+        div.style.height = "10px";
 
         this.obj.trigger_obj.appendChild(div);
     },
 
-    parsePerfdata: function() {
+    parsePerfdata: function () {
         this.perfdata = null;
 
         /*
@@ -758,30 +773,26 @@ var ElementLine = Element.extend({
         // This can fix the perfdata values from Checkmks if and if64 checks.
         // The assumption is that there are perfdata values 'in' and 'out' with byte rates
         // and maximum values given to be able to calculate the percentage usage
-        if (perf[0][2] === null || perf[0][2] === ''
-           || perf[1][2] === null || perf[1][2] === '') {
+        if (perf[0][2] === null || perf[0][2] === "" || perf[1][2] === null || perf[1][2] === "") {
             perf = this.calculateUsage(perf, this.obj.conf.output);
         }
 
         this.perfdata = perf;
     },
 
-    addWeathermapLineError: function(e) {
-        this.obj.conf.summary_output += ' (Weathermap Line Error: ' + e + ')';
+    addWeathermapLineError: function (e) {
+        this.obj.conf.summary_output += " (Weathermap Line Error: " + e + ")";
     },
 
-    calcWeathermapColor: function(id) {
-        if (this.obj.conf.summary_state == "ERROR")
-            return oStates["ERROR"].color;
+    calcWeathermapColor: function (id) {
+        if (this.obj.conf.summary_state == "ERROR") return oStates["ERROR"].color;
 
-        if (!this.perfdata)
-            return oStates["CRITICAL"].color;
+        if (!this.perfdata) return oStates["CRITICAL"].color;
 
-        if (this.perfdata[id][2] == '%' && this.perfdata[id][1] !== null) {
+        if (this.perfdata[id][2] == "%" && this.perfdata[id][1] !== null) {
             return this.getColorFill(this.perfdata[id][1]);
         } else {
-            this.obj.conf.summary_output += ' (Weathermap Line Error: Value '
-                                            + id +' is not a percentage value)';
+            this.obj.conf.summary_output += " (Weathermap Line Error: Value " + id + " is not a percentage value)";
             return oStates["ERROR"].color;
         }
     },
@@ -790,18 +801,17 @@ var ElementLine = Element.extend({
      * This function returns the color to use for this line depending on the
      * given percentage usage and on the configured options for this object
      */
-    getColorFill: function(perc) {
-        var ranges = this.obj.conf.line_weather_colors.split(',');
+    getColorFill: function (perc) {
+        var ranges = this.obj.conf.line_weather_colors.split(",");
         // 0 contains the percentage until this color is used
         // 1 contains the color to be used
-        for(var i = 0; i < ranges.length; i++) {
-            var parts = ranges[i].split(':');
-            if(parseFloat(perc) <= parts[0])
-                return parts[1];
+        for (var i = 0; i < ranges.length; i++) {
+            var parts = ranges[i].split(":");
+            if (parseFloat(perc) <= parts[0]) return parts[1];
             parts = null;
         }
         ranges = null;
-        return '#000000';
+        return "#000000";
     },
 
     /**
@@ -809,32 +819,33 @@ var ElementLine = Element.extend({
      * with an empty UOM. If found it uses the current value and max value
      * for calculating the percentage usage and also the current usage.
      */
-    calculateUsage: function(oldPerfdata, output) {
+    calculateUsage: function (oldPerfdata, output) {
         var newPerfdata = [];
         var foundNew = false;
-        var line_label_in = 'in';
-        var line_label_out = 'out';
+        var line_label_in = "in";
+        var line_label_out = "out";
 
         // Checkmk if/if64 checks support switching between bytes/bits.
         var display_bits = false;
-        var reBits = /\bIn(?:\s+average\s+[^:]+)?:\s*[0-9][0-9.,]*\s*\S*Bit\/s\b[\s\S]*?\bOut(?:\s+average\s+[^:]+)?:\s*[0-9][0-9.,]*\s*\S*Bit\/s\b/i;
+        var reBits =
+            /\bIn(?:\s+average\s+[^:]+)?:\s*[0-9][0-9.,]*\s*\S*Bit\/s\b[\s\S]*?\bOut(?:\s+average\s+[^:]+)?:\s*[0-9][0-9.,]*\s*\S*Bit\/s\b/i;
 
         if (output.match(reBits)) {
-            display_bits=true;
+            display_bits = true;
         }
 
         // This loop takes perfdata with the labels "in" and "out" and uses the current value
         // and maximum values to parse the percentage usage of the line
-        if (typeof this.obj.conf.line_label_in !== 'undefined') {
+        if (typeof this.obj.conf.line_label_in !== "undefined") {
             line_label_in = this.obj.conf.line_label_in;
         }
-        if (typeof this.obj.conf.line_label_out !== 'undefined') {
+        if (typeof this.obj.conf.line_label_out !== "undefined") {
             line_label_out = this.obj.conf.line_label_out;
         }
-        for(var i = 0; i < oldPerfdata.length; i++) {
-            if(oldPerfdata[i][0] == line_label_in && (oldPerfdata[i][2] === null || oldPerfdata[i][2] === '')) {
+        for (var i = 0; i < oldPerfdata.length; i++) {
+            if (oldPerfdata[i][0] == line_label_in && (oldPerfdata[i][2] === null || oldPerfdata[i][2] === "")) {
                 newPerfdata[0] = this.perfdataCalcPerc(oldPerfdata[i]);
-                if(!display_bits) {
+                if (!display_bits) {
                     newPerfdata[2] = this.perfdataCalcBytesReadable(oldPerfdata[i]);
                 } else {
                     oldPerfdata[i][1] *= 8; // convert those hakish bytes to bits
@@ -842,9 +853,9 @@ var ElementLine = Element.extend({
                 }
                 foundNew = true;
             }
-            if(oldPerfdata[i][0] == line_label_out && (oldPerfdata[i][2] === null || oldPerfdata[i][2] === '')) {
+            if (oldPerfdata[i][0] == line_label_out && (oldPerfdata[i][2] === null || oldPerfdata[i][2] === "")) {
                 newPerfdata[1] = this.perfdataCalcPerc(oldPerfdata[i]);
-                if(!display_bits) {
+                if (!display_bits) {
                     newPerfdata[3] = this.perfdataCalcBytesReadable(oldPerfdata[i]);
                 } else {
                     oldPerfdata[i][1] *= 8; // convert those hakish bytes to bits
@@ -853,55 +864,53 @@ var ElementLine = Element.extend({
                 foundNew = true;
             }
         }
-        if(foundNew)
-            return newPerfdata;
-        else
-            return oldPerfdata;
+        if (foundNew) return newPerfdata;
+        else return oldPerfdata;
     },
 
     /**
      * Transform bits in a perfdata set to a human readable value
      */
-    perfdataCalcBitsReadable: function(set, kiloMultiplier=1000) {
-        var KB   = kiloMultiplier;
-        var MB   = kiloMultiplier * kiloMultiplier;
-        var GB   = kiloMultiplier * kiloMultiplier * kiloMultiplier;
-        if(set[1] > GB) {
-            set[1] /= GB
-            set[2]  = 'Gbit/s'
-        } else if(set[1] > MB) {
-            set[1] /= MB
-            set[2]  = 'Mbit/s'
-        } else if(set[1] > KB) {
-            set[1] /= KB
-            set[2]  = 'Kbit/s'
+    perfdataCalcBitsReadable: function (set, kiloMultiplier = 1000) {
+        var KB = kiloMultiplier;
+        var MB = kiloMultiplier * kiloMultiplier;
+        var GB = kiloMultiplier * kiloMultiplier * kiloMultiplier;
+        if (set[1] > GB) {
+            set[1] /= GB;
+            set[2] = "Gbit/s";
+        } else if (set[1] > MB) {
+            set[1] /= MB;
+            set[2] = "Mbit/s";
+        } else if (set[1] > KB) {
+            set[1] /= KB;
+            set[2] = "Kbit/s";
         } else {
-            set[2]  = 'bit/s'
+            set[2] = "bit/s";
         }
-        set[1] = Math.round(set[1]*100)/100;
+        set[1] = Math.round(set[1] * 100) / 100;
         return set;
     },
 
     /**
      * Transform bytes in a perfdata set to a human readable value
      */
-    perfdataCalcBytesReadable: function(set, kiloMultiplier=1000) {
-        var KB   = kiloMultiplier;
-        var MB   = kiloMultiplier * kiloMultiplier;
-        var GB   = kiloMultiplier * kiloMultiplier * kiloMultiplier;
-        if(set[1] > GB) {
-            set[1] /= GB
-            set[2]  = 'GB/s'
-        } else if(set[1] > MB) {
-            set[1] /= MB
-            set[2]  = 'MB/s'
-        } else if(set[1] > KB) {
-            set[1] /= KB
-            set[2]  = 'KB/s'
+    perfdataCalcBytesReadable: function (set, kiloMultiplier = 1000) {
+        var KB = kiloMultiplier;
+        var MB = kiloMultiplier * kiloMultiplier;
+        var GB = kiloMultiplier * kiloMultiplier * kiloMultiplier;
+        if (set[1] > GB) {
+            set[1] /= GB;
+            set[2] = "GB/s";
+        } else if (set[1] > MB) {
+            set[1] /= MB;
+            set[2] = "MB/s";
+        } else if (set[1] > KB) {
+            set[1] /= KB;
+            set[2] = "KB/s";
         } else {
-            set[2]  = 'B/s'
+            set[2] = "B/s";
         }
-        set[1] = Math.round(set[1]*100)/100;
+        set[1] = Math.round(set[1] * 100) / 100;
         return set;
     },
 
@@ -909,13 +918,12 @@ var ElementLine = Element.extend({
      * Calculates the percentage usage of a line when the current value
      *  and the max value are given in the perfdata string
      */
-    perfdataCalcPerc: function(set) {
+    perfdataCalcPerc: function (set) {
         // Check if all needed information are present
-        if(set[1] === null || set[6] === null || set[1] == '' || set[6] == '')
-            return set;
+        if (set[1] === null || set[6] === null || set[1] == "" || set[6] == "") return set;
 
         // Calculate percentages with 2 decimals and reset other options
-        return Array(set[0], Math.round(set[1]*100/set[6]*100)/100, '%', set[3], set[4], 0, 100);
+        return Array(set[0], Math.round(((set[1] * 100) / set[6]) * 100) / 100, "%", set[3], set[4], 0, 100);
     },
 
     /**
@@ -931,32 +939,31 @@ var ElementLine = Element.extend({
      * @author      Greg Frater <greg@fraterfactory.com>
      *
      */
-    parsePerfdataString: function() {
+    parsePerfdataString: function () {
         var parsed = [];
 
         var perfdata = this.obj.conf.perfdata;
-        if (!perfdata)
-            return [];
+        if (!perfdata) return [];
 
         // Clean up perfdata
-        perfdata = perfdata.replace('/\s*=\s*/', '=');
+        perfdata = perfdata.replace("/\s*=\s*/", "=");
 
         // Break perfdata string into array of individual sets
         var re = /([^=]+)=([\d\.\-]+)([\w%]*);?([\d\.\-:~@]+)?;?([\d\.\-:~@]+)?;?([\d\.\-]+)?;?([\d\.\-]+)?\s*/g;
         var perfdataMatches = perfdata.match(re);
 
         // Check for empty perfdata
-        if (perfdataMatches == null)
-            return [];
+        if (perfdataMatches == null) return [];
 
         // Break perfdata parts into array
         for (var i = 0; i < perfdataMatches.length; i++) {
             // Get parts of perfdata from string
-            var tmpSetMatches = perfdataMatches[i].match(/(&#145;)?([\w\s\=\'\-]*)(&#145;)?\=([\d\.\-\+]*)([\w%]*)[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-\+]*)[\;|\s]?([\d\.\-\+]*)/);
+            var tmpSetMatches = perfdataMatches[i].match(
+                /(&#145;)?([\w\s\=\'\-]*)(&#145;)?\=([\d\.\-\+]*)([\w%]*)[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-:~@]+)*[\;|\s]?([\d\.\-\+]*)[\;|\s]?([\d\.\-\+]*)/
+            );
 
             // Check if we got any perfdata
-            if (tmpSetMatches === null)
-                continue;
+            if (tmpSetMatches === null) continue;
 
             parsed.push([
                 tmpSetMatches[2], // label
@@ -965,7 +972,7 @@ var ElementLine = Element.extend({
                 tmpSetMatches[6], // warn
                 tmpSetMatches[7], // crit
                 tmpSetMatches[8], // min
-                tmpSetMatches[9], // max
+                tmpSetMatches[9] // max
             ]);
         }
         return parsed;
@@ -982,13 +989,12 @@ var ElementLine = Element.extend({
      *  or: null - line out of a rectangle, don't render
      */
 
-    cutLineBeyondViewport: function(xA, yA, xB, yB) {
-        if (!g_map)
-            return([xA, yA, xB, yB]); // no viewport - no clipping
+    cutLineBeyondViewport: function (xA, yA, xB, yB) {
+        if (!g_map) return [xA, yA, xB, yB]; // no viewport - no clipping
 
         let viewport_size = g_map.getSize();
-        const xMax = viewport_size.x;  // 1920
-        const yMax = viewport_size.y;  // 1080
+        const xMax = viewport_size.x; // 1920
+        const yMax = viewport_size.y; // 1080
         const xTolerance = xMax * 0.95; // 1824 (95%)
         const yTolerance = yMax * 0.95; // 1026 (95%)
 
@@ -996,10 +1002,10 @@ var ElementLine = Element.extend({
 
         // region codes
         const INSIDE = 0; // 0000
-        const LEFT = 1;   // 0001
-        const RIGHT = 2;  // 0010
+        const LEFT = 1; // 0001
+        const RIGHT = 2; // 0010
         const BOTTOM = 4; // 0100
-        const TOP = 8;    // 1000
+        const TOP = 8; // 1000
 
         // boundaries
         const x_min = -xTolerance;
@@ -1008,21 +1014,24 @@ var ElementLine = Element.extend({
         const y_max = yMax + yTolerance;
 
         // Function to compute region code
-        let regionCode = function (x, y)
-        {
+        let regionCode = function (x, y) {
             let code = INSIDE;
 
-            if (x < x_min)       // to the left of rectangle
+            if (x < x_min)
+                // to the left of rectangle
                 code |= LEFT;
-            else if (x > x_max)  // to the right of rectangle
+            else if (x > x_max)
+                // to the right of rectangle
                 code |= RIGHT;
-            if (y < y_min)       // below the rectangle
+            if (y < y_min)
+                // below the rectangle
                 code |= BOTTOM;
-            else if (y > y_max)  // above the rectangle
+            else if (y > y_max)
+                // above the rectangle
                 code |= TOP;
 
             return code;
-        }
+        };
 
         let cohenSutherlandClip = function (x1, y1, x2, y2) {
             let code1 = regionCode(x1, y1);
@@ -1030,22 +1039,16 @@ var ElementLine = Element.extend({
 
             let accept = false;
 
-            while (true)
-            {
-                if ((code1 == 0) && (code2 == 0))
-                {
+            while (true) {
+                if (code1 == 0 && code2 == 0) {
                     // If both endpoints lie within rectangle
                     accept = true;
                     break;
-                }
-                else if (code1 & code2)
-                {
+                } else if (code1 & code2) {
                     // If both endpoints are outside rectangle,
                     // in same region
                     break;
-                }
-                else
-                {
+                } else {
                     // Some segment of line lies within the
                     // rectangle
                     let code_out;
@@ -1053,63 +1056,48 @@ var ElementLine = Element.extend({
 
                     // At least one endpoint is outside the
                     // rectangle, pick it.
-                    if (code1 != 0)
-                        code_out = code1;
-                    else
-                        code_out = code2;
+                    if (code1 != 0) code_out = code1;
+                    else code_out = code2;
 
                     // Find intersection point;
                     // using formulas y = y1 + slope * (x - x1),
                     // x = x1 + (1 / slope) * (y - y1)
-                    if (code_out & TOP)
-                    {
+                    if (code_out & TOP) {
                         // point is above the clip rectangle
-                        x = x1 + (x2 - x1) * (y_max - y1) / (y2 - y1);
+                        x = x1 + ((x2 - x1) * (y_max - y1)) / (y2 - y1);
                         y = y_max;
-                    }
-                    else if (code_out & BOTTOM)
-                    {
+                    } else if (code_out & BOTTOM) {
                         // point is below the rectangle
-                        x = x1 + (x2 - x1) * (y_min - y1) / (y2 - y1);
+                        x = x1 + ((x2 - x1) * (y_min - y1)) / (y2 - y1);
                         y = y_min;
-                    }
-                    else if (code_out & RIGHT)
-                    {
+                    } else if (code_out & RIGHT) {
                         // point is to the right of rectangle
-                        y = y1 + (y2 - y1) * (x_max - x1) / (x2 - x1);
+                        y = y1 + ((y2 - y1) * (x_max - x1)) / (x2 - x1);
                         x = x_max;
-                    }
-                    else if (code_out & LEFT)
-                    {
+                    } else if (code_out & LEFT) {
                         // point is to the left of rectangle
-                        y = y1 + (y2 - y1) * (x_min - x1) / (x2 - x1);
+                        y = y1 + ((y2 - y1) * (x_min - x1)) / (x2 - x1);
                         x = x_min;
                     }
 
                     // Now intersection point x,y is found
                     // We replace point outside rectangle
                     // by intersection point
-                    if (code_out == code1)
-                    {
+                    if (code_out == code1) {
                         x1 = x;
                         y1 = y;
                         code1 = regionCode(x1, y1);
-                    }
-                    else
-                    {
+                    } else {
                         x2 = x;
                         y2 = y;
                         code2 = regionCode(x2, y2);
                     }
                 }
             }
-            if (accept)
-                return([x1, y1, x2, y2]);
-            else
-                return null;
-        }
+            if (accept) return [x1, y1, x2, y2];
+            else return null;
+        };
 
         return cohenSutherlandClip(xA, yA, xB, yB);
-    },
-
+    }
 });

--- a/share/frontend/nagvis-js/js/ElementShape.js
+++ b/share/frontend/nagvis-js/js/ElementShape.js
@@ -69,8 +69,8 @@ var ElementShape = Element.extend({
                 var w = parseInt(size),
                     h = parseInt(size);
             } else {
-                var w = parseInt(size[0]),
-                    h = parseInt(size[1]);
+                w = parseInt(size[0]);
+                h = parseInt(size[1]);
             }
             oIcon.style.width = w + "px";
             oIcon.style.height = h + "px";

--- a/share/frontend/nagvis-js/js/ElementShape.js
+++ b/share/frontend/nagvis-js/js/ElementShape.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var ElementShape = Element.extend({
+const ElementShape = Element.extend({
     render: function () {
         this.renderShape();
         this.place();
@@ -48,14 +48,14 @@ var ElementShape = Element.extend({
     //
 
     renderShape: function () {
-        var oIconDiv = document.createElement("div");
+        const oIconDiv = document.createElement("div");
         this.dom_obj = oIconDiv;
 
         oIconDiv.setAttribute("id", this.obj.conf.object_id + "-icondiv");
         oIconDiv.className = "icondiv";
         oIconDiv.style.zIndex = this.obj.conf.z;
 
-        var oIcon = document.createElement("img");
+        const oIcon = document.createElement("img");
         this.obj.trigger_obj = oIcon;
         oIcon.setAttribute("id", this.obj.conf.object_id + "-icon");
         oIcon.className = "icon";
@@ -64,10 +64,11 @@ var ElementShape = Element.extend({
         // An icon size might be either one integer for even sized images or
         // two integers for differen height/width images
         if (this.obj.conf.icon_size) {
-            var size = this.obj.conf.icon_size;
+            const size = this.obj.conf.icon_size;
+            let w, h;
             if (size.length == 1) {
-                var w = parseInt(size),
-                    h = parseInt(size);
+                w = parseInt(size);
+                h = parseInt(size);
             } else {
                 w = parseInt(size[0]);
                 h = parseInt(size[1]);
@@ -77,7 +78,7 @@ var ElementShape = Element.extend({
         }
 
         // Construct the real url to fetch for this shape
-        var img_url = null;
+        let img_url = null;
         if (this.obj.conf.icon.match(/^\[(.*)\]$/)) {
             img_url = this.obj.conf.icon.replace(/^\[(.*)\]$/, "$1");
         } else {
@@ -96,7 +97,7 @@ var ElementShape = Element.extend({
         oIcon.alt = this.obj.conf.type;
 
         if (this.obj.conf.url && this.obj.conf.url !== "") {
-            var oIconLink = document.createElement("a");
+            const oIconLink = document.createElement("a");
             oIconLink.href = this.obj.conf.url;
             oIconLink.target = this.obj.conf.url_target;
             oIconLink.appendChild(oIcon);

--- a/share/frontend/nagvis-js/js/ElementShape.js
+++ b/share/frontend/nagvis-js/js/ElementShape.js
@@ -22,15 +22,15 @@
  *****************************************************************************/
 
 var ElementShape = Element.extend({
-    render: function() {
+    render: function () {
         this.renderShape();
         this.place();
     },
 
     // Moves the Shape to it's location as described by this js object
     place: function () {
-        this.dom_obj.style.top  = this.obj.parseCoord(this.obj.conf.y, 'y') + 'px';
-        this.dom_obj.style.left = this.obj.parseCoord(this.obj.conf.x, 'x') + 'px';
+        this.dom_obj.style.top = this.obj.parseCoord(this.obj.conf.y, "y") + "px";
+        this.dom_obj.style.left = this.obj.parseCoord(this.obj.conf.x, "x") + "px";
     },
 
     unlock: function () {
@@ -48,17 +48,17 @@ var ElementShape = Element.extend({
     //
 
     renderShape: function () {
-        var oIconDiv = document.createElement('div');
+        var oIconDiv = document.createElement("div");
         this.dom_obj = oIconDiv;
 
-        oIconDiv.setAttribute('id', this.obj.conf.object_id+'-icondiv');
-        oIconDiv.className = 'icondiv';
+        oIconDiv.setAttribute("id", this.obj.conf.object_id + "-icondiv");
+        oIconDiv.className = "icondiv";
         oIconDiv.style.zIndex = this.obj.conf.z;
 
-        var oIcon = document.createElement('img');
+        var oIcon = document.createElement("img");
         this.obj.trigger_obj = oIcon;
-        oIcon.setAttribute('id', this.obj.conf.object_id+'-icon');
-        oIcon.className = 'icon';
+        oIcon.setAttribute("id", this.obj.conf.object_id + "-icon");
+        oIcon.className = "icon";
 
         // When no icon size is configured, the native size of the image is used.
         // An icon size might be either one integer for even sized images or
@@ -72,22 +72,22 @@ var ElementShape = Element.extend({
                 var w = parseInt(size[0]),
                     h = parseInt(size[1]);
             }
-            oIcon.style.width = w + 'px';
-            oIcon.style.height = h + 'px';
+            oIcon.style.width = w + "px";
+            oIcon.style.height = h + "px";
         }
 
         // Construct the real url to fetch for this shape
         var img_url = null;
         if (this.obj.conf.icon.match(/^\[(.*)\]$/)) {
-            img_url = this.obj.conf.icon.replace(/^\[(.*)\]$/, '$1');
+            img_url = this.obj.conf.icon.replace(/^\[(.*)\]$/, "$1");
         } else {
             img_url = oGeneralProperties.path_shapes + this.obj.conf.icon;
         }
 
-        if (img_url.indexOf('?') !== -1) {
-            img_url += '&_t=' + iNow;
+        if (img_url.indexOf("?") !== -1) {
+            img_url += "&_t=" + iNow;
         } else {
-            img_url += '?_t=' + iNow;
+            img_url += "?_t=" + iNow;
         }
 
         addZoomHandler(oIcon);
@@ -95,8 +95,8 @@ var ElementShape = Element.extend({
         oIcon.src = img_url;
         oIcon.alt = this.obj.conf.type;
 
-        if (this.obj.conf.url && this.obj.conf.url !== '') {
-            var oIconLink = document.createElement('a');
+        if (this.obj.conf.url && this.obj.conf.url !== "") {
+            var oIconLink = document.createElement("a");
             oIconLink.href = this.obj.conf.url;
             oIconLink.target = this.obj.conf.url_target;
             oIconLink.appendChild(oIcon);

--- a/share/frontend/nagvis-js/js/ElementTile.js
+++ b/share/frontend/nagvis-js/js/ElementTile.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var ElementTile = Element.extend({
+const ElementTile = Element.extend({
     render: function () {
         this.renderTile();
     },
@@ -32,11 +32,11 @@ var ElementTile = Element.extend({
 
     // Renders the DOM nodes of the object to show it on the overview page
     renderTile: function () {
-        var alt = "";
+        let alt = "";
         if (this.type == "service") alt = this.obj.conf.name + "-" + this.obj.conf.service_description;
         else alt = this.obj.conf.name;
 
-        var div = document.createElement("div");
+        const div = document.createElement("div");
         this.dom_obj = div;
         this.obj.trigger_obj = div;
         div.setAttribute("id", this.obj.conf.object_id);
@@ -44,7 +44,7 @@ var ElementTile = Element.extend({
 
         // needed for IE. It seems as the IE does not really know what to do
         // with the link definied below ... strange one
-        var url = this.obj.conf.overview_url;
+        const url = this.obj.conf.overview_url;
         div.onclick = function () {
             location.href = url;
             return false;
@@ -54,7 +54,7 @@ var ElementTile = Element.extend({
         if (oPageProperties.showmapthumbs == 1) div.style.height = "200px";
 
         // Link
-        var oLink = document.createElement("a");
+        const oLink = document.createElement("a");
         oLink.setAttribute("id", this.obj.conf.object_id + "-icon");
         oLink.style.display = "block";
         oLink.style.width = "100%";
@@ -63,7 +63,7 @@ var ElementTile = Element.extend({
 
         // Status image
         if (this.obj.conf.icon !== null && this.obj.conf.icon !== "") {
-            var oImg = document.createElement("img");
+            const oImg = document.createElement("img");
             oImg.className = "state";
             oImg.align = "right";
             oImg.src = oGeneralProperties.path_iconsets + this.obj.conf.icon;
@@ -75,7 +75,7 @@ var ElementTile = Element.extend({
         }
 
         // Title
-        var h3 = document.createElement("h3");
+        const h3 = document.createElement("h3");
         h3.appendChild(document.createTextNode(this.obj.conf.alias));
         oLink.appendChild(h3);
 

--- a/share/frontend/nagvis-js/js/ElementTile.js
+++ b/share/frontend/nagvis-js/js/ElementTile.js
@@ -22,7 +22,7 @@
  *****************************************************************************/
 
 var ElementTile = Element.extend({
-    render: function() {
+    render: function () {
         this.renderTile();
     },
 
@@ -32,61 +32,58 @@ var ElementTile = Element.extend({
 
     // Renders the DOM nodes of the object to show it on the overview page
     renderTile: function () {
-        var alt = '';
-        if(this.type == 'service')
-            alt = this.obj.conf.name+'-'+this.obj.conf.service_description;
-        else
-            alt = this.obj.conf.name;
+        var alt = "";
+        if (this.type == "service") alt = this.obj.conf.name + "-" + this.obj.conf.service_description;
+        else alt = this.obj.conf.name;
 
-        var div = document.createElement('div');
+        var div = document.createElement("div");
         this.dom_obj = div;
         this.obj.trigger_obj = div;
-        div.setAttribute('id', this.obj.conf.object_id);
-        div.className = 'mapobj '+this.obj.conf.overview_class;
+        div.setAttribute("id", this.obj.conf.object_id);
+        div.className = "mapobj " + this.obj.conf.overview_class;
 
         // needed for IE. It seems as the IE does not really know what to do
         // with the link definied below ... strange one
         var url = this.obj.conf.overview_url;
-        div.onclick = function() {
+        div.onclick = function () {
             location.href = url;
             return false;
         };
 
         // Only show map thumb when configured
-        if(oPageProperties.showmapthumbs == 1)
-            div.style.height = '200px';
+        if (oPageProperties.showmapthumbs == 1) div.style.height = "200px";
 
         // Link
-        var oLink = document.createElement('a');
-        oLink.setAttribute('id', this.obj.conf.object_id+'-icon');
+        var oLink = document.createElement("a");
+        oLink.setAttribute("id", this.obj.conf.object_id + "-icon");
         oLink.style.display = "block";
         oLink.style.width = "100%";
         oLink.style.height = "100%";
         oLink.href = this.obj.conf.overview_url;
 
         // Status image
-        if (this.obj.conf.icon !== null && this.obj.conf.icon !== '') {
-            var oImg   = document.createElement('img');
-            oImg.className = 'state';
-            oImg.align = 'right';
-            oImg.src   = oGeneralProperties.path_iconsets + this.obj.conf.icon;
-            oImg.style.width = this.obj.conf.icon_size + 'px';
-            oImg.style.height = this.obj.conf.icon_size + 'px';
-            oImg.alt   = this.obj.stateText();
+        if (this.obj.conf.icon !== null && this.obj.conf.icon !== "") {
+            var oImg = document.createElement("img");
+            oImg.className = "state";
+            oImg.align = "right";
+            oImg.src = oGeneralProperties.path_iconsets + this.obj.conf.icon;
+            oImg.style.width = this.obj.conf.icon_size + "px";
+            oImg.style.height = this.obj.conf.icon_size + "px";
+            oImg.alt = this.obj.stateText();
 
             oLink.appendChild(oImg);
         }
 
         // Title
-        var h3 = document.createElement('h3');
+        var h3 = document.createElement("h3");
         h3.appendChild(document.createTextNode(this.obj.conf.alias));
         oLink.appendChild(h3);
 
         // Only show map thumb when configured
-        if(oPageProperties.showmapthumbs == 1 && this.obj.conf.overview_image != '') {
-            oImg = document.createElement('img');
-            oImg.style.width = '200px';
-            oImg.style.height = '150px';
+        if (oPageProperties.showmapthumbs == 1 && this.obj.conf.overview_image != "") {
+            oImg = document.createElement("img");
+            oImg.style.width = "200px";
+            oImg.style.height = "150px";
             oImg.src = this.obj.conf.overview_image;
             oLink.appendChild(oImg);
         }

--- a/share/frontend/nagvis-js/js/NagVisAggr.js
+++ b/share/frontend/nagvis-js/js/NagVisAggr.js
@@ -22,7 +22,7 @@
  *****************************************************************************/
 
 var NagVisAggr = NagVisStatefulObject.extend({
-    constructor: function(oConf) {
+    constructor: function (oConf) {
         this.base(oConf);
     }
 });

--- a/share/frontend/nagvis-js/js/NagVisAggr.js
+++ b/share/frontend/nagvis-js/js/NagVisAggr.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var NagVisAggr = NagVisStatefulObject.extend({
+const NagVisAggr = NagVisStatefulObject.extend({
     constructor: function (oConf) {
         this.base(oConf);
     }

--- a/share/frontend/nagvis-js/js/NagVisContainer.js
+++ b/share/frontend/nagvis-js/js/NagVisContainer.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var NagVisContainer = NagVisStatelessObject.extend({
+const NagVisContainer = NagVisStatelessObject.extend({
     update: function () {
         this.clearElements();
         new ElementBox(this).addTo(this);
@@ -31,7 +31,7 @@ var NagVisContainer = NagVisStatelessObject.extend({
     render: function () {
         this.base();
 
-        var span = this.elements[0].dom_obj.childNodes[0];
+        const span = this.elements[0].dom_obj.childNodes[0];
         span.style.display = "block";
         span.style.height = "100%";
 
@@ -52,7 +52,7 @@ var NagVisContainer = NagVisStatelessObject.extend({
         } else {
             // Create an iframe element which holds the requested url
             span.innerHTML = "";
-            var oIframe = document.createElement("iframe");
+            let oIframe = document.createElement("iframe");
             oIframe.style.borderWidth = 0;
             oIframe.style.width = "100%";
             oIframe.style.height = "100%";

--- a/share/frontend/nagvis-js/js/NagVisContainer.js
+++ b/share/frontend/nagvis-js/js/NagVisContainer.js
@@ -22,7 +22,7 @@
  *****************************************************************************/
 
 var NagVisContainer = NagVisStatelessObject.extend({
-    update: function() {
+    update: function () {
         this.clearElements();
         new ElementBox(this).addTo(this);
         this.base();
@@ -32,32 +32,30 @@ var NagVisContainer = NagVisStatelessObject.extend({
         this.base();
 
         var span = this.elements[0].dom_obj.childNodes[0];
-        span.style.display = 'block';
-        span.style.height = '100%';
+        span.style.display = "block";
+        span.style.height = "100%";
 
-        if (this.conf.view_type === 'inline') {
+        if (this.conf.view_type === "inline") {
             // Request data via ajax call and add it directly to the current page
             call_ajax(this.conf.url, {
-                response_handler: function(html, span) {
+                response_handler: function (html, span) {
                     span.innerHTML = html;
                 },
-                error_handler: function(status_code, response, span) {
-                    if (status_code === 200)
-                        span.innerHTML = 'Error: '+response;
-                    else
-                        span.innerHTML = 'Error: '+status_code;
+                error_handler: function (status_code, response, span) {
+                    if (status_code === 200) span.innerHTML = "Error: " + response;
+                    else span.innerHTML = "Error: " + status_code;
                 },
-                handler_data : span,
-                decode_json  : false,
-                add_ajax_id  : false,
+                handler_data: span,
+                decode_json: false,
+                add_ajax_id: false
             });
         } else {
             // Create an iframe element which holds the requested url
-            span.innerHTML = '';
-            var oIframe = document.createElement('iframe');
+            span.innerHTML = "";
+            var oIframe = document.createElement("iframe");
             oIframe.style.borderWidth = 0;
-            oIframe.style.width  = '100%';
-            oIframe.style.height = '100%';
+            oIframe.style.width = "100%";
+            oIframe.style.height = "100%";
             oIframe.src = this.conf.url;
             span.appendChild(oIframe);
             oIframe = null;
@@ -68,7 +66,7 @@ var NagVisContainer = NagVisStatelessObject.extend({
     // END OF PUBLIC METHODS
     //
 
-    getText: function() {
-        return '';
+    getText: function () {
+        return "";
     }
 });

--- a/share/frontend/nagvis-js/js/NagVisDynGroup.js
+++ b/share/frontend/nagvis-js/js/NagVisDynGroup.js
@@ -22,7 +22,7 @@
  *****************************************************************************/
 
 var NagVisDynGroup = NagVisStatefulObject.extend({
-    constructor: function(oConf) {
+    constructor: function (oConf) {
         this.base(oConf);
     }
 });

--- a/share/frontend/nagvis-js/js/NagVisDynGroup.js
+++ b/share/frontend/nagvis-js/js/NagVisDynGroup.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var NagVisDynGroup = NagVisStatefulObject.extend({
+const NagVisDynGroup = NagVisStatefulObject.extend({
     constructor: function (oConf) {
         this.base(oConf);
     }

--- a/share/frontend/nagvis-js/js/NagVisHost.js
+++ b/share/frontend/nagvis-js/js/NagVisHost.js
@@ -22,7 +22,7 @@
  *****************************************************************************/
 
 var NagVisHost = NagVisStatefulObject.extend({
-    constructor: function(oConf) {
+    constructor: function (oConf) {
         this.base(oConf);
     }
 });

--- a/share/frontend/nagvis-js/js/NagVisHost.js
+++ b/share/frontend/nagvis-js/js/NagVisHost.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var NagVisHost = NagVisStatefulObject.extend({
+const NagVisHost = NagVisStatefulObject.extend({
     constructor: function (oConf) {
         this.base(oConf);
     }

--- a/share/frontend/nagvis-js/js/NagVisHostgroup.js
+++ b/share/frontend/nagvis-js/js/NagVisHostgroup.js
@@ -22,7 +22,7 @@
  *
  *****************************************************************************/
 
-var NagVisHostgroup = NagVisStatefulObject.extend({
+const NagVisHostgroup = NagVisStatefulObject.extend({
     constructor: function (oConf) {
         this.base(oConf);
     }

--- a/share/frontend/nagvis-js/js/NagVisHostgroup.js
+++ b/share/frontend/nagvis-js/js/NagVisHostgroup.js
@@ -23,7 +23,7 @@
  *****************************************************************************/
 
 var NagVisHostgroup = NagVisStatefulObject.extend({
-    constructor: function(oConf) {
+    constructor: function (oConf) {
         this.base(oConf);
     }
 });

--- a/share/frontend/nagvis-js/js/NagVisLine.js
+++ b/share/frontend/nagvis-js/js/NagVisLine.js
@@ -22,7 +22,7 @@
  *
  *****************************************************************************/
 
-var NagVisLine = NagVisStatelessObject.extend({
+const NagVisLine = NagVisStatelessObject.extend({
     constructor: function (oConf) {
         // Call parent constructor;
         this.base(oConf);
@@ -31,7 +31,7 @@ var NagVisLine = NagVisStatelessObject.extend({
     update: function () {
         this.clearElements();
 
-        var line = new ElementLine(this).addTo(this);
+        const line = new ElementLine(this).addTo(this);
 
         // Apply line color configurations
         line.calcColors = (function (obj) {

--- a/share/frontend/nagvis-js/js/NagVisLine.js
+++ b/share/frontend/nagvis-js/js/NagVisLine.js
@@ -23,23 +23,23 @@
  *****************************************************************************/
 
 var NagVisLine = NagVisStatelessObject.extend({
-    constructor: function(oConf) {
+    constructor: function (oConf) {
         // Call parent constructor;
         this.base(oConf);
     },
 
-    update: function() {
+    update: function () {
         this.clearElements();
 
         var line = new ElementLine(this).addTo(this);
 
         // Apply line color configurations
-        line.calcColors = function(obj) {
-            return function() {
+        line.calcColors = (function (obj) {
+            return function () {
                 return [obj.conf.line_color, obj.conf.line_color_border];
             };
-        }(this);
+        })(this);
 
         this.base();
-    },
+    }
 });

--- a/share/frontend/nagvis-js/js/NagVisMap.js
+++ b/share/frontend/nagvis-js/js/NagVisMap.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var NagVisMap = NagVisStatefulObject.extend({
+const NagVisMap = NagVisStatefulObject.extend({
     update: function () {
         this.clearElements();
 
@@ -31,7 +31,7 @@ var NagVisMap = NagVisStatefulObject.extend({
     },
 
     stateText: function () {
-        var substate = "";
+        let substate = "";
         if (this.conf.summary_in_downtime == 1) substate = " (downtime)";
         else if (this.conf.summary_problem_has_been_acknowledged == 1) substate = " (ack)";
         else if (this.conf.summary_stale) substate = " (stale)";

--- a/share/frontend/nagvis-js/js/NagVisMap.js
+++ b/share/frontend/nagvis-js/js/NagVisMap.js
@@ -25,20 +25,16 @@ var NagVisMap = NagVisStatefulObject.extend({
     update: function () {
         this.clearElements();
 
-        if (g_view.type == 'overview')
-            new ElementTile(this).addTo(this);
+        if (g_view.type == "overview") new ElementTile(this).addTo(this);
 
         this.base();
     },
 
     stateText: function () {
-        var substate = '';
-        if (this.conf.summary_in_downtime == 1)
-            substate = ' (downtime)';
-        else if (this.conf.summary_problem_has_been_acknowledged == 1)
-            substate = ' (ack)';
-        else if (this.conf.summary_stale)
-            substate = ' (stale)';
+        var substate = "";
+        if (this.conf.summary_in_downtime == 1) substate = " (downtime)";
+        else if (this.conf.summary_problem_has_been_acknowledged == 1) substate = " (ack)";
+        else if (this.conf.summary_stale) substate = " (stale)";
         return this.conf.summary_state + substate;
-    },
+    }
 });

--- a/share/frontend/nagvis-js/js/NagVisObject.js
+++ b/share/frontend/nagvis-js/js/NagVisObject.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var NagVisObject = Base.extend({
+const NagVisObject = Base.extend({
     dom_obj: null,
     trigger_obj: null,
     visible: false, // currently shown on the map?
@@ -62,26 +62,26 @@ var NagVisObject = Base.extend({
 
         if (this.conf.label_show && this.conf.label_show == "1") new ElementLabel(this).addTo(this);
 
-        for (var i = 0; i < this.elements.length; i++) this.elements[i].update();
+        for (let i = 0; i < this.elements.length; i++) this.elements[i].update();
     },
 
     // The counterpart of update(). Remove the elements added
     // by update. This is used to clean up to prepare a subsequent
     // call of update
     clearElements: function () {
-        for (var i = 0; i < this.elements.length; i++) this.elements[i].removeFrom(this);
+        for (let i = 0; i < this.elements.length; i++) this.elements[i].removeFrom(this);
     },
 
     updateAttrs: function (attrs, only_state) {
         // Update this object (loop all options from array and set in current obj)
-        for (var key in attrs) if (key != "object_id") this.conf[key] = attrs[key];
+        for (const key in attrs) if (key != "object_id") this.conf[key] = attrs[key];
 
         if (!only_state) {
             this.transformAttributes();
             if (this.conf.x) this.transformCoordinates();
         }
 
-        for (var i = 0; i < this.elements.length; i++) this.elements[i].updateAttrs(only_state, this.bIsLocked);
+        for (let i = 0; i < this.elements.length; i++) this.elements[i].updateAttrs(only_state, this.bIsLocked);
 
         if (!only_state && this.conf.x) {
             this.clearElements();
@@ -101,18 +101,18 @@ var NagVisObject = Base.extend({
         this.erase();
 
         // Create container div
-        var container = document.createElement("div");
+        const container = document.createElement("div");
         container.setAttribute("id", this.conf.object_id);
 
         // Save reference to DOM obj in js obj
         this.dom_obj = container;
 
-        for (var i = 0; i < this.elements.length; i++) {
+        for (let i = 0; i < this.elements.length; i++) {
             this.elements[i].render();
         }
 
         if (!this.bIsLocked) {
-            for (i = 0; i < this.elements.length; i++) {
+            for (let i = 0; i < this.elements.length; i++) {
                 this.elements[i].unlock();
             }
         }
@@ -124,18 +124,18 @@ var NagVisObject = Base.extend({
         // to the dom before being able to calculate the correct coordinates
         // needed in place().
         if (this.conf.type == "line" || this.conf.view_type == "line")
-            for (i = 0; i < this.elements.length; i++) this.elements[i].place();
+            for (let i = 0; i < this.elements.length; i++) this.elements[i].place();
     },
 
     draw: function () {
-        for (var i = 0; i < this.elements.length; i++) this.elements[i].draw(this);
+        for (let i = 0; i < this.elements.length; i++) this.elements[i].draw(this);
         this.visible = true;
     },
 
     erase: function () {
         if (!this.visible) return;
 
-        for (var i = 0; i < this.elements.length; i++) this.elements[i].erase(this);
+        for (let i = 0; i < this.elements.length; i++) this.elements[i].erase(this);
 
         g_view.eraseObject(this);
         this.visible = false;
@@ -175,7 +175,7 @@ var NagVisObject = Base.extend({
             return;
         }
 
-        var unlocked = oUserProperties["unlocked-" + oPageProperties.map_name].split(",");
+        const unlocked = oUserProperties["unlocked-" + oPageProperties.map_name].split(",");
         this.bIsLocked = unlocked.indexOf(this.conf.object_id) === -1 && unlocked.indexOf("*") === -1;
     },
 
@@ -214,13 +214,13 @@ var NagVisObject = Base.extend({
     },
 
     transformCoordinates: function () {
-        var converted = g_view.project(this.conf.x.toString().split(","), this.conf.y.toString().split(","));
+        const converted = g_view.project(this.conf.x.toString().split(","), this.conf.y.toString().split(","));
         this.conf.x = converted[0].join(",");
         this.conf.y = converted[1].join(",");
     },
 
     getLineMid: function (coord, dir) {
-        var c = coord.split(",");
+        const c = coord.split(",");
         if (c.length == 2)
             return middle(this.parseCoords(coord, dir)[0], this.parseCoords(coord, dir)[1], this.conf.line_cut);
         else return this.parseCoords(coord, dir)[1];
@@ -233,20 +233,20 @@ var NagVisObject = Base.extend({
      * @author  Lars Michelsen <lm@larsmichelsen.com>
      */
     toggleLock: function (lock) {
-        var equal = false;
+        let equal = false;
         if (isset(lock) && lock === this.bIsLocked) equal = true;
 
         if (isset(lock)) this.bIsLocked = lock;
         else this.bIsLocked = !this.bIsLocked;
 
-        for (var i = 0; i < this.elements.length; i++)
+        for (let i = 0; i < this.elements.length; i++)
             if (this.bIsLocked) this.elements[i].lock();
             else this.elements[i].unlock();
 
         // Only save the user option when not using the edit_mode
         // eslint-disable-next-line no-prototype-builtins
         if (!isset(lock) && (!oViewProperties.hasOwnProperty("edit_mode") || oViewProperties["edit_mode"] !== true)) {
-            var unlocked = [];
+            let unlocked = [];
             // eslint-disable-next-line no-prototype-builtins
             if (oUserProperties.hasOwnProperty("unlocked-" + oPageProperties.map_name))
                 unlocked = oUserProperties["unlocked-" + oPageProperties.map_name].split(",");
@@ -278,13 +278,13 @@ var NagVisObject = Base.extend({
     },
 
     getObjWidth: function () {
-        var o = document.getElementById(this.conf.object_id + "-icondiv");
+        const o = document.getElementById(this.conf.object_id + "-icondiv");
         if (o && o.clientWidth) return parseInt(o.clientWidth);
         else return 0;
     },
 
     getObjHeight: function () {
-        var o = document.getElementById(this.conf.object_id + "-icondiv");
+        const o = document.getElementById(this.conf.object_id + "-icondiv");
         if (o && o.clientHeight) return parseInt(o.clientHeight);
         else return 0;
     },
@@ -299,15 +299,15 @@ var NagVisObject = Base.extend({
     parseCoord: function (val, dir, addZoom) {
         if (addZoom === undefined) addZoom = true;
 
-        var coord = 0;
+        let coord = 0;
 
         if (!isRelativeCoord(val)) {
             coord = parseInt(val);
         } else {
-            var parts = val.split("%");
-            var objectId = parts[0];
-            var offset = parts[1];
-            var refObj = getMapObjByDomObjId(objectId);
+            const parts = val.split("%");
+            const objectId = parts[0];
+            const offset = parts[1];
+            const refObj = getMapObjByDomObjId(objectId);
             if (refObj) {
                 coord = parseFloat(refObj.parseCoord(refObj.conf[dir], dir, false));
                 if (addZoom) coord = addZoomFactor(coord, true);
@@ -330,29 +330,30 @@ var NagVisObject = Base.extend({
      * @author  Lars Michelsen <lm@larsmichelsen.com>
      */
     parseCoords: function (val, dir, addZoom) {
-        var l = [];
+        let l = [];
 
         if (val) l = val.toString().split(",");
 
-        for (var i = 0, len = l.length; i < len; i++) l[i] = this.parseCoord(l[i], dir, addZoom);
+        for (let i = 0, len = l.length; i < len; i++) l[i] = this.parseCoord(l[i], dir, addZoom);
 
         return l;
     },
 
     // Transform the current coords to absolute coords when relative
     makeAbsoluteCoords: function (num) {
-        var x = num === -1 ? this.conf.x : this.conf.x.split(",")[num];
-        var y = num === -1 ? this.conf.y : this.conf.y.split(",")[num];
+        const x = num === -1 ? this.conf.x : this.conf.x.split(",")[num];
+        const y = num === -1 ? this.conf.y : this.conf.y.split(",")[num];
 
         // Skip when already absolute
         if (!isRelativeCoord(x) && !isRelativeCoord(y)) return;
 
         // Get parent object ids
-        var xParent = this.getCoordParent(this.conf.x, num);
-        var yParent = this.getCoordParent(this.conf.y, num);
+        const xParent = this.getCoordParent(this.conf.x, num);
+        const yParent = this.getCoordParent(this.conf.y, num);
 
+        let o;
         if (xParent == yParent) {
-            var o = getMapObjByDomObjId(xParent);
+            o = getMapObjByDomObjId(xParent);
             // Don't remove when another coord is a child of this object
             if (o && Object.size(this.getRelativeCoordsUsingParent(xParent)) == 1) {
                 o.delChild(this);
@@ -377,7 +378,7 @@ var NagVisObject = Base.extend({
             this.conf.x = this.parseCoord(x, "x", false);
             this.conf.y = this.parseCoord(y, "y", false);
         } else {
-            var old = this.conf.x.split(",");
+            let old = this.conf.x.split(",");
             old[num] = this.parseCoord(x, "x", false);
             this.conf.x = old.join(",");
 
@@ -390,19 +391,20 @@ var NagVisObject = Base.extend({
     // Transform the current coords to relative
     // coords to the given object
     makeRelativeCoords: function (oParent, num) {
-        var xParent = this.getCoordParent(this.conf.x, num);
-        var yParent = this.getCoordParent(this.conf.y, num);
+        const xParent = this.getCoordParent(this.conf.x, num);
+        const yParent = this.getCoordParent(this.conf.y, num);
 
-        var x = num === -1 ? this.conf.x : this.conf.x.split(",")[num];
-        var y = num === -1 ? this.conf.y : this.conf.y.split(",")[num];
+        const x = num === -1 ? this.conf.x : this.conf.x.split(",")[num];
+        const y = num === -1 ? this.conf.y : this.conf.y.split(",")[num];
 
         if (isRelativeCoord(x) && isRelativeCoord(y)) {
             // Skip this when already relative to the same object
             if (xParent == oParent.conf.object_id && yParent == oParent.conf.object_id) return;
 
             // If this object was attached to another parent before, remove the attachment
+            let o;
             if (xParent != oParent.conf.object_id) {
-                var o = getMapObjByDomObjId(xParent);
+                o = getMapObjByDomObjId(xParent);
                 if (o) {
                     o.delChild(this);
                     o = null;
@@ -427,10 +429,10 @@ var NagVisObject = Base.extend({
             this.conf.x = this.getRelCoords(oParent, this.parseCoord(this.conf.x, "x", false), "x", -1);
             this.conf.y = this.getRelCoords(oParent, this.parseCoord(this.conf.y, "y", false), "y", -1);
         } else {
-            var newX = this.getRelCoords(oParent, this.parseCoords(this.conf.x, "x", false)[num], "x", -1);
-            var newY = this.getRelCoords(oParent, this.parseCoords(this.conf.y, "y", false)[num], "y", -1);
+            const newX = this.getRelCoords(oParent, this.parseCoords(this.conf.x, "x", false)[num], "x", -1);
+            const newY = this.getRelCoords(oParent, this.parseCoords(this.conf.y, "y", false)[num], "y", -1);
 
-            var old = this.conf.x.split(",");
+            let old = this.conf.x.split(",");
             old[num] = newX;
             this.conf.x = old.join(",");
 
@@ -444,22 +446,22 @@ var NagVisObject = Base.extend({
      * Returns the object id of the parent object
      */
     getCoordParent: function (val, num) {
-        var coord = num === -1 ? val.toString() : val.split(",")[num].toString();
+        const coord = num === -1 ? val.toString() : val.split(",")[num].toString();
         return coord.search("%") !== -1 ? coord.split("%")[0] : coord;
     },
 
     getRelCoords: function (refObj, val, dir, num) {
-        var refPos = num === -1 ? refObj.conf[dir] : refObj.conf[dir].split(",")[num];
-        var offset = parseInt(val) - parseInt(refObj.parseCoord(refPos, dir, false));
-        var pre = offset >= 0 ? "+" : "";
+        const refPos = num === -1 ? refObj.conf[dir] : refObj.conf[dir].split(",")[num];
+        const offset = parseInt(val) - parseInt(refObj.parseCoord(refPos, dir, false));
+        const pre = offset >= 0 ? "+" : "";
         val = refObj.conf.object_id + "%" + pre + offset;
         refObj = null;
         return val;
     },
 
     hasRelativeCoord: function () {
-        var coords = this.conf.x.toString().split(",").concat(this.conf.y.toString().split(","));
-        for (var i = 0, len = coords.length; i < len; i++) if (isRelativeCoord(coords[i])) return true;
+        const coords = this.conf.x.toString().split(",").concat(this.conf.y.toString().split(","));
+        for (let i = 0, len = coords.length; i < len; i++) if (isRelativeCoord(coords[i])) return true;
         return false;
     },
 
@@ -475,16 +477,16 @@ var NagVisObject = Base.extend({
     calcNewCoord: function (val, dir, num) {
         if (!isset(num)) num = -1;
 
-        var oldVal = num === -1 ? this.conf[dir] : this.conf[dir].split(",")[num];
+        let oldVal = num === -1 ? this.conf[dir] : this.conf[dir].split(",")[num];
         // Check if the current value is an integer or a relative coord
         if (isset(oldVal) && isRelativeCoord(oldVal)) {
             // This must be an object id
-            var objectId = null;
+            let objectId = null;
             if (oldVal.search("%") !== -1) objectId = oldVal.split("%")[0];
             else objectId = oldVal;
 
             // Only an object id. Get the coordinate and return it
-            var refObj = getMapObjByDomObjId(objectId);
+            const refObj = getMapObjByDomObjId(objectId);
             // FIXME: Maybe the parent object is also a line. Then -1 is not correct
             if (refObj) val = this.getRelCoords(refObj, val, dir, -1);
             objectId = null;
@@ -496,7 +498,7 @@ var NagVisObject = Base.extend({
         if (num === -1) {
             return val;
         } else {
-            var old = this.conf[dir].split(",");
+            const old = this.conf[dir].split(",");
             if (isRelativeCoord(val)) old[num] = val;
             else old[num] = Math.round(val);
             return old.join(",");
@@ -511,9 +513,9 @@ var NagVisObject = Base.extend({
      * @author  Lars Michelsen <lm@larsmichelsen.com>
      */
     getParentObjectIds: function (num) {
-        var parentIds = {};
+        const parentIds = {};
 
-        var coords;
+        let coords;
         if (isset(num)) {
             coords = (this.conf["x"].split(",")[num] + "," + this.conf["y"].split(",")[num]).split(",");
         } else if (isset(this.conf.x) && isset(this.conf.y)) {
@@ -524,7 +526,7 @@ var NagVisObject = Base.extend({
             return parentIds;
         }
 
-        for (var i = 0, len = coords.length; i < len; i++) {
+        for (let i = 0, len = coords.length; i < len; i++) {
             if (isRelativeCoord(coords[i])) {
                 if (coords[i].search("%") !== -1) parentIds[coords[i].split("%")[0]] = true;
                 else if (coords[i]) parentIds[coords[i]] = true;
@@ -539,8 +541,8 @@ var NagVisObject = Base.extend({
      * Returns the coord indexes which use a specific parent object_id
      */
     getRelativeCoordsUsingParent: function (parentId) {
-        var matches = {};
-        for (var i = 0, len = this.conf.x.split(",").length; i < len; i++) {
+        const matches = {};
+        for (let i = 0, len = this.conf.x.split(",").length; i < len; i++) {
             if (this.getCoordParent(this.conf.x, i) === parentId && !isset(matches[i])) matches[i] = true;
             else if (this.getCoordParent(this.conf.y, i) === parentId && !isset(matches[i])) matches[i] = true;
         }
@@ -574,11 +576,11 @@ var NagVisObject = Base.extend({
      * After that the change must be sent to the core using saveObject...
      */
     detachChilds: function () {
-        for (var i = this.childs.length - 1; i >= 0; i--) {
-            var nums = this.childs[i].getRelativeCoordsUsingParent(this.conf.object_id);
-            var obj = this.childs[i];
+        for (let i = this.childs.length - 1; i >= 0; i--) {
+            let nums = this.childs[i].getRelativeCoordsUsingParent(this.conf.object_id);
+            let obj = this.childs[i];
 
-            for (var num in nums) {
+            for (const num in nums) {
                 obj.makeAbsoluteCoords(num);
             }
 
@@ -609,7 +611,7 @@ var NagVisObject = Base.extend({
      * coordinates have already been set
      */
     place: function () {
-        var i, l;
+        let i, l;
         for (i = 0, l = this.elements.length; i < l; i++) this.elements[i].place();
 
         // Move child objects
@@ -651,27 +653,27 @@ var NagVisObject = Base.extend({
      * the 'this.' keyword can not be used here.
      */
     moveObject: function (trigger_obj, obj) {
-        var arr = trigger_obj.id.split("-");
-        var newPos;
+        const arr = trigger_obj.id.split("-");
+        let newPos;
         if (obj.conf.view_type === "line") {
             newPos = getMidOfAnchor(trigger_obj);
 
             // Get current positions and replace only the current one
-            var anchorId = arr[2];
+            let anchorId = arr[2];
             newPos = [obj.calcNewCoord(newPos[0], "x", anchorId), obj.calcNewCoord(newPos[1], "y", anchorId)];
 
-            var parents = obj.getParentObjectIds(anchorId);
+            const parents = obj.getParentObjectIds(anchorId);
 
             anchorId = null;
         } else {
             // In case of an anchor there is an offset to the real object.
             // Handle this offset in the coordinate calculation for the obj
-            var offsetX = isset(trigger_obj.objOffsetX) ? trigger_obj.objOffsetX : 0;
-            var offsetY = isset(trigger_obj.objOffsetY) ? trigger_obj.objOffsetY : 0;
+            const offsetX = isset(trigger_obj.objOffsetX) ? trigger_obj.objOffsetX : 0;
+            const offsetY = isset(trigger_obj.objOffsetY) ? trigger_obj.objOffsetY : 0;
 
             newPos = [obj.calcNewCoord(trigger_obj.x - offsetX, "x"), obj.calcNewCoord(trigger_obj.y - offsetY, "y")];
 
-            parents = obj.getParentObjectIds();
+            const parents = obj.getParentObjectIds();
         }
 
         obj.conf.x = newPos[0];
@@ -686,14 +688,16 @@ var NagVisObject = Base.extend({
      * the 'this.' keyword can not be used here.
      */
     saveObject: function (trigger_obj, obj, oParent) {
-        var arr = trigger_obj.id.split("-");
-        if (arr.length > 2) var anchorId = arr[2];
+        const arr = trigger_obj.id.split("-");
+        let anchorId;
+        if (arr.length > 2) anchorId = arr[2];
         if (obj.conf.view_type !== "line") anchorId = -1;
 
         // Honor the enabled grid and reposition the object after dropping
         if (useGrid()) {
+            let pos;
             if (obj.conf.view_type === "line") {
-                var pos = coordsToGrid(
+                pos = coordsToGrid(
                     obj.parseCoords(obj.conf.x, "x", false)[anchorId],
                     obj.parseCoords(obj.conf.y, "y", false)[anchorId]
                 );
@@ -712,10 +716,10 @@ var NagVisObject = Base.extend({
             if (oParent !== false) obj.makeRelativeCoords(oParent, anchorId);
             else obj.makeAbsoluteCoords(anchorId);
 
-        var x = obj.conf.x,
+        let x = obj.conf.x,
             y = obj.conf.y;
 
-        var parts = g_view.unproject(x.toString().split(","), y.toString().split(","));
+        const parts = g_view.unproject(x.toString().split(","), y.toString().split(","));
         x = parts[0].join(",");
         y = parts[1].join(",");
 

--- a/share/frontend/nagvis-js/js/NagVisObject.js
+++ b/share/frontend/nagvis-js/js/NagVisObject.js
@@ -112,7 +112,7 @@ var NagVisObject = Base.extend({
         }
 
         if (!this.bIsLocked) {
-            for (var i = 0; i < this.elements.length; i++) {
+            for (i = 0; i < this.elements.length; i++) {
                 this.elements[i].unlock();
             }
         }
@@ -124,7 +124,7 @@ var NagVisObject = Base.extend({
         // to the dom before being able to calculate the correct coordinates
         // needed in place().
         if (this.conf.type == "line" || this.conf.view_type == "line")
-            for (var i = 0; i < this.elements.length; i++) this.elements[i].place();
+            for (i = 0; i < this.elements.length; i++) this.elements[i].place();
     },
 
     draw: function () {
@@ -358,12 +358,12 @@ var NagVisObject = Base.extend({
                 o.delChild(this);
             }
         } else {
-            var o = getMapObjByDomObjId(xParent);
+            o = getMapObjByDomObjId(xParent);
             // Don't remove when another coord is a child of this object
             if (o && Object.size(this.getRelativeCoordsUsingParent(xParent)) == 1) {
                 o.delChild(this);
             }
-            var o = getMapObjByDomObjId(yParent);
+            o = getMapObjByDomObjId(yParent);
             // Don't remove when another coord is a child of this object
             if (o && Object.size(this.getRelativeCoordsUsingParent(yParent)) == 1) {
                 o.delChild(this);
@@ -409,7 +409,7 @@ var NagVisObject = Base.extend({
                 }
             }
             if (yParent != oParent.conf.object_id) {
-                var o = getMapObjByDomObjId(yParent);
+                o = getMapObjByDomObjId(yParent);
                 if (o) {
                     o.delChild(this);
                     o = null;
@@ -473,7 +473,7 @@ var NagVisObject = Base.extend({
      * @author  Lars Michelsen <lm@larsmichelsen.com>
      */
     calcNewCoord: function (val, dir, num) {
-        if (!isset(num)) var num = -1;
+        if (!isset(num)) num = -1;
 
         var oldVal = num === -1 ? this.conf[dir] : this.conf[dir].split(",")[num];
         // Check if the current value is an integer or a relative coord
@@ -513,10 +513,11 @@ var NagVisObject = Base.extend({
     getParentObjectIds: function (num) {
         var parentIds = {};
 
+        var coords;
         if (isset(num)) {
-            var coords = (this.conf["x"].split(",")[num] + "," + this.conf["y"].split(",")[num]).split(",");
+            coords = (this.conf["x"].split(",")[num] + "," + this.conf["y"].split(",")[num]).split(",");
         } else if (isset(this.conf.x) && isset(this.conf.y)) {
-            var coords = (this.conf.x + "," + this.conf.y).split(",");
+            coords = (this.conf.x + "," + this.conf.y).split(",");
         } else {
             // Don't try to do strange things for objects not having coordinates. But
             // that should never happen anyways.
@@ -608,10 +609,11 @@ var NagVisObject = Base.extend({
      * coordinates have already been set
      */
     place: function () {
-        for (var i = 0, l = this.elements.length; i < l; i++) this.elements[i].place();
+        var i, l;
+        for (i = 0, l = this.elements.length; i < l; i++) this.elements[i].place();
 
         // Move child objects
-        for (var i = 0, l = this.childs.length; i < l; i++) this.childs[i].place();
+        for (i = 0, l = this.childs.length; i < l; i++) this.childs[i].place();
     },
 
     needsContextMenu: function () {
@@ -669,7 +671,7 @@ var NagVisObject = Base.extend({
 
             newPos = [obj.calcNewCoord(trigger_obj.x - offsetX, "x"), obj.calcNewCoord(trigger_obj.y - offsetY, "y")];
 
-            var parents = obj.getParentObjectIds();
+            parents = obj.getParentObjectIds();
         }
 
         obj.conf.x = newPos[0];
@@ -698,7 +700,7 @@ var NagVisObject = Base.extend({
                 obj.conf.x = obj.calcNewCoord(pos[0], "x", anchorId);
                 obj.conf.y = obj.calcNewCoord(pos[1], "y", anchorId);
             } else {
-                var pos = coordsToGrid(obj.parseCoord(obj.conf.x, "x", false), obj.parseCoord(obj.conf.y, "y", false));
+                pos = coordsToGrid(obj.parseCoord(obj.conf.x, "x", false), obj.parseCoord(obj.conf.y, "y", false));
                 obj.conf.x = obj.calcNewCoord(pos[0], "x");
                 obj.conf.y = obj.calcNewCoord(pos[1], "y");
             }

--- a/share/frontend/nagvis-js/js/NagVisObject.js
+++ b/share/frontend/nagvis-js/js/NagVisObject.js
@@ -22,75 +22,66 @@
  *****************************************************************************/
 
 var NagVisObject = Base.extend({
-    dom_obj:               null,
-    trigger_obj:           null,
-    visible:               false, // currently shown on the map?
-    conf:                  null,
-    lastUpdate:            null,
-    firstUpdate:           null,
-    bIsFlashing:           false,
-    bIsLocked:             true,
-    childs:                null,
+    dom_obj: null,
+    trigger_obj: null,
+    visible: false, // currently shown on the map?
+    conf: null,
+    lastUpdate: null,
+    firstUpdate: null,
+    bIsFlashing: false,
+    bIsLocked: true,
+    childs: null,
     // Holds all drawable GUI elements
-    elements:              null,
+    elements: null,
 
-    constructor: function(conf) {
+    constructor: function (conf) {
         this.setLastUpdate();
 
-        this.childs      = [];
-        this.elements    = [];
-        this.conf        = conf;
+        this.childs = [];
+        this.elements = [];
+        this.conf = conf;
 
-        if (this.conf.x) // exclude map summary object
+        if (this.conf.x)
+            // exclude map summary object
             this.transformCoordinates();
 
         // When no object_id given by server: generate own id
-        if (this.conf.object_id == null)
-            this.conf.object_id = getRandomLowerCaseLetter() + getRandom(1, 99999);
+        if (this.conf.object_id == null) this.conf.object_id = getRandomLowerCaseLetter() + getRandom(1, 99999);
 
         // Load lock options
         this.loadLocked();
         this.loadViewOpts();
     },
 
-    update: function() {
+    update: function () {
         // All objects need a context menu
         // (some in all states and some only unlocked)
-        if (this.needsContextMenu())
-            new ElementContext(this).addTo(this);
+        if (this.needsContextMenu()) new ElementContext(this).addTo(this);
 
-        if (this.needsHoverMenu())
-            new ElementHover(this).addTo(this);
+        if (this.needsHoverMenu()) new ElementHover(this).addTo(this);
 
-        if (this.conf.label_show && this.conf.label_show == '1')
-            new ElementLabel(this).addTo(this);
+        if (this.conf.label_show && this.conf.label_show == "1") new ElementLabel(this).addTo(this);
 
-        for (var i = 0; i < this.elements.length; i++)
-            this.elements[i].update();
+        for (var i = 0; i < this.elements.length; i++) this.elements[i].update();
     },
 
     // The counterpart of update(). Remove the elements added
     // by update. This is used to clean up to prepare a subsequent
     // call of update
-    clearElements: function() {
-        for (var i = 0; i < this.elements.length; i++)
-            this.elements[i].removeFrom(this);
+    clearElements: function () {
+        for (var i = 0; i < this.elements.length; i++) this.elements[i].removeFrom(this);
     },
 
-    updateAttrs: function(attrs, only_state) {
+    updateAttrs: function (attrs, only_state) {
         // Update this object (loop all options from array and set in current obj)
-        for (var key in attrs)
-            if (key != 'object_id')
-                this.conf[key] = attrs[key];
+        for (var key in attrs) if (key != "object_id") this.conf[key] = attrs[key];
 
         if (!only_state) {
             this.transformAttributes();
-            if (this.conf.x)
-                this.transformCoordinates();
+            if (this.conf.x) this.transformCoordinates();
         }
 
-        for (var i = 0; i < this.elements.length; i++)
-            this.elements[i].updateAttrs(only_state, this.bIsLocked);
+        for (var i = 0; i < this.elements.length; i++) this.elements[i].updateAttrs(only_state, this.bIsLocked);
 
         if (!only_state && this.conf.x) {
             this.clearElements();
@@ -103,15 +94,15 @@ var NagVisObject = Base.extend({
         this.setLastUpdate();
     },
 
-    transformAttributes: function() {},
+    transformAttributes: function () {},
 
     // Renders the current object and all it's elements
     render: function () {
         this.erase();
 
         // Create container div
-        var container = document.createElement('div');
-        container.setAttribute('id', this.conf.object_id);
+        var container = document.createElement("div");
+        container.setAttribute("id", this.conf.object_id);
 
         // Save reference to DOM obj in js obj
         this.dom_obj = container;
@@ -132,39 +123,34 @@ var NagVisObject = Base.extend({
         // The line labels need a) the line added to DOM and b) the label added
         // to the dom before being able to calculate the correct coordinates
         // needed in place().
-        if (this.conf.type == 'line' || this.conf.view_type == 'line')
-            for (var i = 0; i < this.elements.length; i++)
-                this.elements[i].place();
+        if (this.conf.type == "line" || this.conf.view_type == "line")
+            for (var i = 0; i < this.elements.length; i++) this.elements[i].place();
     },
 
-    draw: function() {
-        for (var i = 0; i < this.elements.length; i++)
-            this.elements[i].draw(this);
+    draw: function () {
+        for (var i = 0; i < this.elements.length; i++) this.elements[i].draw(this);
         this.visible = true;
     },
 
     erase: function () {
-        if (!this.visible)
-            return;
+        if (!this.visible) return;
 
-        for (var i = 0; i < this.elements.length; i++)
-            this.elements[i].erase(this);
+        for (var i = 0; i < this.elements.length; i++) this.elements[i].erase(this);
 
         g_view.eraseObject(this);
         this.visible = false;
     },
 
-    remove: function() {
+    remove: function () {
         this.erase();
     },
 
-    addElement: function(obj) {
-        if(this.elements.indexOf(obj) === -1)
-            this.elements.push(obj);
+    addElement: function (obj) {
+        if (this.elements.indexOf(obj) === -1) this.elements.push(obj);
         obj = null;
     },
 
-    removeElement: function(obj) {
+    removeElement: function (obj) {
         this.elements.splice(this.elements.indexOf(obj), 1);
         obj = null;
     },
@@ -177,21 +163,19 @@ var NagVisObject = Base.extend({
      * "edit_mode". In this case all map objects are unlocked but this
      * state is not saved to the user properties.
      */
-    loadLocked: function() {
+    loadLocked: function () {
         // Editing is only possible in maps
-        if (g_view.type != 'map')
-            return;
+        if (g_view.type != "map") return;
 
-        if (!oUserProperties.hasOwnProperty('unlocked-' + oPageProperties.map_name))
-            return;
+        if (!oUserProperties.hasOwnProperty("unlocked-" + oPageProperties.map_name)) return;
 
-        if (oViewProperties.hasOwnProperty('edit_mode') && oViewProperties['edit_mode'] === true) {
+        if (oViewProperties.hasOwnProperty("edit_mode") && oViewProperties["edit_mode"] === true) {
             this.bIsLocked = false;
             return;
         }
 
-        var unlocked = oUserProperties['unlocked-' + oPageProperties.map_name].split(',');
-        this.bIsLocked = unlocked.indexOf(this.conf.object_id) === -1 && unlocked.indexOf('*') === -1;
+        var unlocked = oUserProperties["unlocked-" + oPageProperties.map_name].split(",");
+        this.bIsLocked = unlocked.indexOf(this.conf.object_id) === -1 && unlocked.indexOf("*") === -1;
     },
 
     /**
@@ -201,17 +185,16 @@ var NagVisObject = Base.extend({
      *
      * @author Lars Michelsen <lm@larsmichelsen.com>
      */
-    loadViewOpts: function() {
+    loadViewOpts: function () {
         // Do not load the view options for stateless lines
-        if(this.conf.type == 'line')
-            return;
+        if (this.conf.type == "line") return;
 
         // View specific hover modifier set. Will override the map configured option
-        if(isset(oViewProperties) && isset(oViewProperties.hover_menu))
+        if (isset(oViewProperties) && isset(oViewProperties.hover_menu))
             this.conf.hover_menu = oViewProperties.hover_menu;
 
         // View specific context modifier set. Will override the map configured option
-        if(isset(oViewProperties) && isset(oViewProperties.context_menu))
+        if (isset(oViewProperties) && isset(oViewProperties.context_menu))
             this.conf.context_menu = oViewProperties.context_menu;
     },
 
@@ -222,30 +205,24 @@ var NagVisObject = Base.extend({
      *
      * @author	Lars Michelsen <lm@larsmichelsen.com>
      */
-    setLastUpdate: function() {
+    setLastUpdate: function () {
         this.lastUpdate = iNow;
 
         // Save datetime of the first state update (needed for hover parsing)
-        if(this.firstUpdate === null)
-            this.firstUpdate = this.lastUpdate;
+        if (this.firstUpdate === null) this.firstUpdate = this.lastUpdate;
     },
 
-    transformCoordinates: function() {
-        var converted = g_view.project(
-            this.conf.x.toString().split(','),
-            this.conf.y.toString().split(','));
-        this.conf.x = converted[0].join(',');
-        this.conf.y = converted[1].join(',');
+    transformCoordinates: function () {
+        var converted = g_view.project(this.conf.x.toString().split(","), this.conf.y.toString().split(","));
+        this.conf.x = converted[0].join(",");
+        this.conf.y = converted[1].join(",");
     },
 
-    getLineMid: function(coord, dir) {
-        var c = coord.split(',');
-        if(c.length == 2)
-            return middle(this.parseCoords(coord, dir)[0],
-                          this.parseCoords(coord, dir)[1],
-                          this.conf.line_cut);
-        else
-            return this.parseCoords(coord, dir)[1];
+    getLineMid: function (coord, dir) {
+        var c = coord.split(",");
+        if (c.length == 2)
+            return middle(this.parseCoords(coord, dir)[0], this.parseCoords(coord, dir)[1], this.conf.line_cut);
+        else return this.parseCoords(coord, dir)[1];
     },
 
     /**
@@ -254,72 +231,59 @@ var NagVisObject = Base.extend({
      *
      * @author  Lars Michelsen <lm@larsmichelsen.com>
      */
-    toggleLock: function(lock) {
+    toggleLock: function (lock) {
         var equal = false;
-        if(isset(lock) && lock === this.bIsLocked)
-            equal = true;
+        if (isset(lock) && lock === this.bIsLocked) equal = true;
 
-        if(isset(lock))
-            this.bIsLocked = lock;
-        else
-            this.bIsLocked = !this.bIsLocked;
+        if (isset(lock)) this.bIsLocked = lock;
+        else this.bIsLocked = !this.bIsLocked;
 
         for (var i = 0; i < this.elements.length; i++)
-            if (this.bIsLocked)
-                this.elements[i].lock();
-            else
-                this.elements[i].unlock();
+            if (this.bIsLocked) this.elements[i].lock();
+            else this.elements[i].unlock();
 
         // Only save the user option when not using the edit_mode
-        if (!isset(lock) && (!oViewProperties.hasOwnProperty('edit_mode') || oViewProperties['edit_mode'] !== true)) {
+        if (!isset(lock) && (!oViewProperties.hasOwnProperty("edit_mode") || oViewProperties["edit_mode"] !== true)) {
             var unlocked = [];
-            if(oUserProperties.hasOwnProperty('unlocked-' + oPageProperties.map_name))
-                unlocked = oUserProperties['unlocked-' + oPageProperties.map_name].split(',');
+            if (oUserProperties.hasOwnProperty("unlocked-" + oPageProperties.map_name))
+                unlocked = oUserProperties["unlocked-" + oPageProperties.map_name].split(",");
 
-            if(this.bIsLocked)
-                unlocked.splice(unlocked.indexOf(this.conf.object_id), 1);
-            else
-                unlocked.push(this.conf.object_id);
-            storeUserOption('unlocked-' + oPageProperties.map_name, unlocked.join(','));
+            if (this.bIsLocked) unlocked.splice(unlocked.indexOf(this.conf.object_id), 1);
+            else unlocked.push(this.conf.object_id);
+            storeUserOption("unlocked-" + oPageProperties.map_name, unlocked.join(","));
             unlocked = null;
         }
 
-        if (equal === true)
-            return 0;
-        else
-            return this.bIsLocked ? -1 : 1;
+        if (equal === true) return 0;
+        else return this.bIsLocked ? -1 : 1;
     },
 
     getObjLeft: function () {
-        if (this.conf.x.toString().split(',').length > 1) {
-            return Math.min.apply(Math, this.parseCoords(this.conf.x, 'x'));
+        if (this.conf.x.toString().split(",").length > 1) {
+            return Math.min.apply(Math, this.parseCoords(this.conf.x, "x"));
         } else {
-            return this.parseCoord(this.conf.x, 'x');
+            return this.parseCoord(this.conf.x, "x");
         }
     },
 
     getObjTop: function () {
-        if (this.conf.x.toString().split(',').length > 1) {
-            return Math.min.apply(Math, this.parseCoords(this.conf.y, 'y'));
+        if (this.conf.x.toString().split(",").length > 1) {
+            return Math.min.apply(Math, this.parseCoords(this.conf.y, "y"));
         } else {
-            return this.parseCoord(this.conf.y, 'y');
+            return this.parseCoord(this.conf.y, "y");
         }
     },
 
     getObjWidth: function () {
-        var o = document.getElementById(this.conf.object_id + '-icondiv');
-        if(o && o.clientWidth)
-            return parseInt(o.clientWidth);
-        else
-            return 0;
+        var o = document.getElementById(this.conf.object_id + "-icondiv");
+        if (o && o.clientWidth) return parseInt(o.clientWidth);
+        else return 0;
     },
 
     getObjHeight: function () {
-        var o = document.getElementById(this.conf.object_id + '-icondiv');
-        if(o && o.clientHeight)
-            return parseInt(o.clientHeight);
-        else
-            return 0;
+        var o = document.getElementById(this.conf.object_id + "-icondiv");
+        if (o && o.clientHeight) return parseInt(o.clientHeight);
+        else return 0;
     },
 
     /**
@@ -329,37 +293,31 @@ var NagVisObject = Base.extend({
      *
      * @author  Lars Michelsen <lm@larsmichelsen.com>
      */
-    parseCoord: function(val, dir, addZoom) {
-        if (addZoom === undefined)
-            addZoom = true;
+    parseCoord: function (val, dir, addZoom) {
+        if (addZoom === undefined) addZoom = true;
 
         var coord = 0;
 
-        if(!isRelativeCoord(val)) {
+        if (!isRelativeCoord(val)) {
             coord = parseInt(val);
         } else {
-            var parts     = val.split('%');
-            var objectId  = parts[0];
-            var offset    = parts[1];
-            var refObj    = getMapObjByDomObjId(objectId);
+            var parts = val.split("%");
+            var objectId = parts[0];
+            var offset = parts[1];
+            var refObj = getMapObjByDomObjId(objectId);
             if (refObj) {
                 coord = parseFloat(refObj.parseCoord(refObj.conf[dir], dir, false));
-                if (addZoom)
-                    coord = addZoomFactor(coord, true);
+                if (addZoom) coord = addZoomFactor(coord, true);
 
-                if (addZoom)
-                    coord += addZoomFactor(parseFloat(offset), false);
-                else
-                    coord += parseFloat(offset);
+                if (addZoom) coord += addZoomFactor(parseFloat(offset), false);
+                else coord += parseFloat(offset);
 
                 return coord;
             }
         }
 
-        if (addZoom)
-            return addZoomFactor(coord, true);
-        else
-            return coord;
+        if (addZoom) return addZoomFactor(coord, true);
+        else return coord;
     },
 
     /**
@@ -368,46 +326,43 @@ var NagVisObject = Base.extend({
      *
      * @author  Lars Michelsen <lm@larsmichelsen.com>
      */
-    parseCoords: function(val, dir, addZoom) {
+    parseCoords: function (val, dir, addZoom) {
         var l = [];
 
-	if(val)
-            l = val.toString().split(',');
+        if (val) l = val.toString().split(",");
 
-        for(var i = 0, len = l.length; i < len; i++)
-            l[i] = this.parseCoord(l[i], dir, addZoom);
+        for (var i = 0, len = l.length; i < len; i++) l[i] = this.parseCoord(l[i], dir, addZoom);
 
         return l;
     },
 
     // Transform the current coords to absolute coords when relative
-    makeAbsoluteCoords: function(num) {
-        var x = num === -1 ? this.conf.x : this.conf.x.split(',')[num];
-        var y = num === -1 ? this.conf.y : this.conf.y.split(',')[num];
+    makeAbsoluteCoords: function (num) {
+        var x = num === -1 ? this.conf.x : this.conf.x.split(",")[num];
+        var y = num === -1 ? this.conf.y : this.conf.y.split(",")[num];
 
         // Skip when already absolute
-        if(!isRelativeCoord(x) && !isRelativeCoord(y))
-            return;
+        if (!isRelativeCoord(x) && !isRelativeCoord(y)) return;
 
         // Get parent object ids
         var xParent = this.getCoordParent(this.conf.x, num);
         var yParent = this.getCoordParent(this.conf.y, num);
 
-        if(xParent == yParent) {
+        if (xParent == yParent) {
             var o = getMapObjByDomObjId(xParent);
             // Don't remove when another coord is a child of this object
-            if(o && Object.size(this.getRelativeCoordsUsingParent(xParent)) == 1) {
+            if (o && Object.size(this.getRelativeCoordsUsingParent(xParent)) == 1) {
                 o.delChild(this);
             }
         } else {
             var o = getMapObjByDomObjId(xParent);
             // Don't remove when another coord is a child of this object
-            if(o && Object.size(this.getRelativeCoordsUsingParent(xParent)) == 1) {
+            if (o && Object.size(this.getRelativeCoordsUsingParent(xParent)) == 1) {
                 o.delChild(this);
             }
             var o = getMapObjByDomObjId(yParent);
             // Don't remove when another coord is a child of this object
-            if(o && Object.size(this.getRelativeCoordsUsingParent(yParent)) == 1) {
+            if (o && Object.size(this.getRelativeCoordsUsingParent(yParent)) == 1) {
                 o.delChild(this);
             }
         }
@@ -415,46 +370,44 @@ var NagVisObject = Base.extend({
         // FIXME: Maybe the parent object is also a line. Then -1 is not correct
         //        But it is not coded to attach relative objects to lines. So it is no big
         //        deal to leave this as it is.
-        if(num === -1) {
-            this.conf.x = this.parseCoord(x, 'x', false);
-            this.conf.y = this.parseCoord(y, 'y', false);
+        if (num === -1) {
+            this.conf.x = this.parseCoord(x, "x", false);
+            this.conf.y = this.parseCoord(y, "y", false);
         } else {
-            var old  = this.conf.x.split(',');
-            old[num] = this.parseCoord(x, 'x', false);
-            this.conf.x = old.join(',');
+            var old = this.conf.x.split(",");
+            old[num] = this.parseCoord(x, "x", false);
+            this.conf.x = old.join(",");
 
-            old  = this.conf.y.split(',');
-            old[num] = this.parseCoord(y, 'y', false);
-            this.conf.y = old.join(',');
+            old = this.conf.y.split(",");
+            old[num] = this.parseCoord(y, "y", false);
+            this.conf.y = old.join(",");
         }
     },
 
     // Transform the current coords to relative
     // coords to the given object
-    makeRelativeCoords: function(oParent, num) {
+    makeRelativeCoords: function (oParent, num) {
         var xParent = this.getCoordParent(this.conf.x, num);
         var yParent = this.getCoordParent(this.conf.y, num);
 
-        var x = num === -1 ? this.conf.x : this.conf.x.split(',')[num];
-        var y = num === -1 ? this.conf.y : this.conf.y.split(',')[num];
+        var x = num === -1 ? this.conf.x : this.conf.x.split(",")[num];
+        var y = num === -1 ? this.conf.y : this.conf.y.split(",")[num];
 
-        if(isRelativeCoord(x) && isRelativeCoord(y)) {
+        if (isRelativeCoord(x) && isRelativeCoord(y)) {
             // Skip this when already relative to the same object
-            if(xParent == oParent.conf.object_id
-              && yParent == oParent.conf.object_id)
-                return;
+            if (xParent == oParent.conf.object_id && yParent == oParent.conf.object_id) return;
 
             // If this object was attached to another parent before, remove the attachment
-            if(xParent != oParent.conf.object_id) {
+            if (xParent != oParent.conf.object_id) {
                 var o = getMapObjByDomObjId(xParent);
-                if(o) {
+                if (o) {
                     o.delChild(this);
                     o = null;
                 }
             }
-            if(yParent != oParent.conf.object_id) {
+            if (yParent != oParent.conf.object_id) {
                 var o = getMapObjByDomObjId(yParent);
-                if(o) {
+                if (o) {
                     o.delChild(this);
                     o = null;
                 }
@@ -467,45 +420,43 @@ var NagVisObject = Base.extend({
         // FIXME: Maybe the parent object is also a line. Then -1 is not correct
         //        But it is not coded to attach relative objects to lines. So it is no big
         //        deal to leave this as it is.
-        if(num === -1) {
-            this.conf.x = this.getRelCoords(oParent, this.parseCoord(this.conf.x, 'x', false), 'x', -1);
-            this.conf.y = this.getRelCoords(oParent, this.parseCoord(this.conf.y, 'y', false), 'y', -1);
+        if (num === -1) {
+            this.conf.x = this.getRelCoords(oParent, this.parseCoord(this.conf.x, "x", false), "x", -1);
+            this.conf.y = this.getRelCoords(oParent, this.parseCoord(this.conf.y, "y", false), "y", -1);
         } else {
-            var newX = this.getRelCoords(oParent, this.parseCoords(this.conf.x, 'x', false)[num], 'x', -1);
-            var newY = this.getRelCoords(oParent, this.parseCoords(this.conf.y, 'y', false)[num], 'y', -1);
+            var newX = this.getRelCoords(oParent, this.parseCoords(this.conf.x, "x", false)[num], "x", -1);
+            var newY = this.getRelCoords(oParent, this.parseCoords(this.conf.y, "y", false)[num], "y", -1);
 
-            var old  = this.conf.x.split(',');
+            var old = this.conf.x.split(",");
             old[num] = newX;
-            this.conf.x = old.join(',');
+            this.conf.x = old.join(",");
 
-            old  = this.conf.y.split(',');
+            old = this.conf.y.split(",");
             old[num] = newY;
-            this.conf.y = old.join(',');
+            this.conf.y = old.join(",");
         }
     },
 
     /**
      * Returns the object id of the parent object
      */
-    getCoordParent: function(val, num) {
-        var coord = num === -1 ? val.toString() : val.split(',')[num].toString();
-        return coord.search('%') !== -1 ? coord.split('%')[0] : coord;
+    getCoordParent: function (val, num) {
+        var coord = num === -1 ? val.toString() : val.split(",")[num].toString();
+        return coord.search("%") !== -1 ? coord.split("%")[0] : coord;
     },
 
-    getRelCoords: function(refObj, val, dir, num) {
-        var refPos = num === -1 ? refObj.conf[dir] : refObj.conf[dir].split(',')[num];
+    getRelCoords: function (refObj, val, dir, num) {
+        var refPos = num === -1 ? refObj.conf[dir] : refObj.conf[dir].split(",")[num];
         var offset = parseInt(val) - parseInt(refObj.parseCoord(refPos, dir, false));
-        var pre    = offset >= 0 ? '+' : '';
-        val        = refObj.conf.object_id + '%' + pre + offset;
-        refObj     = null;
+        var pre = offset >= 0 ? "+" : "";
+        val = refObj.conf.object_id + "%" + pre + offset;
+        refObj = null;
         return val;
     },
 
-    hasRelativeCoord: function() {
-        var coords = this.conf.x.toString().split(',').concat(this.conf.y.toString().split(','));
-        for (var i = 0, len = coords.length; i < len; i++)
-            if (isRelativeCoord(coords[i]))
-                return true;
+    hasRelativeCoord: function () {
+        var coords = this.conf.x.toString().split(",").concat(this.conf.y.toString().split(","));
+        for (var i = 0, len = coords.length; i < len; i++) if (isRelativeCoord(coords[i])) return true;
         return false;
     },
 
@@ -518,40 +469,34 @@ var NagVisObject = Base.extend({
      *
      * @author  Lars Michelsen <lm@larsmichelsen.com>
      */
-    calcNewCoord: function(val, dir, num) {
-        if(!isset(num))
-            var num = -1;
+    calcNewCoord: function (val, dir, num) {
+        if (!isset(num)) var num = -1;
 
-        var oldVal = num === -1 ? this.conf[dir] : this.conf[dir].split(',')[num];
+        var oldVal = num === -1 ? this.conf[dir] : this.conf[dir].split(",")[num];
         // Check if the current value is an integer or a relative coord
-        if(isset(oldVal) && isRelativeCoord(oldVal)) {
+        if (isset(oldVal) && isRelativeCoord(oldVal)) {
             // This must be an object id
             var objectId = null;
-            if(oldVal.search('%') !== -1)
-                objectId = oldVal.split('%')[0];
-            else
-                objectId = oldVal;
+            if (oldVal.search("%") !== -1) objectId = oldVal.split("%")[0];
+            else objectId = oldVal;
 
             // Only an object id. Get the coordinate and return it
             var refObj = getMapObjByDomObjId(objectId);
             // FIXME: Maybe the parent object is also a line. Then -1 is not correct
-            if(refObj)
-                val = this.getRelCoords(refObj, val, dir, -1);
+            if (refObj) val = this.getRelCoords(refObj, val, dir, -1);
             objectId = null;
-        } else if(num === -1) {
+        } else if (num === -1) {
             val = Math.round(val);
         }
         oldVal = null;
 
-        if(num === -1) {
+        if (num === -1) {
             return val;
         } else {
-            var old  = this.conf[dir].split(',');
-            if(isRelativeCoord(val))
-                old[num] = val;
-            else
-                old[num] = Math.round(val);
-            return old.join(',');
+            var old = this.conf[dir].split(",");
+            if (isRelativeCoord(val)) old[num] = val;
+            else old[num] = Math.round(val);
+            return old.join(",");
         }
     },
 
@@ -562,25 +507,23 @@ var NagVisObject = Base.extend({
      *
      * @author  Lars Michelsen <lm@larsmichelsen.com>
      */
-    getParentObjectIds: function(num) {
+    getParentObjectIds: function (num) {
         var parentIds = {};
 
         if (isset(num)) {
-            var coords = (this.conf['x'].split(',')[num] + ',' + this.conf['y'].split(',')[num]).split(',');
+            var coords = (this.conf["x"].split(",")[num] + "," + this.conf["y"].split(",")[num]).split(",");
         } else if (isset(this.conf.x) && isset(this.conf.y)) {
-            var coords = (this.conf.x + ',' + this.conf.y).split(',');
+            var coords = (this.conf.x + "," + this.conf.y).split(",");
         } else {
             // Don't try to do strange things for objects not having coordinates. But
             // that should never happen anyways.
             return parentIds;
         }
 
-        for(var i = 0, len = coords.length; i < len; i++) {
-            if(isRelativeCoord(coords[i])) {
-                if(coords[i].search('%') !== -1)
-                    parentIds[coords[i].split('%')[0]] = true;
-                else if (coords[i])
-                    parentIds[coords[i]] = true;
+        for (var i = 0, len = coords.length; i < len; i++) {
+            if (isRelativeCoord(coords[i])) {
+                if (coords[i].search("%") !== -1) parentIds[coords[i].split("%")[0]] = true;
+                else if (coords[i]) parentIds[coords[i]] = true;
             }
         }
         coords = null;
@@ -591,13 +534,11 @@ var NagVisObject = Base.extend({
     /**
      * Returns the coord indexes which use a specific parent object_id
      */
-    getRelativeCoordsUsingParent: function(parentId) {
+    getRelativeCoordsUsingParent: function (parentId) {
         var matches = {};
-        for(var i = 0, len = this.conf.x.split(',').length; i < len; i++) {
-        if(this.getCoordParent(this.conf.x, i) === parentId && !isset(matches[i]))
-            matches[i] = true;
-        else if(this.getCoordParent(this.conf.y, i) === parentId && !isset(matches[i]))
-            matches[i] = true;
+        for (var i = 0, len = this.conf.x.split(",").length; i < len; i++) {
+            if (this.getCoordParent(this.conf.x, i) === parentId && !isset(matches[i])) matches[i] = true;
+            else if (this.getCoordParent(this.conf.y, i) === parentId && !isset(matches[i])) matches[i] = true;
         }
         return matches;
     },
@@ -609,13 +550,12 @@ var NagVisObject = Base.extend({
      *
      * @author  Lars Michelsen <lm@larsmichelsen.com>
      */
-    addChild: function(obj) {
-        if(this.childs.indexOf(obj) === -1)
-            this.childs.push(obj);
+    addChild: function (obj) {
+        if (this.childs.indexOf(obj) === -1) this.childs.push(obj);
         obj = null;
     },
 
-    delChild: function(obj) {
+    delChild: function (obj) {
         this.childs.splice(this.childs.indexOf(obj), 1);
         obj = null;
     },
@@ -629,34 +569,34 @@ var NagVisObject = Base.extend({
      * absolute using child.makeAbsoluteCoords(num).
      * After that the change must be sent to the core using saveObject...
      */
-    detachChilds: function() {
-        for(var i = this.childs.length - 1; i >= 0; i--) {
-        var nums = this.childs[i].getRelativeCoordsUsingParent(this.conf.object_id);
-        var obj = this.childs[i];
+    detachChilds: function () {
+        for (var i = this.childs.length - 1; i >= 0; i--) {
+            var nums = this.childs[i].getRelativeCoordsUsingParent(this.conf.object_id);
+            var obj = this.childs[i];
 
-        for(var num in nums) {
-            obj.makeAbsoluteCoords(num);
-        }
+            for (var num in nums) {
+                obj.makeAbsoluteCoords(num);
+            }
 
-        saveObjectAttr(obj.conf.object_id, {'x': obj.conf.x, 'y': obj.conf.y });
+            saveObjectAttr(obj.conf.object_id, { x: obj.conf.x, y: obj.conf.y });
 
-        obj  = null;
-        nums = null;
+            obj = null;
+            nums = null;
         }
     },
 
     /**
      * Returns the x coordinate of the object in px
      */
-    parsedX: function() {
-        return this.parseCoords(this.conf.x, 'x');
+    parsedX: function () {
+        return this.parseCoords(this.conf.x, "x");
     },
 
     /**
      * Returns the y coordinate of the object in px
      */
-    parsedY: function() {
-        return this.parseCoords(this.conf.y, 'y');
+    parsedY: function () {
+        return this.parseCoords(this.conf.y, "y");
     },
 
     /**
@@ -664,35 +604,39 @@ var NagVisObject = Base.extend({
      * Handles whole redrawing of the object while moving. The new
      * coordinates have already been set
      */
-    place: function() {
-        for(var i = 0, l = this.elements.length; i < l; i++)
-            this.elements[i].place();
+    place: function () {
+        for (var i = 0, l = this.elements.length; i < l; i++) this.elements[i].place();
 
         // Move child objects
-        for(var i = 0, l = this.childs.length; i < l; i++)
-            this.childs[i].place();
+        for (var i = 0, l = this.childs.length; i < l; i++) this.childs[i].place();
     },
 
     needsContextMenu: function () {
-        return (this.conf.context_menu && this.conf.context_menu !== '' && this.conf.context_menu !== '0'
-            && this.conf.context_template && this.conf.context_template !== '');
+        return (
+            this.conf.context_menu &&
+            this.conf.context_menu !== "" &&
+            this.conf.context_menu !== "0" &&
+            this.conf.context_template &&
+            this.conf.context_template !== ""
+        );
     },
 
-    needsHoverMenu: function() {
-        return this.conf.hover_menu && this.conf.hover_menu !== '' && this.conf.hover_menu !== '0'
-            && ((this.conf.hover_template && this.conf.hover_template !== '') ||
-                (this.conf.hover_url && this.conf.hover_url !== ''));
+    needsHoverMenu: function () {
+        return (
+            this.conf.hover_menu &&
+            this.conf.hover_menu !== "" &&
+            this.conf.hover_menu !== "0" &&
+            ((this.conf.hover_template && this.conf.hover_template !== "") ||
+                (this.conf.hover_url && this.conf.hover_url !== ""))
+        );
     },
 
-    needsLink: function() {
-        return this.conf.url && this.conf.url !== '' && this.conf.url !== '#';
+    needsLink: function () {
+        return this.conf.url && this.conf.url !== "" && this.conf.url !== "#";
     },
 
-    needsLineHoverArea: function() {
-        return this.needsHoverMenu()
-            || this.needsContextMenu()
-            || this.needsLink()
-            || !this.bIsLocked;
+    needsLineHoverArea: function () {
+        return this.needsHoverMenu() || this.needsContextMenu() || this.needsLink() || !this.bIsLocked;
     },
 
     /**
@@ -701,28 +645,26 @@ var NagVisObject = Base.extend({
      * Important: This is called from an event handler
      * the 'this.' keyword can not be used here.
      */
-    moveObject: function(trigger_obj, obj) {
-        var arr = trigger_obj.id.split('-');
+    moveObject: function (trigger_obj, obj) {
+        var arr = trigger_obj.id.split("-");
         var newPos;
-        if (obj.conf.view_type === 'line') {
+        if (obj.conf.view_type === "line") {
             newPos = getMidOfAnchor(trigger_obj);
 
             // Get current positions and replace only the current one
             var anchorId = arr[2];
-            newPos = [ obj.calcNewCoord(newPos[0], 'x', anchorId),
-                       obj.calcNewCoord(newPos[1], 'y', anchorId) ];
+            newPos = [obj.calcNewCoord(newPos[0], "x", anchorId), obj.calcNewCoord(newPos[1], "y", anchorId)];
 
             var parents = obj.getParentObjectIds(anchorId);
 
-            anchorId   = null;
+            anchorId = null;
         } else {
             // In case of an anchor there is an offset to the real object.
             // Handle this offset in the coordinate calculation for the obj
             var offsetX = isset(trigger_obj.objOffsetX) ? trigger_obj.objOffsetX : 0;
             var offsetY = isset(trigger_obj.objOffsetY) ? trigger_obj.objOffsetY : 0;
 
-            newPos = [ obj.calcNewCoord(trigger_obj.x - offsetX, 'x'),
-                       obj.calcNewCoord(trigger_obj.y - offsetY, 'y') ];
+            newPos = [obj.calcNewCoord(trigger_obj.x - offsetX, "x"), obj.calcNewCoord(trigger_obj.y - offsetY, "y")];
 
             var parents = obj.getParentObjectIds();
         }
@@ -738,47 +680,44 @@ var NagVisObject = Base.extend({
      * Important: This is called from an event handler
      * the 'this.' keyword can not be used here.
      */
-    saveObject: function(trigger_obj, obj, oParent) {
-        var arr = trigger_obj.id.split('-');
-        if(arr.length > 2)
-            var anchorId = arr[2];
-        if (obj.conf.view_type !== 'line')
-            anchorId = -1;
+    saveObject: function (trigger_obj, obj, oParent) {
+        var arr = trigger_obj.id.split("-");
+        if (arr.length > 2) var anchorId = arr[2];
+        if (obj.conf.view_type !== "line") anchorId = -1;
 
         // Honor the enabled grid and reposition the object after dropping
         if (useGrid()) {
-            if (obj.conf.view_type === 'line') {
-               var pos = coordsToGrid(obj.parseCoords(obj.conf.x, 'x', false)[anchorId],
-                                      obj.parseCoords(obj.conf.y, 'y', false)[anchorId]);
-               obj.conf.x = obj.calcNewCoord(pos[0], 'x', anchorId);
-               obj.conf.y = obj.calcNewCoord(pos[1], 'y', anchorId);
+            if (obj.conf.view_type === "line") {
+                var pos = coordsToGrid(
+                    obj.parseCoords(obj.conf.x, "x", false)[anchorId],
+                    obj.parseCoords(obj.conf.y, "y", false)[anchorId]
+                );
+                obj.conf.x = obj.calcNewCoord(pos[0], "x", anchorId);
+                obj.conf.y = obj.calcNewCoord(pos[1], "y", anchorId);
             } else {
-               var pos = coordsToGrid(obj.parseCoord(obj.conf.x, 'x', false),
-                                      obj.parseCoord(obj.conf.y, 'y', false));
-               obj.conf.x = obj.calcNewCoord(pos[0], 'x');
-               obj.conf.y = obj.calcNewCoord(pos[1], 'y');
+                var pos = coordsToGrid(obj.parseCoord(obj.conf.x, "x", false), obj.parseCoord(obj.conf.y, "y", false));
+                obj.conf.x = obj.calcNewCoord(pos[0], "x");
+                obj.conf.y = obj.calcNewCoord(pos[1], "y");
             }
             obj.place();
         }
 
         // Make relative when oParent set and not already relative
         if (isset(oParent))
-            if(oParent !== false)
-                obj.makeRelativeCoords(oParent, anchorId);
-            else
-                obj.makeAbsoluteCoords(anchorId);
+            if (oParent !== false) obj.makeRelativeCoords(oParent, anchorId);
+            else obj.makeAbsoluteCoords(anchorId);
 
         var x = obj.conf.x,
             y = obj.conf.y;
 
-        var parts = g_view.unproject(x.toString().split(','), y.toString().split(','));
-        x = parts[0].join(',');
-        y = parts[1].join(',');
+        var parts = g_view.unproject(x.toString().split(","), y.toString().split(","));
+        x = parts[0].join(",");
+        y = parts[1].join(",");
 
         // Now send the new attributes to the server for persistance
-        saveObjectAttr(obj.conf.object_id, { 'x': x, 'y': y});
+        saveObjectAttr(obj.conf.object_id, { x: x, y: y });
     },
 
-    highlight: function(show) {},
-    getStatefulMembers: function() {}
+    highlight: function (show) {},
+    getStatefulMembers: function () {}
 });

--- a/share/frontend/nagvis-js/js/NagVisObject.js
+++ b/share/frontend/nagvis-js/js/NagVisObject.js
@@ -167,8 +167,9 @@ var NagVisObject = Base.extend({
         // Editing is only possible in maps
         if (g_view.type != "map") return;
 
-        if (!oUserProperties.hasOwnProperty("unlocked-" + oPageProperties.map_name)) return;
+        if (!oUserProperties.hasOwnProperty("unlocked-" + oPageProperties.map_name)) return; // eslint-disable-line no-prototype-builtins
 
+        // eslint-disable-next-line no-prototype-builtins
         if (oViewProperties.hasOwnProperty("edit_mode") && oViewProperties["edit_mode"] === true) {
             this.bIsLocked = false;
             return;
@@ -243,8 +244,10 @@ var NagVisObject = Base.extend({
             else this.elements[i].unlock();
 
         // Only save the user option when not using the edit_mode
+        // eslint-disable-next-line no-prototype-builtins
         if (!isset(lock) && (!oViewProperties.hasOwnProperty("edit_mode") || oViewProperties["edit_mode"] !== true)) {
             var unlocked = [];
+            // eslint-disable-next-line no-prototype-builtins
             if (oUserProperties.hasOwnProperty("unlocked-" + oPageProperties.map_name))
                 unlocked = oUserProperties["unlocked-" + oPageProperties.map_name].split(",");
 

--- a/share/frontend/nagvis-js/js/NagVisRotation.js
+++ b/share/frontend/nagvis-js/js/NagVisRotation.js
@@ -25,32 +25,32 @@
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 
-var NagVisRotation = NagVisStatelessObject.extend({
+const NagVisRotation = NagVisStatelessObject.extend({
     constructor: function (oConf) {
         this.base(oConf);
     },
 
     parseOverview: function () {
-        var container = document.getElementById("overviewRotations");
+        let container = document.getElementById("overviewRotations");
 
-        var oTable = document.createElement("table");
+        const oTable = document.createElement("table");
         oTable.className = "rotation";
         container.appendChild(oTable);
-        var oTbody = document.createElement("tbody");
+        const oTbody = document.createElement("tbody");
         oTable.appendChild(oTbody);
 
         /* Rotation title */
-        var oTr = document.createElement("tr");
-        var oTd = document.createElement("td");
+        let oTr = document.createElement("tr");
+        let oTd = document.createElement("td");
         oTd.className = "title";
         oTd.setAttribute("rowSpan", this.conf.num_steps);
         oTd.rowSpan = this.conf.num_steps;
 
         // Link
-        var oLink = document.createElement("a");
+        let oLink = document.createElement("a");
         oLink.href = this.conf.url;
 
-        var h3 = document.createElement("h3");
+        let h3 = document.createElement("h3");
         h3.appendChild(document.createTextNode(this.conf.name));
 
         oLink.appendChild(h3);
@@ -62,7 +62,7 @@ var NagVisRotation = NagVisStatelessObject.extend({
         oTd = null;
 
         /* Rotation steps */
-        for (var i = 0, len = this.conf.steps.length; i < len; i++) {
+        for (let i = 0, len = this.conf.steps.length; i < len; i++) {
             if (i !== 0) oTr = document.createElement("tr");
 
             oTd = document.createElement("td");

--- a/share/frontend/nagvis-js/js/NagVisRotation.js
+++ b/share/frontend/nagvis-js/js/NagVisRotation.js
@@ -26,31 +26,31 @@
  */
 
 var NagVisRotation = NagVisStatelessObject.extend({
-    constructor: function(oConf) {
+    constructor: function (oConf) {
         this.base(oConf);
     },
 
-    parseOverview: function() {
-        var container = document.getElementById('overviewRotations');
+    parseOverview: function () {
+        var container = document.getElementById("overviewRotations");
 
-        var oTable = document.createElement('table');
-        oTable.className = 'rotation';
+        var oTable = document.createElement("table");
+        oTable.className = "rotation";
         container.appendChild(oTable);
-        var oTbody = document.createElement('tbody');
+        var oTbody = document.createElement("tbody");
         oTable.appendChild(oTbody);
 
         /* Rotation title */
-        var oTr = document.createElement('tr');
-        var oTd = document.createElement('td');
-        oTd.className = 'title';
-        oTd.setAttribute('rowSpan', this.conf.num_steps);
+        var oTr = document.createElement("tr");
+        var oTd = document.createElement("td");
+        oTd.className = "title";
+        oTd.setAttribute("rowSpan", this.conf.num_steps);
         oTd.rowSpan = this.conf.num_steps;
 
         // Link
-        var oLink = document.createElement('a');
+        var oLink = document.createElement("a");
         oLink.href = this.conf.url;
 
-        var h3 = document.createElement('h3');
+        var h3 = document.createElement("h3");
         h3.appendChild(document.createTextNode(this.conf.name));
 
         oLink.appendChild(h3);
@@ -62,13 +62,12 @@ var NagVisRotation = NagVisStatelessObject.extend({
         oTd = null;
 
         /* Rotation steps */
-        for(var i = 0, len = this.conf.steps.length; i < len; i++) {
-            if(i !== 0)
-                oTr = document.createElement('tr');
+        for (var i = 0, len = this.conf.steps.length; i < len; i++) {
+            if (i !== 0) oTr = document.createElement("tr");
 
-            oTd = document.createElement('td');
+            oTd = document.createElement("td");
 
-            oLink = document.createElement('a');
+            oLink = document.createElement("a");
             oLink.href = this.conf.steps[i].url;
             oLink.appendChild(document.createTextNode(this.conf.steps[i].name));
 

--- a/share/frontend/nagvis-js/js/NagVisService.js
+++ b/share/frontend/nagvis-js/js/NagVisService.js
@@ -26,7 +26,7 @@
  */
 
 var NagVisService = NagVisStatefulObject.extend({
-    constructor: function(oConf) {
+    constructor: function (oConf) {
         this.base(oConf);
-    },
+    }
 });

--- a/share/frontend/nagvis-js/js/NagVisService.js
+++ b/share/frontend/nagvis-js/js/NagVisService.js
@@ -25,7 +25,7 @@
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 
-var NagVisService = NagVisStatefulObject.extend({
+const NagVisService = NagVisStatefulObject.extend({
     constructor: function (oConf) {
         this.base(oConf);
     }

--- a/share/frontend/nagvis-js/js/NagVisServicegroup.js
+++ b/share/frontend/nagvis-js/js/NagVisServicegroup.js
@@ -22,7 +22,7 @@
  *
  *****************************************************************************/
 
-var NagVisServicegroup = NagVisStatefulObject.extend({
+const NagVisServicegroup = NagVisStatefulObject.extend({
     constructor: function (oConf) {
         this.base(oConf);
     }

--- a/share/frontend/nagvis-js/js/NagVisServicegroup.js
+++ b/share/frontend/nagvis-js/js/NagVisServicegroup.js
@@ -23,7 +23,7 @@
  *****************************************************************************/
 
 var NagVisServicegroup = NagVisStatefulObject.extend({
-    constructor: function(oConf) {
+    constructor: function (oConf) {
         this.base(oConf);
     }
 });

--- a/share/frontend/nagvis-js/js/NagVisShape.js
+++ b/share/frontend/nagvis-js/js/NagVisShape.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var NagVisShape = NagVisStatelessObject.extend({
+const NagVisShape = NagVisStatelessObject.extend({
     update: function () {
         this.clearElements();
         new ElementShape(this).addTo(this);

--- a/share/frontend/nagvis-js/js/NagVisShape.js
+++ b/share/frontend/nagvis-js/js/NagVisShape.js
@@ -22,9 +22,9 @@
  *****************************************************************************/
 
 var NagVisShape = NagVisStatelessObject.extend({
-    update: function() {
+    update: function () {
         this.clearElements();
         new ElementShape(this).addTo(this);
         this.base();
-    },
+    }
 });

--- a/share/frontend/nagvis-js/js/NagVisStatefulObject.js
+++ b/share/frontend/nagvis-js/js/NagVisStatefulObject.js
@@ -36,59 +36,59 @@ var NagVisStatefulObject = NagVisObject.extend({
     event_time_first: null,
     event_time_last: null,
 
-    constructor: function(oConf) {
+    constructor: function (oConf) {
         this.base(oConf);
     },
 
-    getMembers: function() {
+    getMembers: function () {
         // Clear member array on every launch
         this.members = [];
 
-        if(this.conf && this.conf.members && this.conf.members.length > 0) {
-            for(var i = 0, len = this.conf.members.length; i < len; i++) {
+        if (this.conf && this.conf.members && this.conf.members.length > 0) {
+            for (var i = 0, len = this.conf.members.length; i < len; i++) {
                 var oMember = this.conf.members[i];
                 var oObj;
 
                 switch (oMember.type) {
-                    case 'host':
+                    case "host":
                         oObj = new NagVisHost(oMember);
-                    break;
-                    case 'service':
+                        break;
+                    case "service":
                         oObj = new NagVisService(oMember);
-                    break;
-                    case 'hostgroup':
+                        break;
+                    case "hostgroup":
                         oObj = new NagVisHostgroup(oMember);
-                    break;
-                    case 'servicegroup':
+                        break;
+                    case "servicegroup":
                         oObj = new NagVisServicegroup(oMember);
-                    break;
-                    case 'dyngroup':
+                        break;
+                    case "dyngroup":
                         oObj = new NagVisDynGroup(oMember);
-                    break;
-                    case 'aggr':
+                        break;
+                    case "aggr":
                         oObj = new NagVisAggr(oMember);
-                    break;
-                    case 'map':
+                        break;
+                    case "map":
                         oObj = new NagVisMap(oMember);
-                    break;
-                    case 'textbox':
+                        break;
+                    case "textbox":
                         oObj = new NagVisTextbox(oMember);
-                    break;
-                    case 'container':
+                        break;
+                    case "container":
                         oObj = new NagVisContainer(oMember);
-                    break;
-                    case 'shape':
+                        break;
+                    case "shape":
                         oObj = new NagVisShape(oMember);
-                    break;
-                    case 'line':
+                        break;
+                    case "line":
                         oObj = new NagVisLine(oMember);
-                    break;
+                        break;
                     default:
-                        alert('Error: Unknown member object type ('+oMember.type+')');
-                    break;
+                        alert("Error: Unknown member object type (" + oMember.type + ")");
+                        break;
                 }
 
-                if(oObj !== null) {
+                if (oObj !== null) {
                     this.members.push(oObj);
                 }
 
@@ -98,7 +98,7 @@ var NagVisStatefulObject = NagVisObject.extend({
         }
     },
 
-    getStatefulMembers: function() {
+    getStatefulMembers: function () {
         var stateful = [];
         for (var i = 0, len = this.members.length; i < len; i++) {
             if (this.members[i].has_state) {
@@ -115,14 +115,14 @@ var NagVisStatefulObject = NagVisObject.extend({
      *
      * @author	Lars Michelsen <lm@larsmichelsen.com>
      */
-    saveLastState: function() {
+    saveLastState: function () {
         this.last_state = {
-          'summary_state': this.conf.summary_state,
-            'summary_in_downtime': this.conf.summary_in_downtime,
-            'summary_stale': this.conf.summary_stale,
-            'summary_problem_has_been_acknowledged': this.conf.summary_problem_has_been_acknowledged,
-            'output': this.conf.output,
-            'perfdata': this.conf.perfdata
+            summary_state: this.conf.summary_state,
+            summary_in_downtime: this.conf.summary_in_downtime,
+            summary_stale: this.conf.summary_stale,
+            summary_problem_has_been_acknowledged: this.conf.summary_problem_has_been_acknowledged,
+            output: this.conf.output,
+            perfdata: this.conf.perfdata
         };
     },
 
@@ -133,11 +133,13 @@ var NagVisStatefulObject = NagVisObject.extend({
      *
      * @author	Lars Michelsen <lm@larsmichelsen.com>
      */
-    stateChanged: function() {
-        if(this.conf.summary_state != this.last_state.summary_state ||
-           this.conf.summary_problem_has_been_acknowledged != this.last_state.summary_problem_has_been_acknowledged ||
-           this.conf.summary_stale != this.last_state.summary_stale ||
-           this.conf.summary_in_downtime != this.last_state.summary_in_downtime) {
+    stateChanged: function () {
+        if (
+            this.conf.summary_state != this.last_state.summary_state ||
+            this.conf.summary_problem_has_been_acknowledged != this.last_state.summary_problem_has_been_acknowledged ||
+            this.conf.summary_stale != this.last_state.summary_stale ||
+            this.conf.summary_in_downtime != this.last_state.summary_in_downtime
+        ) {
             return true;
         } else {
             return false;
@@ -151,30 +153,33 @@ var NagVisStatefulObject = NagVisObject.extend({
      *
      * @author	Lars Michelsen <lm@larsmichelsen.com>
      */
-    stateChangedToWorse: function() {
-        var lastSubState = 'normal';
-        if(this.last_state.summary_problem_has_been_acknowledged && this.last_state.summary_problem_has_been_acknowledged == 1) {
-            lastSubState = 'ack';
-        } else if(this.last_state.summary_in_downtime && this.last_state.summary_in_downtime == 1) {
-            lastSubState = 'downtime';
-        } else if(this.last_state.summary_stale) {
-            lastSubState = 'stale';
+    stateChangedToWorse: function () {
+        var lastSubState = "normal";
+        if (
+            this.last_state.summary_problem_has_been_acknowledged &&
+            this.last_state.summary_problem_has_been_acknowledged == 1
+        ) {
+            lastSubState = "ack";
+        } else if (this.last_state.summary_in_downtime && this.last_state.summary_in_downtime == 1) {
+            lastSubState = "downtime";
+        } else if (this.last_state.summary_stale) {
+            lastSubState = "stale";
         }
 
         // If there is no "last state" return true here
-        if(!this.last_state.summary_state) {
+        if (!this.last_state.summary_state) {
             return true;
         }
 
         var lastWeight = oStates[this.last_state.summary_state][lastSubState];
 
-        var subState = 'normal';
-        if(this.conf.summary_problem_has_been_acknowledged && this.conf.summary_problem_has_been_acknowledged == 1) {
-            subState = 'ack';
-        } else if(this.conf.summary_in_downtime && this.conf.summary_in_downtime == 1) {
-            subState = 'downtime';
-        } else if(this.conf.summary_stale) {
-            subState = 'stale';
+        var subState = "normal";
+        if (this.conf.summary_problem_has_been_acknowledged && this.conf.summary_problem_has_been_acknowledged == 1) {
+            subState = "ack";
+        } else if (this.conf.summary_in_downtime && this.conf.summary_in_downtime == 1) {
+            subState = "downtime";
+        } else if (this.conf.summary_stale) {
+            subState = "stale";
         }
 
         var weight = oStates[this.conf.summary_state][subState];
@@ -185,18 +190,18 @@ var NagVisStatefulObject = NagVisObject.extend({
     /**
      * Returns true if the object is in non acked problem state
      */
-    hasProblematicState: function() {
+    hasProblematicState: function () {
         // In case of acked/downtimed states this is no problematic state
-        if(this.conf.summary_problem_has_been_acknowledged && this.conf.summary_problem_has_been_acknowledged == 1) {
+        if (this.conf.summary_problem_has_been_acknowledged && this.conf.summary_problem_has_been_acknowledged == 1) {
             return false;
-        } else if(this.conf.summary_in_downtime && this.conf.summary_in_downtime == 1) {
+        } else if (this.conf.summary_in_downtime && this.conf.summary_in_downtime == 1) {
             return false;
-        } else if(this.conf.summary_stale && this.conf.summary_stale) {
+        } else if (this.conf.summary_stale && this.conf.summary_stale) {
             return false;
         }
-        
-        var weight = oStates[this.conf.summary_state]['normal'];
-        return weight > oStates['UP']['normal'];
+
+        var weight = oStates[this.conf.summary_state]["normal"];
+        return weight > oStates["UP"]["normal"];
     },
 
     /**
@@ -206,7 +211,7 @@ var NagVisStatefulObject = NagVisObject.extend({
      *
      * @author	Lars Michelsen <lm@larsmichelsen.com>
      */
-    outputOrPerfdataChanged: function() {
+    outputOrPerfdataChanged: function () {
         return this.conf.output != this.last_state.output || this.conf.perfdata != this.last_state.perfdata;
     },
 
@@ -215,24 +220,24 @@ var NagVisStatefulObject = NagVisObject.extend({
         this.getMembers();
         this.replaceMacros();
 
-        if (g_view.type === 'map') {
+        if (g_view.type === "map") {
             switch (this.conf.view_type) {
-                case 'line':
+                case "line":
                     new ElementLine(this).addTo(this);
-                break;
-                case 'gadget':
+                    break;
+                case "gadget":
                     new ElementGadget(this).addTo(this);
-                break;
+                    break;
                 default:
                     new ElementIcon(this).addTo(this);
-                break;
+                    break;
             }
         }
 
         this.base();
     },
 
-    updateAttrs: function(attrs, only_state) {
+    updateAttrs: function (attrs, only_state) {
         // Save old state for later "change detection"
         this.saveLastState();
 
@@ -245,8 +250,7 @@ var NagVisStatefulObject = NagVisObject.extend({
 
         // When the config has not changed, but the state, rerender the whole object
         // the config update is handled within NagVisObject()
-        if (only_state && this.stateChanged())
-            this.render(); // erase, rerender and draw object
+        if (only_state && this.stateChanged()) this.render(); // erase, rerender and draw object
 
         if (this.stateChanged()) {
             /**
@@ -264,19 +268,17 @@ var NagVisStatefulObject = NagVisObject.extend({
                 this.initRepeatedEvents();
             }
             return true;
-        }
-        else {
+        } else {
             return false;
         }
     },
 
-    transformAttributes: function() {
+    transformAttributes: function () {
         this.replaceMacros();
     },
 
-    updateMemberAttrs: function(attrs, only_state) {
-        if (!this.members || !attrs.members)
-            return;
+    updateMemberAttrs: function (attrs, only_state) {
+        if (!this.members || !attrs.members) return;
 
         // Update already existing objects
         for (var i = 0, len = attrs.members.length; i < len; i++) {
@@ -300,64 +302,136 @@ var NagVisStatefulObject = NagVisObject.extend({
      */
     raiseEvents: function (stateChanged) {
         // - Highlight (Flashing)
-        if (oPageProperties.event_highlight === '1') {
-            if (this.conf.view_type && this.conf.view_type === 'icon') {
+        if (oPageProperties.event_highlight === "1") {
+            if (this.conf.view_type && this.conf.view_type === "icon") {
                 // Detach the handler
-                setTimeout(function(obj_id) {
-                    return function() {
-                        flashIcon(obj_id, oPageProperties.event_highlight_duration,
-                                  oPageProperties.event_highlight_interval);
-                    };
-                }(this.conf.object_id), 0);
+                setTimeout(
+                    (function (obj_id) {
+                        return function () {
+                            flashIcon(
+                                obj_id,
+                                oPageProperties.event_highlight_duration,
+                                oPageProperties.event_highlight_interval
+                            );
+                        };
+                    })(this.conf.object_id),
+                    0
+                );
             } else {
                 // FIXME: Atm only flash icons, not lines or gadgets
             }
         }
-    
+
         // - Scroll to object
-        if (oPageProperties.event_scroll === '1') {
-            setTimeout(function(x, y) {
-                return function() {
-                    scrollSlow(x, y, 1);
-                };
-            }(this.parsedX(), this.parsedY()), 0);
+        if (oPageProperties.event_scroll === "1") {
+            setTimeout(
+                (function (x, y) {
+                    return function () {
+                        scrollSlow(x, y, 1);
+                    };
+                })(this.parsedX(), this.parsedY()),
+                0
+            );
         }
-    
+
         // - Eventlog
-        if (this.conf.type == 'service') {
+        if (this.conf.type == "service") {
             if (stateChanged) {
-                eventlog("state-change", "info", this.conf.type+" "+this.conf.name+" "+this.conf.service_description+": Old: "+this.last_state.summary_state+"/"+this.last_state.summary_problem_has_been_acknowledged+"/"+this.last_state.summary_in_downtime+" New: "+this.conf.summary_state+"/"+this.conf.summary_problem_has_been_acknowledged+"/"+this.conf.summary_in_downtime);
+                eventlog(
+                    "state-change",
+                    "info",
+                    this.conf.type +
+                        " " +
+                        this.conf.name +
+                        " " +
+                        this.conf.service_description +
+                        ": Old: " +
+                        this.last_state.summary_state +
+                        "/" +
+                        this.last_state.summary_problem_has_been_acknowledged +
+                        "/" +
+                        this.last_state.summary_in_downtime +
+                        " New: " +
+                        this.conf.summary_state +
+                        "/" +
+                        this.conf.summary_problem_has_been_acknowledged +
+                        "/" +
+                        this.conf.summary_in_downtime
+                );
+            } else {
+                eventlog(
+                    "state-log",
+                    "info",
+                    this.conf.type +
+                        " " +
+                        this.conf.name +
+                        " " +
+                        this.conf.service_description +
+                        ": State: " +
+                        this.conf.summary_state +
+                        "/" +
+                        this.conf.summary_problem_has_been_acknowledged +
+                        "/" +
+                        this.conf.summary_in_downtime
+                );
             }
-            else {
-                eventlog("state-log", "info", this.conf.type+" "+this.conf.name+" "+this.conf.service_description+": State: "+this.conf.summary_state+"/"+this.conf.summary_problem_has_been_acknowledged+"/"+this.conf.summary_in_downtime);
+        } else {
+            if (stateChanged) {
+                eventlog(
+                    "state-change",
+                    "info",
+                    this.conf.type +
+                        " " +
+                        this.conf.name +
+                        ": Old: " +
+                        this.last_state.summary_state +
+                        "/" +
+                        this.last_state.summary_problem_has_been_acknowledged +
+                        "/" +
+                        this.last_state.summary_in_downtime +
+                        " New: " +
+                        this.conf.summary_state +
+                        "/" +
+                        this.conf.summary_problem_has_been_acknowledged +
+                        "/" +
+                        this.conf.summary_in_downtime
+                );
+            } else {
+                eventlog(
+                    "state-log",
+                    "info",
+                    this.conf.type +
+                        " " +
+                        this.conf.name +
+                        ": State: " +
+                        this.conf.summary_state +
+                        "/" +
+                        this.conf.summary_problem_has_been_acknowledged +
+                        "/" +
+                        this.conf.summary_in_downtime
+                );
             }
         }
-        else {
-            if (stateChanged) {
-                eventlog("state-change", "info", this.conf.type+" "+this.conf.name+": Old: "+this.last_state.summary_state+"/"+this.last_state.summary_problem_has_been_acknowledged+"/"+this.last_state.summary_in_downtime+" New: "+this.conf.summary_state+"/"+this.conf.summary_problem_has_been_acknowledged+"/"+this.conf.summary_in_downtime);
-            }
-            else {
-                eventlog("state-log", "info", this.conf.type+" "+this.conf.name+": State: "+this.conf.summary_state+"/"+this.conf.summary_problem_has_been_acknowledged+"/"+this.conf.summary_in_downtime);
-            }
-        }
-    
+
         // - Sound
-        if (oPageProperties.event_sound === '1') {
-            setTimeout(function(obj_id) {
-                return function() {
-                    playSound(obj_id, 1);
-                };
-            }(this.conf.object_id), 0);
+        if (oPageProperties.event_sound === "1") {
+            setTimeout(
+                (function (obj_id) {
+                    return function () {
+                        playSound(obj_id, 1);
+                    };
+                })(this.conf.object_id),
+                0
+            );
         }
     },
 
     // Initializes repeated events (if configured to do so) after first event handling
     initRepeatedEvents: function () {
         // Are the events configured to be re-raised?
-        if(isset(oViewProperties.event_repeat_interval)
-           && oViewProperties.event_repeat_interval != 0) {
+        if (isset(oViewProperties.event_repeat_interval) && oViewProperties.event_repeat_interval != 0) {
             this.event_time_first = iNow;
-            this.event_time_last  = iNow;
+            this.event_time_last = iNow;
         }
     },
 
@@ -370,24 +444,24 @@ var NagVisStatefulObject = NagVisObject.extend({
         if (!this.hasProblematicState()) {
             // Terminate, reset vars
             this.event_time_first = null;
-            this.event_time_last  = null;
+            this.event_time_last = null;
             return;
         }
-    
+
         // Terminate repeated events after duration has been reached when
         // a limited duration has been configured
-        if (oViewProperties.event_repeat_duration != -1 
-           && this.event_time_first 
-              + oViewProperties.event_repeat_duration < iNow) {
+        if (
+            oViewProperties.event_repeat_duration != -1 &&
+            this.event_time_first + oViewProperties.event_repeat_duration < iNow
+        ) {
             // Terminate, reset vars
             this.event_time_first = null;
-            this.event_time_last  = null;
+            this.event_time_last = null;
             return;
         }
-        
+
         // Time for next event interval?
-        if (this.event_time_last
-           + oViewProperties.event_repeat_interval >= iNow) {
+        if (this.event_time_last + oViewProperties.event_repeat_interval >= iNow) {
             this.raiseEvents(false);
             this.event_time_last = iNow;
         }
@@ -399,66 +473,79 @@ var NagVisStatefulObject = NagVisObject.extend({
      * @author 	Lars Michelsen <lm@larsmichelsen.com>
      */
     replaceMacros: function () {
-        var name = '';
-        if(this.conf.type == 'service') {
-            name = 'host_name';
+        var name = "";
+        if (this.conf.type == "service") {
+            name = "host_name";
         } else {
-            name = this.conf.type + '_name';
+            name = this.conf.type + "_name";
         }
 
-        if(this.conf.url && this.conf.url !== '') {
-            if(this.conf.htmlcgi && this.conf.htmlcgi !== '') {
-                this.conf.url = this.conf.url.replace(getRegEx('htmlcgi', '\\[htmlcgi\\]', 'g'), this.conf.htmlcgi);
+        if (this.conf.url && this.conf.url !== "") {
+            if (this.conf.htmlcgi && this.conf.htmlcgi !== "") {
+                this.conf.url = this.conf.url.replace(getRegEx("htmlcgi", "\\[htmlcgi\\]", "g"), this.conf.htmlcgi);
             } else {
-                this.conf.url = this.conf.url.replace(getRegEx('htmlcgi', '\\[htmlcgi\\]', 'g'), oGeneralProperties.path_cgi);
+                this.conf.url = this.conf.url.replace(
+                    getRegEx("htmlcgi", "\\[htmlcgi\\]", "g"),
+                    oGeneralProperties.path_cgi
+                );
             }
 
-            this.conf.url = this.conf.url.replace(getRegEx('htmlbase', '\\[htmlbase\\]', 'g'), oGeneralProperties.path_base);
+            this.conf.url = this.conf.url.replace(
+                getRegEx("htmlbase", "\\[htmlbase\\]", "g"),
+                oGeneralProperties.path_base
+            );
 
-            this.conf.url = this.conf.url.replace(getRegEx(name, '\\['+name+'\\]', 'g'), encodeURIComponent(this.conf.name));
-            if(this.conf.type == 'service') {
-                this.conf.url = this.conf.url.replace(getRegEx('service_description', '\\[service_description\\]', 'g'), encodeURIComponent(this.conf.service_description));
+            this.conf.url = this.conf.url.replace(
+                getRegEx(name, "\\[" + name + "\\]", "g"),
+                encodeURIComponent(this.conf.name)
+            );
+            if (this.conf.type == "service") {
+                this.conf.url = this.conf.url.replace(
+                    getRegEx("service_description", "\\[service_description\\]", "g"),
+                    encodeURIComponent(this.conf.service_description)
+                );
             }
 
-            if(this.conf.type != 'map') {
-                this.conf.url = this.conf.url.replace(getRegEx('backend_id', '\\[backend_id\\]', 'g'), encodeURIComponent(this.conf.backend_id));
+            if (this.conf.type != "map") {
+                this.conf.url = this.conf.url.replace(
+                    getRegEx("backend_id", "\\[backend_id\\]", "g"),
+                    encodeURIComponent(this.conf.backend_id)
+                );
             }
         }
     },
 
-    highlight: function(show) {
+    highlight: function (show) {
         // FIXME: Highlight lines in the future too
-        if(this.conf.view_type !== 'icon')
-            return;
+        if (this.conf.view_type !== "icon") return;
 
-        var oObjIcon = document.getElementById(this.conf.object_id + '-icon');
-        var oObjIconDiv = document.getElementById(this.conf.object_id + '-icondiv');
+        var oObjIcon = document.getElementById(this.conf.object_id + "-icon");
+        var oObjIconDiv = document.getElementById(this.conf.object_id + "-icondiv");
 
         var sColor = oStates[this.conf.summary_state].color;
 
         // Use these classes (icon-flashing-<state>) in your custom css to customise flashing icons
         // e.g. icon-flashing-critical, icondiv-flashing-critical
         // Note you may need to use '!important' to override the inline default
-        // 
-        var sFlashingClass = 'icon-flashing-' + this.conf.summary_state.toLowerCase();
-        var sFlashingDivClass = 'icondiv-flashing-' + this.conf.summary_state.toLowerCase();
+        //
+        var sFlashingClass = "icon-flashing-" + this.conf.summary_state.toLowerCase();
+        var sFlashingDivClass = "icondiv-flashing-" + this.conf.summary_state.toLowerCase();
 
         this.bIsFlashing = show;
-        if(show) {
-            oObjIcon.style.outline  = "5px solid " + sColor;
+        if (show) {
+            oObjIcon.style.outline = "5px solid " + sColor;
             oObjIcon.classList.add(sFlashingClass);
             oObjIconDiv.classList.add(sFlashingDivClass);
         } else {
-            oObjIcon.style.outline  = "none";
+            oObjIcon.style.outline = "none";
             oObjIcon.classList.remove(sFlashingClass);
             oObjIconDiv.classList.remove(sFlashingDivClass);
         }
 
-        sColor            = null;
-        sFlashingClass    = null;
+        sColor = null;
+        sFlashingClass = null;
         sFlashingDivClass = null;
-        oObjIconDiv       = null;
-        oObjIcon          = null;
+        oObjIconDiv = null;
+        oObjIcon = null;
     }
-
 });

--- a/share/frontend/nagvis-js/js/NagVisStatefulObject.js
+++ b/share/frontend/nagvis-js/js/NagVisStatefulObject.js
@@ -25,7 +25,7 @@
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 
-var NagVisStatefulObject = NagVisObject.extend({
+const NagVisStatefulObject = NagVisObject.extend({
     has_state: true,
 
     // Stores the information from last refresh (Needed for change detection)
@@ -45,9 +45,9 @@ var NagVisStatefulObject = NagVisObject.extend({
         this.members = [];
 
         if (this.conf && this.conf.members && this.conf.members.length > 0) {
-            for (var i = 0, len = this.conf.members.length; i < len; i++) {
-                var oMember = this.conf.members[i];
-                var oObj;
+            for (let i = 0, len = this.conf.members.length; i < len; i++) {
+                let oMember = this.conf.members[i];
+                let oObj;
 
                 switch (oMember.type) {
                     case "host":
@@ -99,8 +99,8 @@ var NagVisStatefulObject = NagVisObject.extend({
     },
 
     getStatefulMembers: function () {
-        var stateful = [];
-        for (var i = 0, len = this.members.length; i < len; i++) {
+        const stateful = [];
+        for (let i = 0, len = this.members.length; i < len; i++) {
             if (this.members[i].has_state) {
                 stateful.push(this.members[i]);
             }
@@ -154,7 +154,7 @@ var NagVisStatefulObject = NagVisObject.extend({
      * @author	Lars Michelsen <lm@larsmichelsen.com>
      */
     stateChangedToWorse: function () {
-        var lastSubState = "normal";
+        let lastSubState = "normal";
         if (
             this.last_state.summary_problem_has_been_acknowledged &&
             this.last_state.summary_problem_has_been_acknowledged == 1
@@ -171,9 +171,9 @@ var NagVisStatefulObject = NagVisObject.extend({
             return true;
         }
 
-        var lastWeight = oStates[this.last_state.summary_state][lastSubState];
+        const lastWeight = oStates[this.last_state.summary_state][lastSubState];
 
-        var subState = "normal";
+        let subState = "normal";
         if (this.conf.summary_problem_has_been_acknowledged && this.conf.summary_problem_has_been_acknowledged == 1) {
             subState = "ack";
         } else if (this.conf.summary_in_downtime && this.conf.summary_in_downtime == 1) {
@@ -182,7 +182,7 @@ var NagVisStatefulObject = NagVisObject.extend({
             subState = "stale";
         }
 
-        var weight = oStates[this.conf.summary_state][subState];
+        const weight = oStates[this.conf.summary_state][subState];
 
         return lastWeight < weight;
     },
@@ -200,7 +200,7 @@ var NagVisStatefulObject = NagVisObject.extend({
             return false;
         }
 
-        var weight = oStates[this.conf.summary_state]["normal"];
+        const weight = oStates[this.conf.summary_state]["normal"];
         return weight > oStates["UP"]["normal"];
     },
 
@@ -281,12 +281,12 @@ var NagVisStatefulObject = NagVisObject.extend({
         if (!this.members || !attrs.members) return;
 
         // Update already existing objects
-        for (var i = 0, len = attrs.members.length; i < len; i++) {
-            var member_attrs = attrs.members[i],
+        for (let i = 0, len = attrs.members.length; i < len; i++) {
+            const member_attrs = attrs.members[i],
                 updated = false;
 
-            for (var a = 0, len2 = this.members.length; a < len2; a++) {
-                var member = this.members[a];
+            for (let a = 0, len2 = this.members.length; a < len2; a++) {
+                const member = this.members[a];
                 if (member_attrs.object_id == member.conf.object_id) {
                     member.updateAttrs(member_attrs, only_state);
                     break;
@@ -473,7 +473,7 @@ var NagVisStatefulObject = NagVisObject.extend({
      * @author 	Lars Michelsen <lm@larsmichelsen.com>
      */
     replaceMacros: function () {
-        var name = "";
+        let name = "";
         if (this.conf.type == "service") {
             name = "host_name";
         } else {
@@ -519,17 +519,17 @@ var NagVisStatefulObject = NagVisObject.extend({
         // FIXME: Highlight lines in the future too
         if (this.conf.view_type !== "icon") return;
 
-        var oObjIcon = document.getElementById(this.conf.object_id + "-icon");
-        var oObjIconDiv = document.getElementById(this.conf.object_id + "-icondiv");
+        let oObjIcon = document.getElementById(this.conf.object_id + "-icon");
+        let oObjIconDiv = document.getElementById(this.conf.object_id + "-icondiv");
 
-        var sColor = oStates[this.conf.summary_state].color;
+        let sColor = oStates[this.conf.summary_state].color;
 
         // Use these classes (icon-flashing-<state>) in your custom css to customise flashing icons
         // e.g. icon-flashing-critical, icondiv-flashing-critical
         // Note you may need to use '!important' to override the inline default
         //
-        var sFlashingClass = "icon-flashing-" + this.conf.summary_state.toLowerCase();
-        var sFlashingDivClass = "icondiv-flashing-" + this.conf.summary_state.toLowerCase();
+        let sFlashingClass = "icon-flashing-" + this.conf.summary_state.toLowerCase();
+        let sFlashingDivClass = "icondiv-flashing-" + this.conf.summary_state.toLowerCase();
 
         this.bIsFlashing = show;
         if (show) {

--- a/share/frontend/nagvis-js/js/NagVisStatelessObject.js
+++ b/share/frontend/nagvis-js/js/NagVisStatelessObject.js
@@ -22,6 +22,6 @@
  *
  *****************************************************************************/
 
-var NagVisStatelessObject = NagVisObject.extend({
+const NagVisStatelessObject = NagVisObject.extend({
     has_state: false
 });

--- a/share/frontend/nagvis-js/js/NagVisStatelessObject.js
+++ b/share/frontend/nagvis-js/js/NagVisStatelessObject.js
@@ -23,5 +23,5 @@
  *****************************************************************************/
 
 var NagVisStatelessObject = NagVisObject.extend({
-    has_state: false,
+    has_state: false
 });

--- a/share/frontend/nagvis-js/js/NagVisTextbox.js
+++ b/share/frontend/nagvis-js/js/NagVisTextbox.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var NagVisTextbox = NagVisStatelessObject.extend({
+const NagVisTextbox = NagVisStatelessObject.extend({
     update: function () {
         this.clearElements();
         new ElementBox(this).addTo(this);

--- a/share/frontend/nagvis-js/js/NagVisTextbox.js
+++ b/share/frontend/nagvis-js/js/NagVisTextbox.js
@@ -22,19 +22,19 @@
  *****************************************************************************/
 
 var NagVisTextbox = NagVisStatelessObject.extend({
-    update: function() {
+    update: function () {
         this.clearElements();
         new ElementBox(this).addTo(this);
         this.base();
     },
 
     replaceMacros: function (text) {
-        text = text.replace('[refresh_counter]', '<font id="refreshCounter"></font>');
-        text = text.replace('[worker_last_run]', '<font id="workerLastRunCounter"></font>');
+        text = text.replace("[refresh_counter]", '<font id="refreshCounter"></font>');
+        text = text.replace("[worker_last_run]", '<font id="workerLastRunCounter"></font>');
         return text;
     },
 
-    getText: function() {
+    getText: function () {
         return this.replaceMacros(this.conf.text);
     }
 });

--- a/share/frontend/nagvis-js/js/View.js
+++ b/share/frontend/nagvis-js/js/View.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var View = Base.extend({
+const View = Base.extend({
     id: null,
     dom_obj: null,
     sum_obj: null,
@@ -33,10 +33,10 @@ var View = Base.extend({
     },
 
     update: function (args) {
-        var show = isset(args.show) ? "&show=" + args.show : "";
+        const show = isset(args.show) ? "&show=" + args.show : "";
 
-        var data = [];
-        for (var i = 0, len = args.data.length; i < len; i++) data.push("i[]=" + args.data[i]);
+        const data = [];
+        for (let i = 0, len = args.data.length; i < len; i++) data.push("i[]=" + args.data[i]);
 
         // Get the updated objects via bulk request
         call_ajax(
@@ -88,9 +88,9 @@ var View = Base.extend({
 
         // Procees the "config changed" responses
         if (isset(o["status"]) && o["status"] == "CHANGED") {
-            var oChanged = o["data"];
+            const oChanged = o["data"];
 
-            for (var key in oChanged) {
+            for (const key in oChanged) {
                 if (key == "maincfg") {
                     eventlog("worker", "info", "Main configuration file was updated. Need to reload the page");
                     // Clear the scheduling timeout to prevent problems with FF4 bugs
@@ -126,16 +126,16 @@ var View = Base.extend({
     },
 
     updateFileAges: function (data) {
-        for (var key in data) oFileAges[key] = data[key];
+        for (const key in data) oFileAges[key] = data[key];
     },
 
     // Bulk update object states (and possibly configs) and then visualize changes
     updateObjects: function (attrs, only_state) {
-        var at_least_one_changed = false;
+        let at_least_one_changed = false;
 
         // Loop all object which have new information
-        for (var i = 0, len = attrs.length; i < len; i++) {
-            var objectId = attrs[i].object_id;
+        for (let i = 0, len = attrs.length; i < len; i++) {
+            const objectId = attrs[i].object_id;
 
             // Object not found. This should only be happen for new objects which have
             // just been added to the map by the user. In this case we always have "full"
@@ -165,7 +165,7 @@ var View = Base.extend({
      */
     handleRepeatEvents: function () {
         eventlog("worker", "debug", "handleRepeatEvents: Start");
-        for (var i in this.objects) {
+        for (const i in this.objects) {
             // Trigger repeated event checking/raising for eacht stateful object which
             // has event_time_first set (means there was an event before which is
             // required to be repeated some time)
@@ -177,7 +177,7 @@ var View = Base.extend({
     },
 
     getFileAgeParams: function () {
-        var addParams = "";
+        let addParams = "";
         if (g_view.type === "map" && this.id !== false) addParams = "&f[]=map," + this.id + "," + oFileAges[this.id];
         return "&f[]=maincfg,maincfg," + oFileAges["maincfg"] + addParams;
     },
@@ -185,11 +185,11 @@ var View = Base.extend({
     // Detects objects with deprecated state information
     getObjectsToUpdate: function () {
         eventlog("worker", "debug", "getObjectsToUpdate: Start");
-        var stateful = [],
+        const stateful = [],
             stateless = [];
 
         // Assign all object which need an update indexes to return Array
-        for (var i in this.objects) {
+        for (const i in this.objects) {
             if (this.objects[i].lastUpdate <= iNow - oWorkerProperties.worker_update_object_states) {
                 if (this.objects[i] instanceof NagVisStatefulObject) {
                     stateful.push(i);
@@ -222,7 +222,7 @@ var View = Base.extend({
         if (!oPageProperties.event_background || oPageProperties.event_background != "1")
             return oPageProperties.background_color;
 
-        var sColor;
+        let sColor;
         // When state is PENDING, OK, UP, set default background color
         if (
             !oObj.summary_state ||
@@ -255,7 +255,7 @@ var View = Base.extend({
 
     // Gets the favicon of the page representating the state of the view
     getFaviconImage: function (oObj) {
-        var sFavicon;
+        let sFavicon;
 
         if (oObj.summary_in_downtime && oObj.summary_in_downtime == 1) sFavicon = "downtime";
         else if (oObj.summary_problem_has_been_acknowledged && oObj.summary_problem_has_been_acknowledged == 1)
@@ -277,11 +277,11 @@ var View = Base.extend({
      * @author  Lars Michelsen <lm@larsmichelsen.com>
      */
     scaleView: function () {
-        var header = document.getElementById("header");
-        var content = this.dom_obj;
+        const header = document.getElementById("header");
+        const content = this.dom_obj;
         if (!content) return;
 
-        var headerSpacer = document.getElementById("headerspacer");
+        let headerSpacer = document.getElementById("headerspacer");
         if (header) {
             header.style.width = pageWidth() + "px";
             if (headerSpacer) {

--- a/share/frontend/nagvis-js/js/View.js
+++ b/share/frontend/nagvis-js/js/View.js
@@ -22,38 +22,50 @@
  *****************************************************************************/
 
 var View = Base.extend({
-    id      : null,
-    dom_obj : null,
-    sum_obj : null,
-    objects : null,
+    id: null,
+    dom_obj: null,
+    sum_obj: null,
+    objects: null,
 
-    constructor: function(id) {
+    constructor: function (id) {
         this.id = id;
         this.objects = {};
     },
 
-    update: function(args) {
-        var show = isset(args.show) ? '&show='+args.show : '';
+    update: function (args) {
+        var show = isset(args.show) ? "&show=" + args.show : "";
 
         var data = [];
-        for (var i = 0, len = args.data.length; i < len; i++)
-            data.push('i[]='+args.data[i]);
+        for (var i = 0, len = args.data.length; i < len; i++) data.push("i[]=" + args.data[i]);
 
         // Get the updated objects via bulk request
-        call_ajax(oGeneralProperties.path_server+'?mod=' + args.mod + '&act=getObjectStates'
-                       + show +'&ty=state'+getViewParams() + this.getFileAgeParams(), {
-            response_handler : this.handleUpdate.bind(this),
-            method           : "POST",
-            post_data        : data.join('&')
-        });
+        call_ajax(
+            oGeneralProperties.path_server +
+                "?mod=" +
+                args.mod +
+                "&act=getObjectStates" +
+                show +
+                "&ty=state" +
+                getViewParams() +
+                this.getFileAgeParams(),
+            {
+                response_handler: this.handleUpdate.bind(this),
+                method: "POST",
+                post_data: data.join("&")
+            }
+        );
 
         // Need to re-raise repeated events?
         this.handleRepeatEvents();
     },
 
-    render: function() {
-        addEvent(window, 'resize', function() { g_view.scaleView() });
-        addEvent(window, 'scroll', function() { g_view.scaleView() });
+    render: function () {
+        addEvent(window, "resize", function () {
+            g_view.scaleView();
+        });
+        addEvent(window, "scroll", function () {
+            g_view.scaleView();
+        });
         this.scaleView();
     },
 
@@ -61,7 +73,7 @@ var View = Base.extend({
      * This callback function handles the ajax response of bulk object
      * status updates
      */
-    handleUpdate: function(o) {
+    handleUpdate: function (o) {
         // Stop processing these informations when the current view should not be
         // updated at the moment e.g. when reparsing the map after a changed mapcfg
         if (this.blockUpdates) {
@@ -75,18 +87,16 @@ var View = Base.extend({
         }
 
         // Procees the "config changed" responses
-        if (isset(o['status']) && o['status'] == 'CHANGED') {
-            var oChanged = o['data'];
+        if (isset(o["status"]) && o["status"] == "CHANGED") {
+            var oChanged = o["data"];
 
             for (var key in oChanged) {
-                if (key == 'maincfg') {
+                if (key == "maincfg") {
                     eventlog("worker", "info", "Main configuration file was updated. Need to reload the page");
                     // Clear the scheduling timeout to prevent problems with FF4 bugs
-                    if (g_worker_id)
-                        window.clearTimeout(g_worker_id);
+                    if (g_worker_id) window.clearTimeout(g_worker_id);
                     window.location.reload(true);
                     return;
-
                 } else {
                     if (g_view.hasUnlocked()) {
                         eventlog("worker", "info", "Map config updated, but having unlocked objects - not reloading.");
@@ -112,17 +122,15 @@ var View = Base.extend({
          * Now proceed with real actions when everything is OK
          */
 
-        if (o.length > 0)
-            this.updateObjects(o, true);
+        if (o.length > 0) this.updateObjects(o, true);
     },
 
-    updateFileAges: function(data) {
-        for (var key in data)
-            oFileAges[key] = data[key];
+    updateFileAges: function (data) {
+        for (var key in data) oFileAges[key] = data[key];
     },
 
     // Bulk update object states (and possibly configs) and then visualize changes
-    updateObjects: function(attrs, only_state) {
+    updateObjects: function (attrs, only_state) {
         var at_least_one_changed = false;
 
         // Loop all object which have new information
@@ -137,27 +145,25 @@ var View = Base.extend({
                 this.addObject(attrs[i]);
                 this.renderObject(objectId);
                 at_least_one_changed = true; // always reload summary state
-            }
-            else {
+            } else {
                 at_least_one_changed |= this.objects[objectId].updateAttrs(attrs[i], only_state);
             }
         }
 
-        if (at_least_one_changed)
-            this.handleStateChanged();
+        if (at_least_one_changed) this.handleStateChanged();
     },
 
-    handleStateChanged: function() {},
+    handleStateChanged: function () {},
 
     // Is called by an object to add the rendered dom object to the map
-    drawObject: function(obj) {},
-    eraseObject: function(obj) {},
+    drawObject: function (obj) {},
+    eraseObject: function (obj) {},
 
     /**
      * Is called by the worker function to check all objects for repeated
      * events to be triggered independent of the state updates.
      */
-    handleRepeatEvents: function() {
+    handleRepeatEvents: function () {
         eventlog("worker", "debug", "handleRepeatEvents: Start");
         for (var i in this.objects) {
             // Trigger repeated event checking/raising for eacht stateful object which
@@ -170,15 +176,14 @@ var View = Base.extend({
         eventlog("worker", "debug", "handleRepeatEvents: End");
     },
 
-    getFileAgeParams: function() {
-        var addParams = '';
-        if (g_view.type === 'map' && this.id !== false)
-            addParams = '&f[]=map,' + this.id + ',' + oFileAges[this.id];
-        return '&f[]=maincfg,maincfg,' + oFileAges['maincfg'] + addParams;
+    getFileAgeParams: function () {
+        var addParams = "";
+        if (g_view.type === "map" && this.id !== false) addParams = "&f[]=map," + this.id + "," + oFileAges[this.id];
+        return "&f[]=maincfg,maincfg," + oFileAges["maincfg"] + addParams;
     },
 
     // Detects objects with deprecated state information
-    getObjectsToUpdate: function() {
+    getObjectsToUpdate: function () {
         eventlog("worker", "debug", "getObjectsToUpdate: Start");
         var stateful = [],
             stateless = [];
@@ -188,78 +193,77 @@ var View = Base.extend({
             if (this.objects[i].lastUpdate <= iNow - oWorkerProperties.worker_update_object_states) {
                 if (this.objects[i] instanceof NagVisStatefulObject) {
                     stateful.push(i);
-                } else if (this.objects[i].conf.enable_refresh
-                           && this.objects[i].conf.enable_refresh == '1') {
+                } else if (this.objects[i].conf.enable_refresh && this.objects[i].conf.enable_refresh == "1") {
                     // Do not update stateless objects where enable_refresh=0
                     stateless.push(i);
                 }
             }
         }
 
-        eventlog("worker", "debug", "getObjectsToUpdate: Stateful: "+stateful.length
-                                   +" Stateless: "+stateless.length);
+        eventlog(
+            "worker",
+            "debug",
+            "getObjectsToUpdate: Stateful: " + stateful.length + " Stateless: " + stateless.length
+        );
         return [stateful, stateless];
     },
 
     // Renders basic information like favicon and page title
-    renderPageBasics: function() {
-        if (this.sum_obj)
-            favicon.change(this.getFaviconImage(this.sum_obj.conf));
+    renderPageBasics: function () {
+        if (this.sum_obj) favicon.change(this.getFaviconImage(this.sum_obj.conf));
 
         document.title = oPageProperties.page_title;
 
-        if (this.sum_obj)
-            document.body.style.backgroundColor = this.getBackgroundColor(this.sum_obj.conf);
+        if (this.sum_obj) document.body.style.backgroundColor = this.getBackgroundColor(this.sum_obj.conf);
     },
 
     // Gets the background color of the map by the summary state of the map
-    getBackgroundColor: function(oObj) {
-        if (!oPageProperties.event_background || oPageProperties.event_background != '1')
+    getBackgroundColor: function (oObj) {
+        if (!oPageProperties.event_background || oPageProperties.event_background != "1")
             return oPageProperties.background_color;
 
         var sColor;
         // When state is PENDING, OK, UP, set default background color
-        if (!oObj.summary_state || oObj.summary_state == 'PENDING'
-           || oObj.summary_state == 'OK' || oObj.summary_state == 'UP')
+        if (
+            !oObj.summary_state ||
+            oObj.summary_state == "PENDING" ||
+            oObj.summary_state == "OK" ||
+            oObj.summary_state == "UP"
+        )
             sColor = oPageProperties.background_color;
         else {
             sColor = oStates[oObj.summary_state].bgcolor;
 
             // Ack or downtime?
             if (oObj.summary_in_downtime && oObj.summary_in_downtime == 1)
-                if (isset(oStates[oObj.summary_state]['downtime_bgcolor'])
-                    && oStates[oObj.summary_state]['downtime_bgcolor'] != '')
-                    sColor = oStates[oObj.summary_state]['downtime_bgcolor'];
-                else
-                    sColor = lightenColor(sColor, 100, 100, 100);
-
-            else if (oObj.summary_problem_has_been_acknowledged
-                     && oObj.summary_problem_has_been_acknowledged == 1)
-
-                if (isset(oStates[oObj.summary_state]['ack_bgcolor'])
-                    && oStates[oObj.summary_state]['ack_bgcolor'] != '')
-                    sColor = oStates[oObj.summary_state]['ack_bgcolor'];
-                else
-                    sColor = lightenColor(sColor, 100, 100, 100);
+                if (
+                    isset(oStates[oObj.summary_state]["downtime_bgcolor"]) &&
+                    oStates[oObj.summary_state]["downtime_bgcolor"] != ""
+                )
+                    sColor = oStates[oObj.summary_state]["downtime_bgcolor"];
+                else sColor = lightenColor(sColor, 100, 100, 100);
+            else if (oObj.summary_problem_has_been_acknowledged && oObj.summary_problem_has_been_acknowledged == 1)
+                if (
+                    isset(oStates[oObj.summary_state]["ack_bgcolor"]) &&
+                    oStates[oObj.summary_state]["ack_bgcolor"] != ""
+                )
+                    sColor = oStates[oObj.summary_state]["ack_bgcolor"];
+                else sColor = lightenColor(sColor, 100, 100, 100);
         }
         return sColor;
     },
-    
+
     // Gets the favicon of the page representating the state of the view
-    getFaviconImage: function(oObj) {
+    getFaviconImage: function (oObj) {
         var sFavicon;
-    
-        if (oObj.summary_in_downtime && oObj.summary_in_downtime == 1)
-            sFavicon = 'downtime';
-        else if (oObj.summary_problem_has_been_acknowledged
-                 && oObj.summary_problem_has_been_acknowledged == 1)
-            sFavicon = 'ack';
-        else if (oObj.summary_state.toLowerCase() == 'unreachable')
-            sFavicon = 'down';
-        else
-            sFavicon = oObj.summary_state.toLowerCase();
-        
-        return oGeneralProperties.path_images+'internal/favicon_'+sFavicon+'.png';
+
+        if (oObj.summary_in_downtime && oObj.summary_in_downtime == 1) sFavicon = "downtime";
+        else if (oObj.summary_problem_has_been_acknowledged && oObj.summary_problem_has_been_acknowledged == 1)
+            sFavicon = "ack";
+        else if (oObj.summary_state.toLowerCase() == "unreachable") sFavicon = "down";
+        else sFavicon = oObj.summary_state.toLowerCase();
+
+        return oGeneralProperties.path_images + "internal/favicon_" + sFavicon + ".png";
     },
 
     /**
@@ -272,22 +276,21 @@ var View = Base.extend({
      *
      * @author  Lars Michelsen <lm@larsmichelsen.com>
      */
-    scaleView: function() {
-        var header  = document.getElementById('header');
+    scaleView: function () {
+        var header = document.getElementById("header");
         var content = this.dom_obj;
-        if (!content)
-            return;
+        if (!content) return;
 
-        var headerSpacer = document.getElementById('headerspacer');
+        var headerSpacer = document.getElementById("headerspacer");
         if (header) {
-            header.style.width = pageWidth() + 'px';
+            header.style.width = pageWidth() + "px";
             if (headerSpacer) {
-                headerSpacer.style.height = header.clientHeight + 'px';
+                headerSpacer.style.height = header.clientHeight + "px";
                 headerSpacer = null;
             }
         }
 
-        content.style.top = getHeaderHeight() + 'px';
+        content.style.top = getHeaderHeight() + "px";
 
         if (typeof sidebarUpdatePosition == "function") {
             sidebarUpdatePosition();
@@ -296,15 +299,14 @@ var View = Base.extend({
 
     // Transforms the view specific coordinates to browser x/y coordinates.
     // This is executed when loading object coordinates from persistance.
-    project: function(x, y) {
+    project: function (x, y) {
         return [x, y];
     },
 
     // Transforms the X/Y coordinates to view specific coords, like
     // on worldmaps to lat/long coordinates. This is executed when
     // persisting the object coordinates after a change
-    unproject: function(x, y) {
+    unproject: function (x, y) {
         return [x, y];
-    },
-
+    }
 });

--- a/share/frontend/nagvis-js/js/ViewMap.js
+++ b/share/frontend/nagvis-js/js/ViewMap.js
@@ -201,7 +201,6 @@ var ViewMap = View.extend({
             default:
                 console.error("Error: Unknown object type", attrs);
                 return;
-                break;
         }
 
         // Save the number of unlocked objects

--- a/share/frontend/nagvis-js/js/ViewMap.js
+++ b/share/frontend/nagvis-js/js/ViewMap.js
@@ -22,37 +22,37 @@
  *****************************************************************************/
 
 var ViewMap = View.extend({
-    type           : 'map',
+    type: "map",
     // is set to true on first rendering
-    rendered       : false,
+    rendered: false,
     // This is turned to true when the map is currently reparsing (e.g. due to
     // a changed map config file). This blocks object updates.
-    blockUpdates   : false,
+    blockUpdates: false,
     // The number of currently unlocked objects for editing. When this is
     // above 0, it will lead to block state updates till it's 0 again
-    num_unlocked   : false,
+    num_unlocked: false,
 
-    constructor: function(id) {
+    constructor: function (id) {
         this.base(id);
     },
 
-    init: function() {
-        if (!usesSource('worldmap')) {
+    init: function () {
+        if (!usesSource("worldmap")) {
             renderZoombar();
-            addEvent(document, 'mousedown', context_handle_global_mousedown);
+            addEvent(document, "mousedown", context_handle_global_mousedown);
         }
 
         this.render();
     },
 
-    update: function() {
+    update: function () {
         var to_update = this.getObjectsToUpdate();
 
         if (to_update[0].length > 0) {
             this.base({
-                mod  : 'Map',
-                show : this.id,
-                data : to_update[0]
+                mod: "Map",
+                show: this.id,
+                data: to_update[0]
             });
         }
 
@@ -64,8 +64,8 @@ var ViewMap = View.extend({
      */
 
     // Parses the map on initial page load or changed map configuration
-    render: function() {
-        this.dom_obj = document.getElementById('map');
+    render: function () {
+        this.dom_obj = document.getElementById("map");
 
         // Is updated later by this.getProperties(), but we might need it in
         // the case an error occurs in getProperties() and one needs
@@ -79,42 +79,43 @@ var ViewMap = View.extend({
         var wasInMaintenance = inMaintenance(false);
 
         // Get new map properties from server on changed map cfg
-        if (this.rendered)
-            this.updateProperties();
+        if (this.rendered) this.updateProperties();
 
-        if(inMaintenance()) {
+        if (inMaintenance()) {
             this.blockUpdates = false;
-            return false
-        } else if(wasInMaintenance === true) {
+            return false;
+        } else if (wasInMaintenance === true) {
             // Hide the maintenance message when it was in maintenance before
-            frontendMessageRemove('maintenance');
+            frontendMessageRemove("maintenance");
         }
         wasInMaintenance = null;
 
-        call_ajax(oGeneralProperties.path_server + '?mod=Map&act=getMapObjects&show='
-                  + this.id + getViewParams(), {
-            response_handler : this.handleMapInit.bind(this),
-            error_handler    : this.handleMapInitError.bind(this)
+        call_ajax(oGeneralProperties.path_server + "?mod=Map&act=getMapObjects&show=" + this.id + getViewParams(), {
+            response_handler: this.handleMapInit.bind(this),
+            error_handler: this.handleMapInitError.bind(this)
         });
 
         this.rendered = true;
         this.base();
     },
 
-    handleMapInitError: function(status_code, response, handler_data) {
+    handleMapInitError: function (status_code, response, handler_data) {
         hideStatusMessage();
         if (response === null) {
             var response = {
-                'type'    : 'error',
-                'title'   : 'Error: Invalid response',
-                'message' : 'Got empty response from server (code: ' + status_code + '). '
-                          + 'Take a look at the web server error log for details.',
+                type: "error",
+                title: "Error: Invalid response",
+                message:
+                    "Got empty response from server (code: " +
+                    status_code +
+                    "). " +
+                    "Take a look at the web server error log for details."
             };
         }
-        frontendMessage(response, 'serverError');
+        frontendMessage(response, "serverError");
     },
 
-    handleMapInit: function(oObjects) {
+    handleMapInit: function (oObjects) {
         // Only perform the rendering actions when all information are available
         if (!oObjects) {
             hideStatusMessage();
@@ -124,35 +125,33 @@ var ViewMap = View.extend({
         // Remove all old objects
         for (var i in this.objects) {
             var obj = this.objects[i];
-            if(obj && typeof obj.remove === 'function') {
+            if (obj && typeof obj.remove === "function") {
                 // Remove parsed object from map
                 obj.remove();
 
-                if(!obj.bIsLocked)
-                    this.updateNumUnlocked(-1);
+                if (!obj.bIsLocked) this.updateNumUnlocked(-1);
 
                 // Remove element from object container
                 delete this.objects[i];
             }
         }
 
-        if (usesSource('worldmap')) {
+        if (usesSource("worldmap")) {
             g_map_objects.clearLayers();
         }
 
-        eventlog("worker", "info", "Parsing "+this.type+" objects");
+        eventlog("worker", "info", "Parsing " + this.type + " objects");
         this.initializeObjects(oObjects);
 
         // Maybe force page reload when the map shal fill the viewport
-        if (getViewParam('zoom') == 'fill')
-            set_fill_zoom_factor();
+        if (getViewParam("zoom") == "fill") set_fill_zoom_factor();
 
         // Set map basics
         // Needs to be called after the summary state of the map is known
         this.renderMapBasics();
 
         // When user searches for an object highlight it
-        if(oViewProperties && oViewProperties.search && oViewProperties.search != '') {
+        if (oViewProperties && oViewProperties.search && oViewProperties.search != "") {
             eventlog("worker", "info", "Searching for matching object(s)");
             searchObjects(oViewProperties.search);
         }
@@ -163,69 +162,68 @@ var ViewMap = View.extend({
         this.blockUpdates = false;
     },
 
-    addObject: function(attrs) {
+    addObject: function (attrs) {
         var obj;
         switch (attrs.type) {
-            case 'host':
+            case "host":
                 obj = new NagVisHost(attrs);
-            break;
-            case 'service':
+                break;
+            case "service":
                 obj = new NagVisService(attrs);
-            break;
-            case 'hostgroup':
+                break;
+            case "hostgroup":
                 obj = new NagVisHostgroup(attrs);
-            break;
-            case 'servicegroup':
+                break;
+            case "servicegroup":
                 obj = new NagVisServicegroup(attrs);
-            break;
-            case 'dyngroup':
+                break;
+            case "dyngroup":
                 obj = new NagVisDynGroup(attrs);
-            break;
-            case 'aggr':
+                break;
+            case "aggr":
                 obj = new NagVisAggr(attrs);
-            break;
-            case 'map':
+                break;
+            case "map":
                 obj = new NagVisMap(attrs);
-            break;
-            case 'textbox':
+                break;
+            case "textbox":
                 obj = new NagVisTextbox(attrs);
-            break;
-            case 'container':
+                break;
+            case "container":
                 obj = new NagVisContainer(attrs);
-            break;
-            case 'shape':
+                break;
+            case "shape":
                 obj = new NagVisShape(attrs);
-            break;
-            case 'line':
+                break;
+            case "line":
                 obj = new NagVisLine(attrs);
-            break;
+                break;
             default:
-                console.error('Error: Unknown object type', attrs);
+                console.error("Error: Unknown object type", attrs);
                 return;
-            break;
+                break;
         }
-    
+
         // Save the number of unlocked objects
-        if (!obj.bIsLocked)
-            this.updateNumUnlocked(1);
-    
+        if (!obj.bIsLocked) this.updateNumUnlocked(1);
+
         // Put object to map objects array
         this.objects[obj.conf.object_id] = obj;
     },
 
-    erase: function() {
+    erase: function () {
         for (var i in this.objects) {
             this.objects[i].erase();
         }
     },
 
-    renderObject: function(object_id) {
+    renderObject: function (object_id) {
         var obj = this.objects[object_id];
         var parents = obj.getParentObjectIds();
 
-        if (parents && usesSource('automap')){
+        if (parents && usesSource("automap")) {
             for (var parentObjId in parents) {
-                if (!this.objects[parentObjId]){
+                if (!this.objects[parentObjId]) {
                     return;
                 }
             }
@@ -234,10 +232,14 @@ var ViewMap = View.extend({
         // FIXME: Are all these steps needed here?
         obj.update();
         obj.render();
-    
+
         // add eventhandling when enabled via event_on_load option
-        if (isset(oViewProperties.event_on_load) && oViewProperties.event_on_load == 1
-           && obj.has_state && obj.hasProblematicState()) {
+        if (
+            isset(oViewProperties.event_on_load) &&
+            oViewProperties.event_on_load == 1 &&
+            obj.has_state &&
+            obj.hasProblematicState()
+        ) {
             obj.raiseEvents(false);
             obj.initRepeatedEvents();
         }
@@ -251,57 +253,54 @@ var ViewMap = View.extend({
     },
 
     // Add the objects dom_obj to the maps dom_obj
-    drawObject: function(obj) {
+    drawObject: function (obj) {
         this.dom_obj.appendChild(obj.dom_obj);
     },
 
-    // Removes the given objects dom_obj from the maps dom_obj 
-    eraseObject: function(obj) {
+    // Removes the given objects dom_obj from the maps dom_obj
+    eraseObject: function (obj) {
         this.dom_obj.removeChild(obj.dom_obj);
     },
 
     // Does initial rendering of map objects
-    initializeObjects: function(aMapObjectConf) {
+    initializeObjects: function (aMapObjectConf) {
         eventlog("worker", "debug", "initializeObjects: Start setting map objects");
-    
+
         // Don't loop the first object - that is the summary of the current map
         this.sum_obj = new NagVisMap(aMapObjectConf[0]);
-    
-        for (var i = 1, len = aMapObjectConf.length; i < len; i++)
-            this.addObject(aMapObjectConf[i]);
-    
+
+        for (var i = 1, len = aMapObjectConf.length; i < len; i++) this.addObject(aMapObjectConf[i]);
+
         // First parse the objects on the map
         // Then store the object position dependencies.
         // Before both can be done all objects need to be added
         // to the map objects list
-        for (var i in this.objects)
-            this.renderObject(i);
+        for (var i in this.objects) this.renderObject(i);
 
         eventlog("worker", "debug", "initializeObjects: End setting map objects");
     },
 
     // Sets basic information like background image
-    renderMapBasics: function() {
+    renderMapBasics: function () {
         var title = oPageProperties.alias;
-        if (this.sum_obj && this.sum_obj.conf)
-            title += ' (' + this.sum_obj.conf.summary_state + ')';
-        title += ' :: ' + oGeneralProperties.internal_title;
+        if (this.sum_obj && this.sum_obj.conf) title += " (" + this.sum_obj.conf.summary_state + ")";
+        title += " :: " + oGeneralProperties.internal_title;
         oPageProperties.page_title = title;
 
         this.renderPageBasics();
         this.renderBackgroundImage();
     },
 
-    renderBackgroundImage: function() {
+    renderBackgroundImage: function () {
         var sImage = oPageProperties.background_image;
 
-        var oImage = document.getElementById('backgroundImage');
-        if (typeof sImage !== 'undefined' && sImage !== 'none' && sImage !== '') {
+        var oImage = document.getElementById("backgroundImage");
+        if (typeof sImage !== "undefined" && sImage !== "none" && sImage !== "") {
             // Use existing image or create new
             if (!oImage) {
-                var oImage = document.createElement('img');
-                oImage.setAttribute('id', 'backgroundImage');
-                document.getElementById('map').appendChild(oImage);
+                var oImage = document.createElement("img");
+                oImage.setAttribute("id", "backgroundImage");
+                document.getElementById("map").appendChild(oImage);
                 addZoomHandler(oImage, true);
             }
 
@@ -314,15 +313,21 @@ var ViewMap = View.extend({
     },
 
     // When at least one object state changed, fetch a new summary state from the server
-    handleStateChanged: function() {
-        call_ajax(oGeneralProperties.path_server + '?mod=Map&act=getObjectStates&show='+this.id
-                        + '&ty=summary' + getViewParams(), {
-            response_handler : this.handleSumObjUpdate.bind(this)
-        });
+    handleStateChanged: function () {
+        call_ajax(
+            oGeneralProperties.path_server +
+                "?mod=Map&act=getObjectStates&show=" +
+                this.id +
+                "&ty=summary" +
+                getViewParams(),
+            {
+                response_handler: this.handleSumObjUpdate.bind(this)
+            }
+        );
     },
 
     // This function updates the map basics like background, favicon and title
-    handleSumObjUpdate: function(objects) {
+    handleSumObjUpdate: function (objects) {
         this.sum_obj = new NagVisMap(objects[0]);
         this.renderMapBasics();
     },
@@ -332,14 +337,19 @@ var ViewMap = View.extend({
      * is set during initial rendering, but needed when the configuration
      * has changed on the server.
      */
-    updateProperties: function() {
-        call_ajax(oGeneralProperties.path_server+'?mod=Map&act=getMapProperties&show='
-                  + escapeUrlValues(this.id)+getViewParams(), {
-            response_handler : function(props) {
-                oPageProperties = props;
-                g_view.renderMapBasics();
+    updateProperties: function () {
+        call_ajax(
+            oGeneralProperties.path_server +
+                "?mod=Map&act=getMapProperties&show=" +
+                escapeUrlValues(this.id) +
+                getViewParams(),
+            {
+                response_handler: function (props) {
+                    oPageProperties = props;
+                    g_view.renderMapBasics();
+                }
             }
-        });
+        );
     },
 
     /**
@@ -347,20 +357,18 @@ var ViewMap = View.extend({
      * Stateless objects which shal be refreshed (enable_refresh=1) need a special
      * handling as they are reloaded by being reparsed.
      */
-    rerenderStatelessObjects: function(objects) {
-        for (var i = 0, len = objects.length; i < len; i++)
-            this.objects[objects[i]].render();
+    rerenderStatelessObjects: function (objects) {
+        for (var i = 0, len = objects.length; i < len; i++) this.objects[objects[i]].render();
     },
 
-    removeObject: function(object_id) {
+    removeObject: function (object_id) {
         var obj = this.objects[object_id];
 
         obj.detachChilds();
         saveObjectRemove(object_id);
         obj.remove();
 
-        if (!obj.bIsLocked)
-            this.updateNumUnlocked(-1);
+        if (!obj.bIsLocked) this.updateNumUnlocked(-1);
 
         delete this.objects[object_id];
     },
@@ -369,31 +377,28 @@ var ViewMap = View.extend({
      * OBJECT VIEW/EDIT LOCKING
      */
 
-    hasUnlocked: function() {
+    hasUnlocked: function () {
         return this.num_unlocked > 0;
     },
 
-    toggleObjectLock: function(object_id, lock) {
+    toggleObjectLock: function (object_id, lock) {
         this.updateNumUnlocked(this.objects[object_id].toggleLock(lock));
     },
 
-    updateNumUnlocked: function(num) {
+    updateNumUnlocked: function (num) {
         this.num_unlocked += num;
         if (this.num_unlocked == 0) {
             // Not in edit mode anymore
-            var o = document.getElementById('editIndicator');
-            if (o)
-                o.style.display = 'none';
+            var o = document.getElementById("editIndicator");
+            if (o) o.style.display = "none";
 
             gridRemove();
         } else {
             // In edit mode (for at least one object)
-            var o = document.getElementById('editIndicator');
-            if (o)
-                o.style.display = '';
+            var o = document.getElementById("editIndicator");
+            if (o) o.style.display = "";
 
             gridParse();
         }
     }
-
 });

--- a/share/frontend/nagvis-js/js/ViewMap.js
+++ b/share/frontend/nagvis-js/js/ViewMap.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var ViewMap = View.extend({
+const ViewMap = View.extend({
     type: "map",
     // is set to true on first rendering
     rendered: false,
@@ -46,7 +46,7 @@ var ViewMap = View.extend({
     },
 
     update: function () {
-        var to_update = this.getObjectsToUpdate();
+        const to_update = this.getObjectsToUpdate();
 
         if (to_update[0].length > 0) {
             this.base({
@@ -76,7 +76,7 @@ var ViewMap = View.extend({
         // Block updates of the current map
         this.blockUpdates = true;
 
-        var wasInMaintenance = inMaintenance(false);
+        let wasInMaintenance = inMaintenance(false);
 
         // Get new map properties from server on changed map cfg
         if (this.rendered) this.updateProperties();
@@ -123,8 +123,8 @@ var ViewMap = View.extend({
         }
 
         // Remove all old objects
-        for (var i in this.objects) {
-            var obj = this.objects[i];
+        for (const i in this.objects) {
+            const obj = this.objects[i];
             if (obj && typeof obj.remove === "function") {
                 // Remove parsed object from map
                 obj.remove();
@@ -163,7 +163,7 @@ var ViewMap = View.extend({
     },
 
     addObject: function (attrs) {
-        var obj;
+        let obj;
         switch (attrs.type) {
             case "host":
                 obj = new NagVisHost(attrs);
@@ -211,17 +211,17 @@ var ViewMap = View.extend({
     },
 
     erase: function () {
-        for (var i in this.objects) {
+        for (const i in this.objects) {
             this.objects[i].erase();
         }
     },
 
     renderObject: function (object_id) {
-        var obj = this.objects[object_id];
-        var parents = obj.getParentObjectIds();
+        const obj = this.objects[object_id];
+        const parents = obj.getParentObjectIds();
 
         if (parents && usesSource("automap")) {
-            for (var parentObjId in parents) {
+            for (const parentObjId in parents) {
                 if (!this.objects[parentObjId]) {
                     return;
                 }
@@ -245,7 +245,7 @@ var ViewMap = View.extend({
 
         // Store object dependencies
         if (parents) {
-            for (parentObjId in parents) {
+            for (const parentObjId in parents) {
                 if (isset(this.objects[parentObjId])) this.objects[parentObjId].addChild(obj);
             }
         }
@@ -268,20 +268,20 @@ var ViewMap = View.extend({
         // Don't loop the first object - that is the summary of the current map
         this.sum_obj = new NagVisMap(aMapObjectConf[0]);
 
-        for (var i = 1, len = aMapObjectConf.length; i < len; i++) this.addObject(aMapObjectConf[i]);
+        for (let i = 1, len = aMapObjectConf.length; i < len; i++) this.addObject(aMapObjectConf[i]);
 
         // First parse the objects on the map
         // Then store the object position dependencies.
         // Before both can be done all objects need to be added
         // to the map objects list
-        for (i in this.objects) this.renderObject(i);
+        for (const i in this.objects) this.renderObject(i);
 
         eventlog("worker", "debug", "initializeObjects: End setting map objects");
     },
 
     // Sets basic information like background image
     renderMapBasics: function () {
-        var title = oPageProperties.alias;
+        let title = oPageProperties.alias;
         if (this.sum_obj && this.sum_obj.conf) title += " (" + this.sum_obj.conf.summary_state + ")";
         title += " :: " + oGeneralProperties.internal_title;
         oPageProperties.page_title = title;
@@ -291,9 +291,9 @@ var ViewMap = View.extend({
     },
 
     renderBackgroundImage: function () {
-        var sImage = oPageProperties.background_image;
+        const sImage = oPageProperties.background_image;
 
-        var oImage = document.getElementById("backgroundImage");
+        let oImage = document.getElementById("backgroundImage");
         if (typeof sImage !== "undefined" && sImage !== "none" && sImage !== "") {
             // Use existing image or create new
             if (!oImage) {
@@ -357,11 +357,11 @@ var ViewMap = View.extend({
      * handling as they are reloaded by being reparsed.
      */
     rerenderStatelessObjects: function (objects) {
-        for (var i = 0, len = objects.length; i < len; i++) this.objects[objects[i]].render();
+        for (let i = 0, len = objects.length; i < len; i++) this.objects[objects[i]].render();
     },
 
     removeObject: function (object_id) {
-        var obj = this.objects[object_id];
+        const obj = this.objects[object_id];
 
         obj.detachChilds();
         saveObjectRemove(object_id);
@@ -388,13 +388,13 @@ var ViewMap = View.extend({
         this.num_unlocked += num;
         if (this.num_unlocked == 0) {
             // Not in edit mode anymore
-            var o = document.getElementById("editIndicator");
+            const o = document.getElementById("editIndicator");
             if (o) o.style.display = "none";
 
             gridRemove();
         } else {
             // In edit mode (for at least one object)
-            o = document.getElementById("editIndicator");
+            const o = document.getElementById("editIndicator");
             if (o) o.style.display = "";
 
             gridParse();

--- a/share/frontend/nagvis-js/js/ViewMap.js
+++ b/share/frontend/nagvis-js/js/ViewMap.js
@@ -102,7 +102,7 @@ var ViewMap = View.extend({
     handleMapInitError: function (status_code, response, handler_data) {
         hideStatusMessage();
         if (response === null) {
-            var response = {
+            response = {
                 type: "error",
                 title: "Error: Invalid response",
                 message:
@@ -245,7 +245,7 @@ var ViewMap = View.extend({
 
         // Store object dependencies
         if (parents) {
-            for (var parentObjId in parents) {
+            for (parentObjId in parents) {
                 if (isset(this.objects[parentObjId])) this.objects[parentObjId].addChild(obj);
             }
         }
@@ -274,7 +274,7 @@ var ViewMap = View.extend({
         // Then store the object position dependencies.
         // Before both can be done all objects need to be added
         // to the map objects list
-        for (var i in this.objects) this.renderObject(i);
+        for (i in this.objects) this.renderObject(i);
 
         eventlog("worker", "debug", "initializeObjects: End setting map objects");
     },
@@ -297,7 +297,7 @@ var ViewMap = View.extend({
         if (typeof sImage !== "undefined" && sImage !== "none" && sImage !== "") {
             // Use existing image or create new
             if (!oImage) {
-                var oImage = document.createElement("img");
+                oImage = document.createElement("img");
                 oImage.setAttribute("id", "backgroundImage");
                 document.getElementById("map").appendChild(oImage);
                 addZoomHandler(oImage, true);
@@ -394,7 +394,7 @@ var ViewMap = View.extend({
             gridRemove();
         } else {
             // In edit mode (for at least one object)
-            var o = document.getElementById("editIndicator");
+            o = document.getElementById("editIndicator");
             if (o) o.style.display = "";
 
             gridParse();

--- a/share/frontend/nagvis-js/js/ViewOverview.js
+++ b/share/frontend/nagvis-js/js/ViewOverview.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var ViewOverview = View.extend({
+const ViewOverview = View.extend({
     type: "overview",
     rendered_maps: 0,
     processed_maps: 0,
@@ -39,7 +39,7 @@ var ViewOverview = View.extend({
     },
 
     update: function () {
-        var to_update = this.getObjectsToUpdate();
+        const to_update = this.getObjectsToUpdate();
         if (to_update[0].length > 0) {
             this.base({
                 mod: "Overview",
@@ -56,17 +56,17 @@ var ViewOverview = View.extend({
         this.dom_obj = document.getElementById("overview");
 
         // Render maps and the rotations when enabled
-        var types = [
+        const types = [
             [oPageProperties.showmaps, "overviewMaps", oPageProperties.lang_mapIndex],
             [oPageProperties.showrotations, "overviewRotations", oPageProperties.lang_rotationPools]
         ];
-        for (var i = 0; i < types.length; i++) {
+        for (let i = 0; i < types.length; i++) {
             if (types[i][0] === 1) {
-                var h2 = document.createElement("h2");
+                const h2 = document.createElement("h2");
                 h2.innerHTML = types[i][2];
                 this.dom_obj.appendChild(h2);
 
-                var container = document.createElement("div");
+                const container = document.createElement("div");
                 container.setAttribute("id", types[i][1]);
                 container.className = "infobox";
                 this.dom_obj.appendChild(container);
@@ -77,19 +77,19 @@ var ViewOverview = View.extend({
 
     // Add the objects dom_obj to the maps dom_obj
     drawObject: function (obj) {
-        var container = document.getElementById("overviewMaps");
+        const container = document.getElementById("overviewMaps");
         container.appendChild(obj.dom_obj);
     },
 
     // Removes the given objects dom_obj from the maps dom_obj
     eraseObject: function (obj) {
-        var container = document.getElementById("overviewMaps");
+        const container = document.getElementById("overviewMaps");
         if (obj.dom_obj.parentNode == container) container.removeChild(obj.dom_obj);
     },
 
     // Adds a single map to the overview map list
     addMap: function (objects, data) {
-        var map_name = data[0],
+        const map_name = data[0],
             worldmap_has_bbox = data[1];
 
         this.processed_maps += 1;
@@ -104,14 +104,14 @@ var ViewOverview = View.extend({
             if (this.processed_maps == g_map_names.length) finishOverviewMaps();
             return false;
         }
-        var map_conf = objects[0];
+        const map_conf = objects[0];
 
         // The worldmap preview summary state should reflect the state shown by the worldmap
         // when the user opens it. This means it is needed to calculate which area of the worldmap
         // will be shown to the user and then only deal with the objects within this area.
         // Bad here: For the worldmaps we need to do a second HTTP request which should be avoided
         if (!worldmap_has_bbox && map_conf["sources"] && map_conf["sources"].indexOf("worldmap") !== -1) {
-            var worldmap = L.map("overview", {
+            const worldmap = L.map("overview", {
                 markerZoomAnimation: false,
                 maxBounds: [
                     [-85, -180.0],
@@ -123,7 +123,7 @@ var ViewOverview = View.extend({
             worldmap.remove();
 
             // leaflet does not clean up everything. We do it on our own.
-            var overview = document.getElementById("overview");
+            const overview = document.getElementById("overview");
             remove_class(overview, "leaflet-container");
             remove_class(overview, "leaflet-retina");
             remove_class(overview, "leaflet-fade-anim");
@@ -145,12 +145,12 @@ var ViewOverview = View.extend({
 
         this.rendered_maps += 1; // also count errors
 
-        var container = document.getElementById("overviewMaps");
+        const container = document.getElementById("overviewMaps");
 
         // Find the map placeholder div (replace it to keep sorting)
-        var mapdiv = null;
-        var child = null;
-        for (var i = 0; i < container.childNodes.length; i++) {
+        let mapdiv = null;
+        let child = null;
+        for (let i = 0; i < container.childNodes.length; i++) {
             child = container.childNodes[i];
             if (child.id == map_name) {
                 mapdiv = child;
@@ -159,7 +159,7 @@ var ViewOverview = View.extend({
         }
 
         // render the map object
-        var obj = new NagVisMap(map_conf);
+        const obj = new NagVisMap(map_conf);
         // Save object to map objects array
         this.objects[obj.conf.object_id] = obj;
         obj.update();
@@ -179,12 +179,12 @@ var ViewOverview = View.extend({
     // Does initial parsing of rotations on the overview page
     addRotations: function (rotations) {
         if (oPageProperties.showrotations === 1 && rotations.length > 0) {
-            for (var i = 0, len = rotations.length; i < len; i++) {
+            for (let i = 0, len = rotations.length; i < len; i++) {
                 new NagVisRotation(rotations[i]).parseOverview();
             }
         } else {
             // Hide the rotations container
-            var container = document.getElementById("overviewRotations");
+            const container = document.getElementById("overviewRotations");
             if (container) {
                 container.style.display = "none";
             }
@@ -193,7 +193,7 @@ var ViewOverview = View.extend({
 
     // Fetches all maps to be shown on the overview page
     loadMaps: function () {
-        var map_container = document.getElementById("overviewMaps");
+        const map_container = document.getElementById("overviewMaps");
 
         if (oPageProperties.showmaps !== 1 || g_map_names.length == 0) {
             if (map_container) map_container.parentNode.style.display = "none";
@@ -201,8 +201,8 @@ var ViewOverview = View.extend({
             return false;
         }
 
-        for (var i = 0, len = g_map_names.length; i < len; i++) {
-            var mapdiv = document.createElement("div");
+        for (let i = 0, len = g_map_names.length; i < len; i++) {
+            const mapdiv = document.createElement("div");
             mapdiv.setAttribute("id", g_map_names[i]);
             map_container.appendChild(mapdiv);
             call_ajax(

--- a/share/frontend/nagvis-js/js/ViewOverview.js
+++ b/share/frontend/nagvis-js/js/ViewOverview.js
@@ -22,28 +22,28 @@
  *****************************************************************************/
 
 var ViewOverview = View.extend({
-    type           : 'overview',
-    rendered_maps  : 0,
-    processed_maps : 0,
+    type: "overview",
+    rendered_maps: 0,
+    processed_maps: 0,
 
-    constructor: function() {
+    constructor: function () {
         this.base(null);
     },
 
-    init: function() {
-        addEvent(document, 'mousedown', context_handle_global_mousedown);
+    init: function () {
+        addEvent(document, "mousedown", context_handle_global_mousedown);
         this.renderPageBasics();
         this.render();
         this.loadMaps();
         this.loadRotations();
     },
 
-    update: function() {
+    update: function () {
         var to_update = this.getObjectsToUpdate();
         if (to_update[0].length > 0) {
             this.base({
-                mod  : 'Overview',
-                data : to_update[0]
+                mod: "Overview",
+                data: to_update[0]
             });
         }
     },
@@ -52,23 +52,23 @@ var ViewOverview = View.extend({
      * END OF PUBLIC METHODS
      */
 
-    render: function() {
-        this.dom_obj = document.getElementById('overview');
+    render: function () {
+        this.dom_obj = document.getElementById("overview");
 
         // Render maps and the rotations when enabled
         var types = [
-            [ oPageProperties.showmaps,      'overviewMaps',      oPageProperties.lang_mapIndex ],
-            [ oPageProperties.showrotations, 'overviewRotations', oPageProperties.lang_rotationPools ]
+            [oPageProperties.showmaps, "overviewMaps", oPageProperties.lang_mapIndex],
+            [oPageProperties.showrotations, "overviewRotations", oPageProperties.lang_rotationPools]
         ];
         for (var i = 0; i < types.length; i++) {
             if (types[i][0] === 1) {
-                var h2 = document.createElement('h2');
+                var h2 = document.createElement("h2");
                 h2.innerHTML = types[i][2];
                 this.dom_obj.appendChild(h2);
 
-                var container = document.createElement('div');
-                container.setAttribute('id', types[i][1]);
-                container.className = 'infobox';
+                var container = document.createElement("div");
+                container.setAttribute("id", types[i][1]);
+                container.className = "infobox";
                 this.dom_obj.appendChild(container);
             }
         }
@@ -76,30 +76,32 @@ var ViewOverview = View.extend({
     },
 
     // Add the objects dom_obj to the maps dom_obj
-    drawObject: function(obj) {
-        var container = document.getElementById('overviewMaps');
+    drawObject: function (obj) {
+        var container = document.getElementById("overviewMaps");
         container.appendChild(obj.dom_obj);
     },
 
-    // Removes the given objects dom_obj from the maps dom_obj 
-    eraseObject: function(obj) {
-        var container = document.getElementById('overviewMaps');
-        if (obj.dom_obj.parentNode == container)
-            container.removeChild(obj.dom_obj);
+    // Removes the given objects dom_obj from the maps dom_obj
+    eraseObject: function (obj) {
+        var container = document.getElementById("overviewMaps");
+        if (obj.dom_obj.parentNode == container) container.removeChild(obj.dom_obj);
     },
 
     // Adds a single map to the overview map list
-    addMap: function(objects, data) {
-        var map_name           = data[0],
-            worldmap_has_bbox  = data[1];
+    addMap: function (objects, data) {
+        var map_name = data[0],
+            worldmap_has_bbox = data[1];
 
         this.processed_maps += 1;
 
         // Exit this function on invalid call
-        if (objects === null || objects.length != 1)  {
-            eventlog("worker", "warning", "addOverviewMap: Invalid call - maybe broken ajax response ("+map_name+")");
-            if (this.processed_maps == g_map_names.length)
-                finishOverviewMaps();
+        if (objects === null || objects.length != 1) {
+            eventlog(
+                "worker",
+                "warning",
+                "addOverviewMap: Invalid call - maybe broken ajax response (" + map_name + ")"
+            );
+            if (this.processed_maps == g_map_names.length) finishOverviewMaps();
             return false;
         }
         var map_conf = objects[0];
@@ -108,36 +110,42 @@ var ViewOverview = View.extend({
         // when the user opens it. This means it is needed to calculate which area of the worldmap
         // will be shown to the user and then only deal with the objects within this area.
         // Bad here: For the worldmaps we need to do a second HTTP request which should be avoided
-        if (!worldmap_has_bbox && map_conf['sources']
-            && map_conf['sources'].indexOf('worldmap') !== -1) {
-
-            var worldmap = L.map('overview', {
+        if (!worldmap_has_bbox && map_conf["sources"] && map_conf["sources"].indexOf("worldmap") !== -1) {
+            var worldmap = L.map("overview", {
                 markerZoomAnimation: false,
-                maxBounds: [ [-85,-180.0], [85,180.0] ],
+                maxBounds: [
+                    [-85, -180.0],
+                    [85, 180.0]
+                ],
                 minZoom: 2
-            }).setView(map_conf['worldmap_center'].split(','), parseInt(map_conf['worldmap_zoom']));
+            }).setView(map_conf["worldmap_center"].split(","), parseInt(map_conf["worldmap_zoom"]));
 
             worldmap.remove();
 
             // leaflet does not clean up everything. We do it on our own.
-            var overview = document.getElementById('overview');
-            remove_class(overview, 'leaflet-container');
-            remove_class(overview, 'leaflet-retina');
-            remove_class(overview, 'leaflet-fade-anim');
+            var overview = document.getElementById("overview");
+            remove_class(overview, "leaflet-container");
+            remove_class(overview, "leaflet-retina");
+            remove_class(overview, "leaflet-fade-anim");
 
             this.processed_maps -= 1;
-            call_ajax(oGeneralProperties.path_server+'?mod=Overview&act=getObjectStates'
-                      + '&i[]=map-' + escapeUrlValues(map_name)
-                      + getViewParams({'bbox': worldmap.getBounds().toBBoxString()}), {
-                response_handler : this.addMap.bind(this),
-                handler_data     : [ map_name, true ]
-            });
+            call_ajax(
+                oGeneralProperties.path_server +
+                    "?mod=Overview&act=getObjectStates" +
+                    "&i[]=map-" +
+                    escapeUrlValues(map_name) +
+                    getViewParams({ bbox: worldmap.getBounds().toBBoxString() }),
+                {
+                    response_handler: this.addMap.bind(this),
+                    handler_data: [map_name, true]
+                }
+            );
             return;
         }
 
         this.rendered_maps += 1; // also count errors
 
-        var container = document.getElementById('overviewMaps');
+        var container = document.getElementById("overviewMaps");
 
         // Find the map placeholder div (replace it to keep sorting)
         var mapdiv = null;
@@ -159,57 +167,61 @@ var ViewOverview = View.extend({
         container.replaceChild(obj.dom_obj, mapdiv);
 
         // Finalize rendering after last map...
-        if (this.processed_maps == g_map_names.length)
-            this.finishMaps();
+        if (this.processed_maps == g_map_names.length) this.finishMaps();
     },
 
-    finishMaps: function() {
+    finishMaps: function () {
         // Hide the "Loading..." message. This is not the best place since rotations
         // might not have been loaded now but in most cases this is the longest running request
         hideStatusMessage();
     },
 
     // Does initial parsing of rotations on the overview page
-    addRotations: function(rotations) {
+    addRotations: function (rotations) {
         if (oPageProperties.showrotations === 1 && rotations.length > 0) {
             for (var i = 0, len = rotations.length; i < len; i++) {
                 new NagVisRotation(rotations[i]).parseOverview();
             }
         } else {
             // Hide the rotations container
-            var container = document.getElementById('overviewRotations');
+            var container = document.getElementById("overviewRotations");
             if (container) {
-                container.style.display = 'none';
+                container.style.display = "none";
             }
         }
     },
 
     // Fetches all maps to be shown on the overview page
-    loadMaps: function() {
-        var map_container = document.getElementById('overviewMaps');
+    loadMaps: function () {
+        var map_container = document.getElementById("overviewMaps");
 
         if (oPageProperties.showmaps !== 1 || g_map_names.length == 0) {
-            if (map_container)
-                map_container.parentNode.style.display = 'none';
+            if (map_container) map_container.parentNode.style.display = "none";
             hideStatusMessage();
             return false;
         }
 
         for (var i = 0, len = g_map_names.length; i < len; i++) {
-            var mapdiv = document.createElement('div');
-            mapdiv.setAttribute('id', g_map_names[i])
+            var mapdiv = document.createElement("div");
+            mapdiv.setAttribute("id", g_map_names[i]);
             map_container.appendChild(mapdiv);
-            call_ajax(oGeneralProperties.path_server+'?mod=Overview&act=getObjectStates'
-                      + '&i[]=map-' + escapeUrlValues(g_map_names[i]) + getViewParams(), {
-                response_handler : this.addMap.bind(this),
-                handler_data     : [ g_map_names[i], false ]
-            });
+            call_ajax(
+                oGeneralProperties.path_server +
+                    "?mod=Overview&act=getObjectStates" +
+                    "&i[]=map-" +
+                    escapeUrlValues(g_map_names[i]) +
+                    getViewParams(),
+                {
+                    response_handler: this.addMap.bind(this),
+                    handler_data: [g_map_names[i], false]
+                }
+            );
         }
     },
 
     // Fetches all rotations to be shown on the overview page
-    loadRotations: function() {
-        call_ajax(oGeneralProperties.path_server+'?mod=Overview&act=getOverviewRotations', {
+    loadRotations: function () {
+        call_ajax(oGeneralProperties.path_server + "?mod=Overview&act=getOverviewRotations", {
             response_handler: this.addRotations.bind(this)
         });
     }

--- a/share/frontend/nagvis-js/js/ViewUrl.js
+++ b/share/frontend/nagvis-js/js/ViewUrl.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var ViewUrl = View.extend({
+const ViewUrl = View.extend({
     type: "url",
     constructor: function (id) {
         this.base(id);
@@ -43,7 +43,7 @@ var ViewUrl = View.extend({
 
     // Fetches the contents of the given url and prints it on the current page
     render: function () {
-        var url = oPageProperties.url;
+        const url = oPageProperties.url;
         this.dom_obj = document.getElementById("url");
         if (this.dom_obj.tagName == "DIV") {
             // Fetch contents from server

--- a/share/frontend/nagvis-js/js/ViewUrl.js
+++ b/share/frontend/nagvis-js/js/ViewUrl.js
@@ -22,17 +22,17 @@
  *****************************************************************************/
 
 var ViewUrl = View.extend({
-    type: 'url',
-    constructor: function(id) {
+    type: "url",
+    constructor: function (id) {
         this.base(id);
     },
 
-    init: function() {
+    init: function () {
         this.render();
         hideStatusMessage();
     },
 
-    update: function() {
+    update: function () {
         // Fetches the contents from the server and prints it to the page
         this.render();
     },
@@ -42,19 +42,17 @@ var ViewUrl = View.extend({
      */
 
     // Fetches the contents of the given url and prints it on the current page
-    render: function() {
+    render: function () {
         var url = oPageProperties.url;
-        this.dom_obj = document.getElementById('url');
-        if (this.dom_obj.tagName == 'DIV') {
+        this.dom_obj = document.getElementById("url");
+        if (this.dom_obj.tagName == "DIV") {
             // Fetch contents from server
-            call_ajax(oGeneralProperties.path_server + '?mod=Url&act=getContents&show='
-                      + escapeUrlValues(url), {
-                response_handler: function(response) {
+            call_ajax(oGeneralProperties.path_server + "?mod=Url&act=getContents&show=" + escapeUrlValues(url), {
+                response_handler: function (response) {
                     this.dom_obj.innerHTML = response.content;
-                }.bind(this),
+                }.bind(this)
             });
-        }
-        else {
+        } else {
             // iframe
             this.dom_obj.src = url;
         }

--- a/share/frontend/nagvis-js/js/ViewWorldmap.js
+++ b/share/frontend/nagvis-js/js/ViewWorldmap.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var ViewWorldmap = ViewMap.extend({
+const ViewWorldmap = ViewMap.extend({
     constructor: function (id) {
         this.base(id);
     },
@@ -32,7 +32,7 @@ var ViewWorldmap = ViewMap.extend({
     },
 
     drawObject: function (obj) {
-        var latlng = g_map.containerPointToLatLng(L.point(0, 0));
+        const latlng = g_map.containerPointToLatLng(L.point(0, 0));
         L.nagVisMarker(latlng, {
             icon: L.nagVisObj({ node: obj.dom_obj, obj: obj }),
             // prevent using leaflets event handlers
@@ -55,7 +55,7 @@ var ViewWorldmap = ViewMap.extend({
 
     initWorldmap: function () {
         L.Icon.Default.imagePath = oGeneralProperties.path_base + "/frontend/nagvis-js/images/leaflet";
-        var layers = {
+        const layers = {
             map: L.tileLayer(oGeneralProperties.worldmap_tiles_url, {
                 attribution: oGeneralProperties.worldmap_tiles_attribution,
                 noWrap: true, // don't repeat the world on horizontal axis
@@ -82,7 +82,7 @@ var ViewWorldmap = ViewMap.extend({
             layers: [layers.map]
         });
 
-        let restored_coordinates = window.location.hash.substr(1).split("/");
+        const restored_coordinates = window.location.hash.substr(1).split("/");
         if (restored_coordinates.length === 3) {
             // place the map view according to location hash (#lat/lon/zoom) - consistent page reloads
             g_map.setView([restored_coordinates[1], restored_coordinates[0]], restored_coordinates[2]);
@@ -108,8 +108,8 @@ var ViewWorldmap = ViewMap.extend({
         g_map.on("mousedown", context_handle_global_mousedown);
 
         // dim the colors of map background so that red motorways don't distract
-        let saturate_percentage = getViewParam("worldmap_tiles_saturate");
-        let ltp = document.getElementsByClassName("leaflet-tile-pane");
+        const saturate_percentage = getViewParam("worldmap_tiles_saturate");
+        const ltp = document.getElementsByClassName("leaflet-tile-pane");
         if (ltp && saturate_percentage !== "") ltp[0].style.filter = "saturate(" + saturate_percentage + "%)";
     },
 
@@ -120,14 +120,14 @@ var ViewWorldmap = ViewMap.extend({
     // Is used to update the objects to show on the worldmap
     handleMoveEnd: function (lEvent) {
         // Update the related view properties
-        var ll = g_map.getCenter();
+        const ll = g_map.getCenter();
         setViewParam("worldmap_center", ll.lat + "," + ll.lng);
         setViewParam("worldmap_zoom", g_map.getZoom());
 
         this.render(); // re-render the whole map
 
         // Put the new map view coords into URL (location) - consistent reloads
-        var new_center = g_map.getCenter();
+        const new_center = g_map.getCenter();
         window.location.hash = new_center.lng + "/" + new_center.lat + "/" + g_map.getZoom();
     },
 
@@ -156,10 +156,10 @@ var ViewWorldmap = ViewMap.extend({
     },
 
     project: function (lat, lng) {
-        var new_coord,
-            x = [],
+        let new_coord;
+        const x = [],
             y = [];
-        for (var i = 0; i < lat.length; i++) {
+        for (let i = 0; i < lat.length; i++) {
             if (isRelativeCoord(lat[i]) || isRelativeCoord(lng[i])) {
                 // do not convert relative positioned objects
                 x.push(lat[i]);
@@ -181,10 +181,10 @@ var ViewWorldmap = ViewMap.extend({
             y = [y];
         }
 
-        var latlng,
-            lat = [],
+        let latlng;
+        const lat = [],
             lng = [];
-        for (var i = 0, l = x.length; i < l; i++) {
+        for (let i = 0, l = x.length; i < l; i++) {
             if (isRelativeCoord(x[i]) || isRelativeCoord(y[i])) {
                 // do not convert relative positioned objects
                 lat[i] = x[i];
@@ -213,11 +213,11 @@ L.NagVisObj = L.Icon.extend({
     },
 
     createIcon: function (oldIcon) {
-        var div = oldIcon && oldIcon.tagName === "DIV" ? oldIcon : document.createElement("div"),
+        const div = oldIcon && oldIcon.tagName === "DIV" ? oldIcon : document.createElement("div"),
             options = this.options;
 
         // remove all existing childs
-        for (var i = div.childNodes.length; i > 0; i--) div.removeChild(div.childNodes[0]);
+        for (let i = div.childNodes.length; i > 0; i--) div.removeChild(div.childNodes[0]);
 
         if (options.node !== null) {
             div.appendChild(options.node);
@@ -231,7 +231,7 @@ L.NagVisObj = L.Icon.extend({
     _applyOffset: function () {
         // Fix icon position which is not automatically fixed by this._setIconStyles because we
         // enforce iconAnchor: [0, 0].
-        var offset = L.point(this.options.iconSize);
+        const offset = L.point(this.options.iconSize);
         offset._divideBy(2);
         this.options.obj.trigger_obj.style.marginLeft = -offset.x + "px";
         this.options.obj.trigger_obj.style.marginTop = -offset.y + "px";
@@ -250,7 +250,7 @@ L.NagVisMarker = L.Marker.extend({
     initialize: function (latlng, options) {
         L.Marker.prototype.initialize.call(this, latlng, options);
 
-        var obj = options.icon.options.obj;
+        const obj = options.icon.options.obj;
 
         // add reference to the marker object to the nagvis object
         obj.marker = this;
@@ -269,7 +269,7 @@ L.NagVisMarker = L.Marker.extend({
 
     // Update the size off the icon to make the object being centered
     _onAdd: function (lEvent) {
-        var icon = this.options.icon,
+        const icon = this.options.icon,
             trigger_obj = icon.options.obj.trigger_obj,
             w = pxToInt(trigger_obj.style.width),
             h = pxToInt(trigger_obj.style.height);

--- a/share/frontend/nagvis-js/js/ViewWorldmap.js
+++ b/share/frontend/nagvis-js/js/ViewWorldmap.js
@@ -22,74 +22,76 @@
  *****************************************************************************/
 
 var ViewWorldmap = ViewMap.extend({
-    constructor: function(id) {
+    constructor: function (id) {
         this.base(id);
     },
 
-    init: function() {
+    init: function () {
         this.initWorldmap();
         this.base();
     },
 
-    drawObject: function(obj) {
+    drawObject: function (obj) {
         var latlng = g_map.containerPointToLatLng(L.point(0, 0));
         L.nagVisMarker(latlng, {
-            icon: L.nagVisObj({node: obj.dom_obj, obj: obj}),
+            icon: L.nagVisObj({ node: obj.dom_obj, obj: obj }),
             // prevent using leaflets event handlers
             clickable: false,
             // Can not use this for lines, because line canvas objects would
             // overlay normal icon objects and make theeir actions unusable
             // Lines adapt this behaviour on their own.
-            riseOnHover: obj.conf.view_type !== 'line',
+            riseOnHover: obj.conf.view_type !== "line",
             // Put lines one layer behind all other objects to fix canvas hiding
             // the other objects
-            zIndexOffset: obj.conf.view_type === 'line' ? -1 : 0
+            zIndexOffset: obj.conf.view_type === "line" ? -1 : 0
         }).addTo(g_map_objects);
     },
 
-    eraseObject: function(obj) {},
+    eraseObject: function (obj) {},
 
     /**
      * END OF PUBLIC METHODS
      */
 
-    initWorldmap: function() {
-        L.Icon.Default.imagePath = oGeneralProperties.path_base+'/frontend/nagvis-js/images/leaflet';
+    initWorldmap: function () {
+        L.Icon.Default.imagePath = oGeneralProperties.path_base + "/frontend/nagvis-js/images/leaflet";
         var layers = {
-            "map": L.tileLayer(oGeneralProperties.worldmap_tiles_url, {
+            map: L.tileLayer(oGeneralProperties.worldmap_tiles_url, {
                 attribution: oGeneralProperties.worldmap_tiles_attribution,
                 noWrap: true, // don't repeat the world on horizontal axis
                 detectRetina: false, // this causes trouble with maximum zoom level (19 vs. 20), don't use
-                maxZoom: 20,
-            }),
-        }
-        if(oGeneralProperties.worldmap_satellite_tiles_url) {
+                maxZoom: 20
+            })
+        };
+        if (oGeneralProperties.worldmap_satellite_tiles_url) {
             layers.satellite = L.tileLayer(oGeneralProperties.worldmap_satellite_tiles_url, {
                 attribution: oGeneralProperties.worldmap_satellite_tiles_attribution,
                 noWrap: true, // don't repeat the world on horizontal axis
                 detectRetina: false,
-                maxZoom: 20,
-            })
+                maxZoom: 20
+            });
         }
 
-        g_map = L.map('map', {
+        g_map = L.map("map", {
             markerZoomAnimation: false,
-            maxBounds: [ [-85,-180.0], [85,180.0] ],
+            maxBounds: [
+                [-85, -180.0],
+                [85, 180.0]
+            ],
             minZoom: 2,
             layers: [layers.map]
-        })
+        });
 
-        let restored_coordinates = window.location.hash.substr(1).split('/');
+        let restored_coordinates = window.location.hash.substr(1).split("/");
         if (restored_coordinates.length === 3) {
             // place the map view according to location hash (#lat/lon/zoom) - consistent page reloads
             g_map.setView([restored_coordinates[1], restored_coordinates[0]], restored_coordinates[2]);
         } else {
             // or default (map-defined) view
-            g_map.setView(getViewParam('worldmap_center').split(','), parseInt(getViewParam('worldmap_zoom')));
+            g_map.setView(getViewParam("worldmap_center").split(","), parseInt(getViewParam("worldmap_zoom")));
         }
 
-        if (layers.satellite)
-            L.control.layers(layers).addTo(g_map);
+        if (layers.satellite) L.control.layers(layers).addTo(g_map);
 
         g_map_objects = L.layerGroup().addTo(g_map);
 
@@ -98,31 +100,29 @@ var ViewWorldmap = ViewMap.extend({
         // an ajax call with the current viewport to the core code, which
         // then returns a list of objects to add to the map depending on
         // this viewport.
-        g_map.on('zoomstart', this.handleMoveStart.bind(this));
-        g_map.on('moveend', this.handleMoveEnd.bind(this));
+        g_map.on("zoomstart", this.handleMoveStart.bind(this));
+        g_map.on("moveend", this.handleMoveEnd.bind(this));
 
         // hide eventual open header dropdown menus when clicking on the map
-        if (typeof checkHideMenu !== "undefined")
-            g_map.on('mousedown', checkHideMenu);
-        g_map.on('mousedown', context_handle_global_mousedown);
+        if (typeof checkHideMenu !== "undefined") g_map.on("mousedown", checkHideMenu);
+        g_map.on("mousedown", context_handle_global_mousedown);
 
         // dim the colors of map background so that red motorways don't distract
-        let saturate_percentage = getViewParam('worldmap_tiles_saturate');
-        let ltp = document.getElementsByClassName('leaflet-tile-pane');
-        if (ltp && saturate_percentage !== '')
-            ltp[0].style.filter = "saturate("+saturate_percentage+"%)";
+        let saturate_percentage = getViewParam("worldmap_tiles_saturate");
+        let ltp = document.getElementsByClassName("leaflet-tile-pane");
+        if (ltp && saturate_percentage !== "") ltp[0].style.filter = "saturate(" + saturate_percentage + "%)";
     },
 
-    handleMoveStart: function(lEvent) {
+    handleMoveStart: function (lEvent) {
         this.erase();
     },
 
     // Is used to update the objects to show on the worldmap
-    handleMoveEnd: function(lEvent) {
+    handleMoveEnd: function (lEvent) {
         // Update the related view properties
         var ll = g_map.getCenter();
-        setViewParam('worldmap_center', ll.lat+','+ll.lng);
-        setViewParam('worldmap_zoom', g_map.getZoom());
+        setViewParam("worldmap_center", ll.lat + "," + ll.lng);
+        setViewParam("worldmap_zoom", g_map.getZoom());
 
         this.render(); // re-render the whole map
 
@@ -131,27 +131,34 @@ var ViewWorldmap = ViewMap.extend({
         window.location.hash = new_center.lng + "/" + new_center.lat + "/" + g_map.getZoom();
     },
 
-    saveView: function() {
-        call_ajax(oGeneralProperties.path_server+'?mod=Map&act=modifyObject&map='
-                  + this.id + '&type=global&id=0'
-                  + '&worldmap_center='+getViewParam('worldmap_center')
-                  + '&worldmap_zoom='+getViewParam('worldmap_zoom'));
+    saveView: function () {
+        call_ajax(
+            oGeneralProperties.path_server +
+                "?mod=Map&act=modifyObject&map=" +
+                this.id +
+                "&type=global&id=0" +
+                "&worldmap_center=" +
+                getViewParam("worldmap_center") +
+                "&worldmap_zoom=" +
+                getViewParam("worldmap_zoom")
+        );
     },
 
     // Scale the map to a viewport showing all objects at once
-    scaleToAll: function() {
-        call_ajax(oGeneralProperties.path_server+'?mod=Map&act=getWorldmapBounds'
-                  + '&show=' + this.id, {
-            response_handler: this.handleScaleToAll.bind(this),
+    scaleToAll: function () {
+        call_ajax(oGeneralProperties.path_server + "?mod=Map&act=getWorldmapBounds" + "&show=" + this.id, {
+            response_handler: this.handleScaleToAll.bind(this)
         });
     },
 
-    handleScaleToAll: function(data) {
+    handleScaleToAll: function (data) {
         g_map.fitBounds(data);
     },
 
-    project: function(lat, lng) {
-        var new_coord, x = [], y = [];
+    project: function (lat, lng) {
+        var new_coord,
+            x = [],
+            y = [];
         for (var i = 0; i < lat.length; i++) {
             if (isRelativeCoord(lat[i]) || isRelativeCoord(lng[i])) {
                 // do not convert relative positioned objects
@@ -168,13 +175,15 @@ var ViewWorldmap = ViewMap.extend({
 
     // converts an a single or an array of XY coordinates to latlng coordinates
     // based on the current visible viewport
-    unproject: function(x, y) {
-        if (typeof x !== 'object') {
+    unproject: function (x, y) {
+        if (typeof x !== "object") {
             x = [x];
             y = [y];
         }
 
-        var latlng, lat = [], lng = [];
+        var latlng,
+            lat = [],
+            lng = [];
         for (var i = 0, l = x.length; i < l; i++) {
             if (isRelativeCoord(x[i]) || isRelativeCoord(y[i])) {
                 // do not convert relative positioned objects
@@ -198,35 +207,34 @@ L.NagVisObj = L.Icon.extend({
         // Is set later by onAdd function to respect the real icon size
         iconSize: [0, 0],
         iconAnchor: [0, 0],
-        className: 'leaflet-nagvis-obj',
+        className: "leaflet-nagvis-obj",
         node: null,
-        obj: null,
+        obj: null
     },
 
     createIcon: function (oldIcon) {
-        var div = (oldIcon && oldIcon.tagName === 'DIV') ? oldIcon : document.createElement('div'),
+        var div = oldIcon && oldIcon.tagName === "DIV" ? oldIcon : document.createElement("div"),
             options = this.options;
 
         // remove all existing childs
-        for(var i = div.childNodes.length; i > 0; i--)
-            div.removeChild(div.childNodes[0]);
+        for (var i = div.childNodes.length; i > 0; i--) div.removeChild(div.childNodes[0]);
 
         if (options.node !== null) {
             div.appendChild(options.node);
         }
 
-        this._setIconStyles(div, 'icon');
+        this._setIconStyles(div, "icon");
         this._applyOffset();
         return div;
     },
 
-    _applyOffset: function() {
+    _applyOffset: function () {
         // Fix icon position which is not automatically fixed by this._setIconStyles because we
         // enforce iconAnchor: [0, 0].
         var offset = L.point(this.options.iconSize);
         offset._divideBy(2);
-        this.options.obj.trigger_obj.style.marginLeft = (-offset.x) + 'px';
-        this.options.obj.trigger_obj.style.marginTop  = (-offset.y) + 'px';
+        this.options.obj.trigger_obj.style.marginLeft = -offset.x + "px";
+        this.options.obj.trigger_obj.style.marginTop = -offset.y + "px";
     },
 
     createShadow: function () {
@@ -249,19 +257,18 @@ L.NagVisMarker = L.Marker.extend({
 
         // prevent dragging the viewport when click+hold+drag on an object
         // this does not work correctly for lines, so disable it for them
-        if (obj.conf.view_type !== 'line') {
-            addEvent(obj.dom_obj, 'mousedown', function(event) {
+        if (obj.conf.view_type !== "line") {
+            addEvent(obj.dom_obj, "mousedown", function (event) {
                 event = event || window.event;
-                if (getButton(event) == 'LEFT')
-                    return preventDefaultEvents(event);
+                if (getButton(event) == "LEFT") return preventDefaultEvents(event);
             });
         }
 
-        this.on('add', this._onAdd, this);
+        this.on("add", this._onAdd, this);
     },
 
     // Update the size off the icon to make the object being centered
-    _onAdd: function(lEvent) {
+    _onAdd: function (lEvent) {
         var icon = this.options.icon,
             trigger_obj = icon.options.obj.trigger_obj,
             w = pxToInt(trigger_obj.style.width),
@@ -269,7 +276,7 @@ L.NagVisMarker = L.Marker.extend({
 
         icon.options.iconSize = [w, h];
         icon._applyOffset();
-    },
+    }
 });
 
 L.nagVisMarker = function (ll, options) {

--- a/share/frontend/nagvis-js/js/ajax.js
+++ b/share/frontend/nagvis-js/js/ajax.js
@@ -57,7 +57,7 @@ function call_ajax(url, args) {
         args
     );
 
-    var AJAX = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject("Microsoft.XMLHTTP");
+    const AJAX = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject("Microsoft.XMLHTTP");
     if (!AJAX) return null;
 
     if (args.add_ajax_id) {
@@ -84,7 +84,7 @@ function call_ajax(url, args) {
                     // args.error_handler.
                     frontendMessageRemove("serverError");
 
-                    var response = AJAX.responseText;
+                    let response = AJAX.responseText;
                     if (args.decode_json) {
                         try {
                             response = JSON.parse(response);
@@ -148,33 +148,34 @@ function call_ajax(url, args) {
  * which is then be used as request data in ajax queries
  */
 function getFormParams(formId, skipHelperFields) {
+    let data, formdata;
     if (window.FormData) {
-        var data = new FormData();
-        var formdata = true;
+        data = new FormData();
+        formdata = true;
     } else {
         formdata = false;
         data = "";
     }
 
-    var add_data = function (key, val) {
+    const add_data = function (key, val) {
         if (formdata) data.append(key, val);
         else data += key + "=" + escapeUrlValues(val) + "&";
     };
 
     // Read form contents
-    var oForm = document.getElementById(formId);
+    let oForm = document.getElementById(formId);
     if (typeof oForm === "undefined") return data;
 
     // Get relevant input elements
-    var aFields = oForm.querySelectorAll("input,textarea");
+    let aFields = oForm.querySelectorAll("input,textarea");
 
-    for (var i = 0, len = aFields.length; i < len; i++) {
+    for (let i = 0, len = aFields.length; i < len; i++) {
         // Filter helper fields (if told to do so)
         if (skipHelperFields && aFields[i].name.charAt(0) === "_") continue;
 
         // Skip options which use the default value and where the value has
         // not been set before
-        var oFieldDefault = document.getElementById("_" + aFields[i].name);
+        let oFieldDefault = document.getElementById("_" + aFields[i].name);
         if (aFields[i] && oFieldDefault && !document.getElementById("_conf_" + aFields[i].name)) {
             if (aFields[i].value === oFieldDefault.value) {
                 continue;
@@ -212,7 +213,7 @@ function getFormParams(formId, skipHelperFields) {
             }
 
             if (aFields[i].files.length > 0) {
-                var file = aFields[i].files[0];
+                const file = aFields[i].files[0];
                 data.append(aFields[i].name, file, file.name);
             }
         }
@@ -220,7 +221,7 @@ function getFormParams(formId, skipHelperFields) {
 
     // Get relevant select elements
     aFields = oForm.getElementsByTagName("select");
-    for (i = 0, len = aFields.length; i < len; i++) {
+    for (let i = 0, len = aFields.length; i < len; i++) {
         // Filter helper fields (NagVis WUI specific)
         if (skipHelperFields && aFields[i].name.charAt(0) === "_") continue;
 
@@ -240,7 +241,7 @@ function getFormParams(formId, skipHelperFields) {
                 add_data(aFields[i].name, aFields[i].options[aFields[i].selectedIndex].value);
             }
         } else {
-            for (var a = 0; a < aFields[i].options.length; a++) {
+            for (let a = 0; a < aFields[i].options.length; a++) {
                 // Only add selected options
                 if (aFields[i].options[a].selected == true) {
                     add_data(aFields[i].name + "[]", aFields[i].options[a].value);

--- a/share/frontend/nagvis-js/js/ajax.js
+++ b/share/frontend/nagvis-js/js/ajax.js
@@ -61,7 +61,7 @@ function call_ajax(url, args) {
     if (!AJAX) return null;
 
     if (args.add_ajax_id) {
-        url += url.indexOf("\?") !== -1 ? "&" : "?";
+        url += url.indexOf("?") !== -1 ? "&" : "?";
         url += "_ajaxid=" + iNow;
     }
 

--- a/share/frontend/nagvis-js/js/ajax.js
+++ b/share/frontend/nagvis-js/js/ajax.js
@@ -152,8 +152,8 @@ function getFormParams(formId, skipHelperFields) {
         var data = new FormData();
         var formdata = true;
     } else {
-        var formdata = false;
-        var data = "";
+        formdata = false;
+        data = "";
     }
 
     var add_data = function (key, val) {
@@ -220,12 +220,12 @@ function getFormParams(formId, skipHelperFields) {
 
     // Get relevant select elements
     aFields = oForm.getElementsByTagName("select");
-    for (var i = 0, len = aFields.length; i < len; i++) {
+    for (i = 0, len = aFields.length; i < len; i++) {
         // Filter helper fields (NagVis WUI specific)
         if (skipHelperFields && aFields[i].name.charAt(0) === "_") continue;
 
         // Skip options which use the default value
-        var oFieldDefault = document.getElementById("_" + aFields[i].name);
+        oFieldDefault = document.getElementById("_" + aFields[i].name);
         if (aFields[i] && oFieldDefault) {
             if (aFields[i].value === oFieldDefault.value) {
                 continue;

--- a/share/frontend/nagvis-js/js/ajax.js
+++ b/share/frontend/nagvis-js/js/ajax.js
@@ -21,41 +21,48 @@
  *
  *****************************************************************************/
 
-function call_ajax(url, args)
-{
-    args = merge_args({
-        add_ajax_id      : true,
-        response_handler : null,
-        error_handler    : function(status_code, response, handler_data) {
-            if (response === null) {
-                response = {
-                    'type'    : 'error',
-                    'title'   : 'Network error',
-                    'message' : "Failed to execute ajax call. Maybe a network issue or webserver is not available."
-                          + "<div class=details>\n"
-                          + "HTTP-Status-Code: " + status_code + "<br />\n"
-                          + "Time: " + iNow + "<br />\n"
-                          + "URL: <code>" + url.replace(/</g, '&lt;') + "</code><br />\n"
-                          + "</div>"
-                };
-            }
-            frontendMessage(response, 'serverError');
+function call_ajax(url, args) {
+    args = merge_args(
+        {
+            add_ajax_id: true,
+            response_handler: null,
+            error_handler: function (status_code, response, handler_data) {
+                if (response === null) {
+                    response = {
+                        type: "error",
+                        title: "Network error",
+                        message:
+                            "Failed to execute ajax call. Maybe a network issue or webserver is not available." +
+                            "<div class=details>\n" +
+                            "HTTP-Status-Code: " +
+                            status_code +
+                            "<br />\n" +
+                            "Time: " +
+                            iNow +
+                            "<br />\n" +
+                            "URL: <code>" +
+                            url.replace(/</g, "&lt;") +
+                            "</code><br />\n" +
+                            "</div>"
+                    };
+                }
+                frontendMessage(response, "serverError");
+            },
+            handler_data: null,
+            method: "GET",
+            post_data: null,
+            sync: false,
+            decode_json: true
         },
-        handler_data     : null,
-        method           : "GET",
-        post_data        : null,
-        sync             : false,
-        decode_json      : true,
-    }, args);
+        args
+    );
 
-    var AJAX = window.XMLHttpRequest ? new XMLHttpRequest()
-                                     : new ActiveXObject("Microsoft.XMLHTTP");
-    if (!AJAX)
-        return null;
+    var AJAX = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject("Microsoft.XMLHTTP");
+    if (!AJAX) return null;
 
     if (args.add_ajax_id) {
-        url += url.indexOf('\?') !== -1 ? "&" : "?";
-        url += "_ajaxid="+iNow;
+        url += url.indexOf("\?") !== -1 ? "&" : "?";
+        url += "_ajaxid=" + iNow;
     }
 
     AJAX.open(args.method, url, !args.sync);
@@ -64,32 +71,43 @@ function call_ajax(url, args)
         // Set post specific options. request might be a FormData object. In this case
         // the request is not using form-urlencoded data, instead it is automatically
         // set to multipart/form-data
-        if (typeof args.post_data !== 'object')
-            AJAX.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+        if (typeof args.post_data !== "object")
+            AJAX.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
     }
 
     if (!args.sync) {
-        AJAX.onreadystatechange = function() {
+        AJAX.onreadystatechange = function () {
             if (AJAX && AJAX.readyState == 4) {
                 if (AJAX.status == 200) {
                     // in case this is no error remove all frontend messages of type
                     // serverError which might have been shown by the default
                     // args.error_handler.
-                    frontendMessageRemove('serverError');
+                    frontendMessageRemove("serverError");
 
                     var response = AJAX.responseText;
                     if (args.decode_json) {
                         try {
                             response = JSON.parse(response);
-                        } catch(e) {
-                            args.error_handler(AJAX.status, {
-                                'type'    : 'error',
-                                'title'   : 'Error: Syntax Error',
-                                'message' : "Invalid JSON response<div class=details>\nTime: "
-                                      + iNow + "<br />\nURL: " + url.replace(/</g, '&lt;') + "<br />\n"
-                                      + "Response: <code>" + response + '</code></div>'
-                            }, 0, 'jsonError');
-                            return '';
+                        } catch (e) {
+                            args.error_handler(
+                                AJAX.status,
+                                {
+                                    type: "error",
+                                    title: "Error: Syntax Error",
+                                    message:
+                                        "Invalid JSON response<div class=details>\nTime: " +
+                                        iNow +
+                                        "<br />\nURL: " +
+                                        url.replace(/</g, "&lt;") +
+                                        "<br />\n" +
+                                        "Response: <code>" +
+                                        response +
+                                        "</code></div>"
+                                },
+                                0,
+                                "jsonError"
+                            );
+                            return "";
                         }
 
                         // The server might return a json object which is representing
@@ -100,29 +118,25 @@ function call_ajax(url, args)
                         // this kind of error data on their own.
                         if (isset(response.type) && isset(response.message)) {
                             args.error_handler(AJAX.status, response, args.handler_data);
-                            return '';
+                            return "";
                         }
                     }
 
-                    if (args.response_handler)
-                        args.response_handler(response, args.handler_data);
-                }
-                else if (AJAX.status == 401) {
+                    if (args.response_handler) args.response_handler(response, args.handler_data);
+                } else if (AJAX.status == 401) {
                     // This is reached when someone is not authenticated anymore
                     // but has some webservices running which are still fetching
                     // infos via AJAX. Reload the whole frameset or only the
                     // single page in that case.
                     document.location.reload();
-                }
-                else if (AJAX.status == 0) {
+                } else if (AJAX.status == 0) {
                     // this happens when a user aborts currently running ajax
                     // requests by reloading the page. simply ignore
-                }
-                else {
+                } else {
                     args.error_handler(AJAX.status, null, args.handler_data);
                 }
             }
-        }
+        };
     }
 
     AJAX.send(args.post_data);
@@ -139,66 +153,62 @@ function getFormParams(formId, skipHelperFields) {
         var formdata = true;
     } else {
         var formdata = false;
-        var data = '';
+        var data = "";
     }
 
-    var add_data = function(key, val) {
-        if (formdata)
-            data.append(key, val);
-        else
-            data += key + "=" + escapeUrlValues(val) + "&";
+    var add_data = function (key, val) {
+        if (formdata) data.append(key, val);
+        else data += key + "=" + escapeUrlValues(val) + "&";
     };
 
     // Read form contents
     var oForm = document.getElementById(formId);
-    if (typeof oForm === 'undefined')
-        return data;
+    if (typeof oForm === "undefined") return data;
 
     // Get relevant input elements
-    var aFields = oForm.querySelectorAll('input,textarea');
+    var aFields = oForm.querySelectorAll("input,textarea");
 
     for (var i = 0, len = aFields.length; i < len; i++) {
         // Filter helper fields (if told to do so)
-        if (skipHelperFields && aFields[i].name.charAt(0) === '_')
-            continue;
+        if (skipHelperFields && aFields[i].name.charAt(0) === "_") continue;
 
         // Skip options which use the default value and where the value has
         // not been set before
-        var oFieldDefault    = document.getElementById('_'+aFields[i].name);
-        if (aFields[i] && oFieldDefault && !document.getElementById('_conf_'+aFields[i].name)) {
+        var oFieldDefault = document.getElementById("_" + aFields[i].name);
+        if (aFields[i] && oFieldDefault && !document.getElementById("_conf_" + aFields[i].name)) {
             if (aFields[i].value === oFieldDefault.value) {
                 continue;
             }
         }
         oFieldDefault = null;
 
-        if (aFields[i].type == "hidden"
-            || aFields[i].type == "text"
-            || aFields[i].type == "textarea"
-            || aFields[i].type == "password"
-            || aFields[i].type == "submit") {
+        if (
+            aFields[i].type == "hidden" ||
+            aFields[i].type == "text" ||
+            aFields[i].type == "textarea" ||
+            aFields[i].type == "password" ||
+            aFields[i].type == "submit"
+        ) {
             add_data(aFields[i].name, aFields[i].value);
-        }
-        else if (aFields[i].type == "checkbox") {
+        } else if (aFields[i].type == "checkbox") {
+            if (aFields[i].checked) {
+                add_data(aFields[i].name, aFields[i].value);
+            } else {
+                add_data(aFields[i].name, "");
+            }
+        } else if (aFields[i].type == "radio") {
             if (aFields[i].checked) {
                 add_data(aFields[i].name, aFields[i].value);
             }
-            else {
-                add_data(aFields[i].name, '');
-            }
-        }
-        else if (aFields[i].type == "radio") {
-            if (aFields[i].checked) {
-                add_data(aFields[i].name, aFields[i].value);
-            }
-        }
-        else if (aFields[i].type == "file") {
+        } else if (aFields[i].type == "file") {
             // Now handle the file upload elements (which lead to an error when not
             // using the form data mechanism)
             if (!formdata) {
-                throw new Error('File upload not supported with your browser. '
-                               +'This form can only be used when using a browser '
-                               +'which suports javascript file uploads (FormData).');
+                throw new Error(
+                    "File upload not supported with your browser. " +
+                        "This form can only be used when using a browser " +
+                        "which suports javascript file uploads (FormData)."
+                );
             }
 
             if (aFields[i].files.length > 0) {
@@ -206,27 +216,25 @@ function getFormParams(formId, skipHelperFields) {
                 data.append(aFields[i].name, file, file.name);
             }
         }
-
     }
 
     // Get relevant select elements
-    aFields = oForm.getElementsByTagName('select');
-    for(var i = 0, len = aFields.length; i < len; i++) {
+    aFields = oForm.getElementsByTagName("select");
+    for (var i = 0, len = aFields.length; i < len; i++) {
         // Filter helper fields (NagVis WUI specific)
-        if (skipHelperFields && aFields[i].name.charAt(0) === '_')
-            continue;
+        if (skipHelperFields && aFields[i].name.charAt(0) === "_") continue;
 
         // Skip options which use the default value
-        var oFieldDefault = document.getElementById('_'+aFields[i].name);
-        if(aFields[i] && oFieldDefault) {
-            if(aFields[i].value === oFieldDefault.value) {
+        var oFieldDefault = document.getElementById("_" + aFields[i].name);
+        if (aFields[i] && oFieldDefault) {
+            if (aFields[i].value === oFieldDefault.value) {
                 continue;
             }
         }
         oFieldDefault = null;
 
         // Can't use the selectedIndex when using select fields with multiple
-        if(!aFields[i].multiple || aFields[i].multiple !== true) {
+        if (!aFields[i].multiple || aFields[i].multiple !== true) {
             // Skip fields where nothing is selected
             if (aFields[i].selectedIndex != -1) {
                 add_data(aFields[i].name, aFields[i].options[aFields[i].selectedIndex].value);
@@ -235,7 +243,7 @@ function getFormParams(formId, skipHelperFields) {
             for (var a = 0; a < aFields[i].options.length; a++) {
                 // Only add selected options
                 if (aFields[i].options[a].selected == true) {
-                    add_data(aFields[i].name+'[]', aFields[i].options[a].value);
+                    add_data(aFields[i].name + "[]", aFields[i].options[a].value);
                 }
             }
         }

--- a/share/frontend/nagvis-js/js/ajaxActions.js
+++ b/share/frontend/nagvis-js/js/ajaxActions.js
@@ -3,8 +3,8 @@ function getMidOfAnchor(oObj) {
 }
 
 function saveObjectAttr(objId, attr) {
-    var urlPart = "";
-    for (var key in attr)
+    let urlPart = "";
+    for (const key in attr)
         // parseInt() returned NaN, because value was set to "auto";
         // but also allow relative coordinate strings (contain '%')
         if (!isNaN(attr[key]) || isRelativeCoord(attr[key])) urlPart += "&" + key + "=" + escapeUrlValues(attr[key]);

--- a/share/frontend/nagvis-js/js/ajaxActions.js
+++ b/share/frontend/nagvis-js/js/ajaxActions.js
@@ -1,22 +1,30 @@
 function getMidOfAnchor(oObj) {
-    return [ oObj.x + parseInt(oObj.style.width)  / 2,
-             oObj.y + parseInt(oObj.style.height) / 2 ];
+    return [oObj.x + parseInt(oObj.style.width) / 2, oObj.y + parseInt(oObj.style.height) / 2];
 }
 
 function saveObjectAttr(objId, attr) {
-    var urlPart = '';
+    var urlPart = "";
     for (var key in attr)
         // parseInt() returned NaN, because value was set to "auto";
         // but also allow relative coordinate strings (contain '%')
-        if ( ! isNaN(attr[key]) || isRelativeCoord(attr[key]) )
-            urlPart += '&' + key + '=' + escapeUrlValues(attr[key]);
+        if (!isNaN(attr[key]) || isRelativeCoord(attr[key])) urlPart += "&" + key + "=" + escapeUrlValues(attr[key]);
 
-    call_ajax(oGeneralProperties.path_server + '?mod=Map&act=modifyObject&map='
-              + escapeUrlValues(oPageProperties.map_name) + '&id=' + escapeUrlValues(objId) + urlPart);
+    call_ajax(
+        oGeneralProperties.path_server +
+            "?mod=Map&act=modifyObject&map=" +
+            escapeUrlValues(oPageProperties.map_name) +
+            "&id=" +
+            escapeUrlValues(objId) +
+            urlPart
+    );
 }
 
 function saveObjectRemove(objId) {
-    call_ajax(oGeneralProperties.path_server + '?mod=Map&act=deleteObject&map='
-              + escapeUrlValues(oPageProperties.map_name) + '&id=' + escapeUrlValues(objId));
-
+    call_ajax(
+        oGeneralProperties.path_server +
+            "?mod=Map&act=deleteObject&map=" +
+            escapeUrlValues(oPageProperties.map_name) +
+            "&id=" +
+            escapeUrlValues(objId)
+    );
 }

--- a/share/frontend/nagvis-js/js/dynfavicon.js
+++ b/share/frontend/nagvis-js/js/dynfavicon.js
@@ -8,7 +8,7 @@
  * Copyright (c) 2004-2016 NagVis Project (Contact: info@nagvis.org)
  *****************************************************************************/
 
-var favicon = {
+const favicon = {
     // -- "PUBLIC" ----------------------------------------------------------------
 
     change: function (iconURL) {
@@ -18,9 +18,9 @@ var favicon = {
     // -- "PRIVATE" ---------------------------------------------------------------
 
     addLink: function (iconURL) {
-        var docHead = document.getElementsByTagName("head")[0];
+        let docHead = document.getElementsByTagName("head")[0];
 
-        var link = document.createElement("link");
+        let link = document.createElement("link");
         link.type = "image/x-icon";
         link.rel = "shortcut icon";
         link.href = iconURL;
@@ -34,12 +34,12 @@ var favicon = {
     },
 
     removeLinkIfExists: function () {
-        var docHead = document.getElementsByTagName("head")[0];
-        var links = docHead.getElementsByTagName("link");
+        let docHead = document.getElementsByTagName("head")[0];
+        let links = docHead.getElementsByTagName("link");
 
         if (!docHead || !links) return false;
 
-        for (var i = 0, len = links.length; i < len; i++) {
+        for (let i = 0, len = links.length; i < len; i++) {
             if (links[i] && links[i].type == "image/x-icon" && links[i].rel == "shortcut icon") {
                 docHead.removeChild(links[i]);
             }

--- a/share/frontend/nagvis-js/js/dynfavicon.js
+++ b/share/frontend/nagvis-js/js/dynfavicon.js
@@ -8,17 +8,16 @@
  * Copyright (c) 2004-2016 NagVis Project (Contact: info@nagvis.org)
  *****************************************************************************/
 
-
 var favicon = {
     // -- "PUBLIC" ----------------------------------------------------------------
 
-    change: function(iconURL) {
+    change: function (iconURL) {
         this.addLink(iconURL, true);
     },
 
     // -- "PRIVATE" ---------------------------------------------------------------
 
-    addLink: function(iconURL) {
+    addLink: function (iconURL) {
         var docHead = document.getElementsByTagName("head")[0];
 
         var link = document.createElement("link");
@@ -34,14 +33,13 @@ var favicon = {
         docHead = null;
     },
 
-    removeLinkIfExists: function() {
+    removeLinkIfExists: function () {
         var docHead = document.getElementsByTagName("head")[0];
         var links = docHead.getElementsByTagName("link");
 
-        if(!docHead || !links)
-            return false;
+        if (!docHead || !links) return false;
 
-        for (var i=0, len = links.length; i<len; i++) {
+        for (var i = 0, len = links.length; i < len; i++) {
             if (links[i] && links[i].type == "image/x-icon" && links[i].rel == "shortcut icon") {
                 docHead.removeChild(links[i]);
             }

--- a/share/frontend/nagvis-js/js/edit.js
+++ b/share/frontend/nagvis-js/js/edit.js
@@ -26,7 +26,7 @@ function getTargetRaw(event) {
 }
 
 function getTargetByClass(event, className) {
-    var target = getTargetRaw(event);
+    let target = getTargetRaw(event);
     while (target && !has_class(target, className)) target = target.parentNode;
     return target;
 }
@@ -38,26 +38,26 @@ function toggleMapObjectLock(event, object_id) {
 
 // Toggles the mode of all map objects: editable or not
 function toggleAllMapObjectsLock(event) {
-    var lock = g_view.hasUnlocked();
+    const lock = g_view.hasUnlocked();
 
-    for (var object_id in g_view.objects) g_view.toggleObjectLock(object_id, lock);
+    for (const object_id in g_view.objects) g_view.toggleObjectLock(object_id, lock);
 
     if (!lock) storeUserOption("unlocked-" + oPageProperties.map_name, "*");
     else storeUserOption("unlocked-" + oPageProperties.map_name, "");
     return preventDefaultEvents(event);
 }
 
-var draggingEnabled = true;
-var draggingObject = null;
-var dragObjectOffset = null;
-var dragObjectPos = null;
-var dragObjectStartPos = null;
-var dragObjectChilds = {};
-var dragStopHandlers = {};
-var dragMoveHandlers = {};
-var dragObjects = {};
+let draggingEnabled = true;
+let draggingObject = null;
+let dragObjectOffset = null;
+const dragObjectPos = null;
+let dragObjectStartPos = null;
+const dragObjectChilds = {};
+const dragStopHandlers = {};
+const dragMoveHandlers = {};
+const dragObjects = {};
 
-var g_resize_obj = null; //This gets a value as soon as a resize start
+let g_resize_obj = null; //This gets a value as soon as a resize start
 
 /** Object resizing **/
 
@@ -74,15 +74,15 @@ function g_resize_object() {
 
 // Find out what kind of resize! Return a string inlcluding the directions
 function getDirection(event, el) {
-    var xPos, yPos, offset, dir;
+    let dir;
     dir = "";
 
     // Handle IE and other browsers
-    xPos = event.offsetX ? event.offsetX : event.layerX ? event.layerX : 0;
-    yPos = event.offsetY ? event.offsetY : event.layerY ? event.layerY : 0;
+    const xPos = event.offsetX ? event.offsetX : event.layerX ? event.layerX : 0;
+    const yPos = event.offsetY ? event.offsetY : event.layerY ? event.layerY : 0;
 
     // The distance from the edge in pixels
-    offset = 8;
+    const offset = 8;
 
     if (yPos < offset) {
         dir += "n";
@@ -101,11 +101,11 @@ function getDirection(event, el) {
 
 function resizeMouseDown(event) {
     event = event || window.event;
-    var target = getTargetByClass(event, "resizeable");
+    const target = getTargetByClass(event, "resizeable");
 
     if (!target || target.id == "") return true;
 
-    var dir = getDirection(event, target);
+    const dir = getDirection(event, target);
     if (dir == "") return true;
 
     // Disable dragging while resizing
@@ -135,23 +135,23 @@ function resizeMouseUp(event) {
     draggingEnabled = true;
     draggingObject = null;
 
-    var dom_obj = g_resize_obj.el;
+    const dom_obj = g_resize_obj.el;
 
-    var objId = dom_obj.id.split("-")[0];
-    var objX = rmZoomFactor(pxToInt(dom_obj.style.left), true);
-    var objY = rmZoomFactor(pxToInt(dom_obj.style.top), true);
-    var objW = rmZoomFactor(parseInt(dom_obj.style.width));
-    var objH = rmZoomFactor(parseInt(dom_obj.style.height));
+    const objId = dom_obj.id.split("-")[0];
+    let objX = rmZoomFactor(pxToInt(dom_obj.style.left), true);
+    let objY = rmZoomFactor(pxToInt(dom_obj.style.top), true);
+    const objW = rmZoomFactor(parseInt(dom_obj.style.width));
+    const objH = rmZoomFactor(parseInt(dom_obj.style.height));
 
     // (worldmap) X and Y are center coordinates, not the top/left corner
-    var objMarginTop = rmZoomFactor(pxToInt(dom_obj.style.marginTop), true);
-    var objMarginLeft = rmZoomFactor(pxToInt(dom_obj.style.marginLeft), true);
+    const objMarginTop = rmZoomFactor(pxToInt(dom_obj.style.marginTop), true);
+    const objMarginLeft = rmZoomFactor(pxToInt(dom_obj.style.marginLeft), true);
     if (objMarginLeft && objMarginTop) {
         objX = Math.round(objX + objMarginLeft + objW / 2);
         objY = Math.round(objY + objMarginTop + objH / 2);
     }
 
-    var parts = g_view.unproject(objX, objY);
+    const parts = g_view.unproject(objX, objY);
 
     saveObjectAttr(objId, {
         x: parts[0],
@@ -167,13 +167,13 @@ function resizeMouseUp(event) {
 
 function resizeMouseMove(event) {
     event = event || window.event;
-    var target = getTargetByClass(event, "resizeable");
+    const target = getTargetByClass(event, "resizeable");
 
     // First update the cursor. This needs to be done even
     // when not yet resizing to visualize that it is possible
 
     if (target) {
-        var str = getDirection(event, target);
+        let str = getDirection(event, target);
 
         // Fix the cursor
         if (str == "") str = "";
@@ -185,9 +185,9 @@ function resizeMouseMove(event) {
 
     if (g_resize_obj === null) return true;
 
-    var scale = g_resize_obj.el.dataset.theScale ? g_resize_obj.el.dataset.theScale : 1;
+    const scale = g_resize_obj.el.dataset.theScale ? g_resize_obj.el.dataset.theScale : 1;
 
-    var minWidth = 8 * scale, // The smallest width and height possible
+    const minWidth = 8 * scale, // The smallest width and height possible
         minHeight = 8 * scale;
 
     let grabOffsetX = event.clientX - g_resize_obj.grabx;
@@ -196,9 +196,9 @@ function resizeMouseMove(event) {
     if (g_resize_obj.dir.indexOf("e") != -1) {
         grabOffsetX = Math.max(grabOffsetX, -g_resize_obj.width * scale + minWidth);
 
-        let newWidth = g_resize_obj.width + grabOffsetX / scale;
-        let newLeft = g_resize_obj.left + grabOffsetX / 2;
-        let newMarginLeft = -newWidth / 2;
+        const newWidth = g_resize_obj.width + grabOffsetX / scale;
+        const newLeft = g_resize_obj.left + grabOffsetX / 2;
+        const newMarginLeft = -newWidth / 2;
 
         g_resize_obj.el.style.width = newWidth + "px";
         g_resize_obj.el.style.left = newLeft + "px";
@@ -207,9 +207,9 @@ function resizeMouseMove(event) {
     if (g_resize_obj.dir.indexOf("s") != -1) {
         grabOffsetY = Math.max(grabOffsetY, -g_resize_obj.height * scale + minHeight);
 
-        let newHeight = g_resize_obj.height + grabOffsetY / scale;
-        let newTop = g_resize_obj.top + grabOffsetY / 2;
-        let newMarginTop = -newHeight / 2;
+        const newHeight = g_resize_obj.height + grabOffsetY / scale;
+        const newTop = g_resize_obj.top + grabOffsetY / 2;
+        const newMarginTop = -newHeight / 2;
 
         g_resize_obj.el.style.height = newHeight + "px";
         g_resize_obj.el.style.top = newTop + "px";
@@ -219,9 +219,9 @@ function resizeMouseMove(event) {
     if (g_resize_obj.dir.indexOf("w") != -1) {
         grabOffsetX = Math.min(grabOffsetX, g_resize_obj.width * scale - minWidth);
 
-        let newWidth = g_resize_obj.width - grabOffsetX / scale;
-        let newLeft = g_resize_obj.left + grabOffsetX / 2;
-        let newMarginLeft = -newWidth / 2;
+        const newWidth = g_resize_obj.width - grabOffsetX / scale;
+        const newLeft = g_resize_obj.left + grabOffsetX / 2;
+        const newMarginLeft = -newWidth / 2;
 
         g_resize_obj.el.style.width = newWidth + "px";
         g_resize_obj.el.style.left = newLeft + "px";
@@ -230,9 +230,9 @@ function resizeMouseMove(event) {
     if (g_resize_obj.dir.indexOf("n") != -1) {
         grabOffsetY = Math.min(grabOffsetY, g_resize_obj.height * scale - minHeight);
 
-        let newHeight = g_resize_obj.height - grabOffsetY / scale;
-        let newTop = g_resize_obj.top + grabOffsetY / 2;
-        let newMarginTop = -newHeight / 2;
+        const newHeight = g_resize_obj.height - grabOffsetY / scale;
+        const newTop = g_resize_obj.top + grabOffsetY / 2;
+        const newMarginTop = -newHeight / 2;
 
         g_resize_obj.el.style.height = newHeight + "px";
         g_resize_obj.el.style.top = newTop + "px";
@@ -299,15 +299,15 @@ function makeDragable(trigger_obj, obj, dragStopHandler, dragMoveHandler) {
 function dragStart(event) {
     event = event || window.event;
 
-    var target = getTargetByClass(event, "dragger");
-    var button = getButton(event);
+    const target = getTargetByClass(event, "dragger");
+    const button = getButton(event);
 
     // Skip calls when already dragging or other button than left mouse
     if (draggingObject !== null || button != "LEFT" || !target || !draggingEnabled) return true;
 
     contextHide();
 
-    var parts = getEventMousePos(event),
+    const parts = getEventMousePos(event),
         posx = parts[0],
         posy = parts[1];
 
@@ -320,8 +320,8 @@ function dragStart(event) {
     dragObjectStartPos = [draggingObject.x, draggingObject.y];
 
     // Save diff coords of relative objects
-    var sLabelName = target.id.replace("box_", "rel_label_");
-    var oLabel = document.getElementById(sLabelName);
+    const sLabelName = target.id.replace("box_", "rel_label_");
+    const oLabel = document.getElementById(sLabelName);
     if (oLabel) {
         dragObjectChilds[sLabelName] = [oLabel.offsetLeft - draggingObject.x, oLabel.offsetTop - draggingObject.y];
     }
@@ -336,7 +336,7 @@ function dragObject(event) {
 
     if (draggingObject === null || !draggingEnabled) return true;
 
-    var parts = getEventMousePos(event),
+    const parts = getEventMousePos(event),
         posx = parts[0],
         posy = parts[1],
         newLeft = posx - dragObjectOffset[0],
@@ -355,32 +355,32 @@ function dragObject(event) {
     moveRelativeObject(draggingObject.id, newTop, newLeft);
 
     // Is this object currently relative positioned?
-    var idParts = draggingObject.id.split("-");
-    var obj = g_view.objects[idParts[0]];
-    var parents;
+    const idParts = draggingObject.id.split("-");
+    const obj = g_view.objects[idParts[0]];
+    let parents;
     if (obj.conf.view_type === "line") {
-        var anchorId = idParts[2];
+        const anchorId = idParts[2];
         parents = obj.getParentObjectIds(anchorId);
     } else {
         parents = obj.getParentObjectIds();
     }
-    var isRel = Object.keys(parents).length > 0;
+    const isRel = Object.keys(parents).length > 0;
 
     // Unhighlight all other objects
-    for (var i in g_view.objects) g_view.objects[i].highlight(false);
+    for (const i in g_view.objects) g_view.objects[i].highlight(false);
 
     // Highlight parents when relative
-    for (var objectId in parents) g_view.objects[objectId].highlight(true);
+    for (const objectId in parents) g_view.objects[objectId].highlight(true);
 
     // With pressed CTRL key the icon should be docked
     // This means the object will be positioned relative to that object
     // This code only highlights that object. When the CTRL key is still pressed
     // when dropping the object the currently moved object will be positioned
     // relative to this object.
-    var msg = null;
+    let msg = null;
     if (event.ctrlKey) {
         // Find the nearest object to the current position and highlight it
-        var o = getNearestObject(draggingObject, newLeft, newTop);
+        let o = getNearestObject(draggingObject, newLeft, newTop);
         if (o) {
             o.highlight(true);
             o = null;
@@ -392,7 +392,7 @@ function dragObject(event) {
     // Shift key makes the object absolute positioned when still held during dropping
     else if (event.shiftKey) {
         // Unhighlight all objects
-        for (var a in g_view.objects) g_view.objects[a].highlight(false);
+        for (const a in g_view.objects) g_view.objects[a].highlight(false);
 
         if (isRel) msg = "Hold SHIFT till drop for absolute positioning";
     } else {
@@ -414,12 +414,12 @@ function dragObject(event) {
  * in order to prevent relative coordinate loops.
  */
 function getNearestObject(draggingObject, x, y) {
-    var nearest = null;
-    var min = null;
-    var dist;
+    let nearest = null;
+    let min = null;
+    let dist;
 
-    var obj;
-    for (var i in g_view.objects) {
+    let obj;
+    for (const i in g_view.objects) {
         obj = g_view.objects[i];
 
         // Skip own object
@@ -428,8 +428,8 @@ function getNearestObject(draggingObject, x, y) {
         // FIXME: Also handle lines
         if (obj.conf.view_type !== "icon" || obj.conf.type == "line") continue;
 
-        var objX = obj.parseCoord(obj.conf.x, "x");
-        var objY = obj.parseCoord(obj.conf.y, "y");
+        const objX = obj.parseCoord(obj.conf.x, "x");
+        const objY = obj.parseCoord(obj.conf.y, "y");
         dist = Math.sqrt((objX - x) * (objX - x) + (objY - y) * (objY - y));
         if (min === null || dist < min) {
             // Got a nearer one. Ok. But does it have a reference to us?
@@ -457,14 +457,14 @@ function coordsReferTo(obj, target_object_id) {
     }
 
     if (isRelativeCoord(obj.conf.x)) {
-        var xParent = getMapObjByDomObjId(obj.getCoordParent(obj.conf.x, -1));
+        const xParent = getMapObjByDomObjId(obj.getCoordParent(obj.conf.x, -1));
         if (coordsReferTo(xParent, target_object_id)) {
             return true;
         }
     }
 
     if (isRelativeCoord(obj.conf.y)) {
-        var yParent = getMapObjByDomObjId(obj.getCoordParent(obj.conf.y, -1));
+        const yParent = getMapObjByDomObjId(obj.getCoordParent(obj.conf.y, -1));
         if (coordsReferTo(yParent, target_object_id)) {
             return true;
         }
@@ -474,9 +474,9 @@ function coordsReferTo(obj, target_object_id) {
 }
 
 function moveRelativeObject(parentId, parentTop, parentLeft) {
-    var sLabelName = parentId.replace("box_", "rel_label_");
+    let sLabelName = parentId.replace("box_", "rel_label_");
     if (typeof dragObjectChilds[sLabelName] !== "undefined") {
-        var oLabel = document.getElementById(sLabelName);
+        let oLabel = document.getElementById(sLabelName);
         if (oLabel) {
             oLabel.style.position = "absolute";
             oLabel.style.left = dragObjectChilds[sLabelName][0] + parentLeft + "px";
@@ -521,7 +521,7 @@ function dragStop(event) {
         return;
     }
 
-    var oParent = null;
+    let oParent = null;
     if (event.ctrlKey) {
         oParent = getNearestObject(draggingObject, draggingObject.x, draggingObject.y);
         if (oParent) oParent.highlight(false);
@@ -530,7 +530,7 @@ function dragStop(event) {
     if (event.shiftKey) oParent = false;
 
     // Unhilight parent objects
-    for (var objectId in getMapObjByDomObjId(draggingObject.id.split("-")[0]).getParentObjectIds())
+    for (const objectId in getMapObjByDomObjId(draggingObject.id.split("-")[0]).getParentObjectIds())
         getMapObjByDomObjId(objectId).highlight(false);
 
     dragStopHandlers[draggingObject.id](draggingObject, dragObjects[draggingObject.id], oParent);
@@ -548,7 +548,7 @@ function dragging() {
 
 /** add object code **/
 
-var addObjType = null,
+let addObjType = null,
     addViewType = null,
     addNumLeft = null,
     addAction = null,
@@ -560,9 +560,9 @@ var addObjType = null,
 
 function cloneObject(e, objId) {
     cloneId = objId;
-    var obj = getMapObjByDomObjId(objId);
+    const obj = getMapObjByDomObjId(objId);
 
-    var numClicks = 1;
+    let numClicks = 1;
     if (
         obj.conf.type == "textbox" ||
         obj.conf.type == "container" ||
@@ -598,7 +598,7 @@ function getEventMousePos(event) {
 
     // Ignore clicks on the header menu
     if (event.target) {
-        var target = event.target;
+        let target = event.target;
         while (target) {
             if (target.id && target.id == "header") {
                 return false;
@@ -607,7 +607,7 @@ function getEventMousePos(event) {
         }
     }
 
-    var posx, posy;
+    let posx, posy;
     if (event.pageX || event.pageY) {
         posx = event.pageX;
         posy = event.pageY;
@@ -643,7 +643,7 @@ function stopAdding() {
 function addClick(e) {
     if (!adding()) return true;
 
-    var pos = getEventMousePos(e);
+    let pos = getEventMousePos(e);
     if (pos === false) {
         // abort adding when clicking on the header
         stopAdding();
@@ -675,16 +675,17 @@ function addClick(e) {
     // If this is reached all object coords have been collected
     //
 
+    let w, h;
     if (addObjType == "textbox" || addObjType == "container") {
-        var w = addX.pop() - addX[0];
-        var h = addY.pop() - addY[0];
+        w = addX.pop() - addX[0];
+        h = addY.pop() - addY[0];
     }
 
-    var parts = g_view.unproject(addX, addY);
+    const parts = g_view.unproject(addX, addY);
     addX = parts[0];
     addY = parts[1];
 
-    var sUrl = "";
+    let sUrl = "";
     if (addAction == "add" || addAction == "clone")
         sUrl =
             oGeneralProperties.path_server +
@@ -731,12 +732,12 @@ function adding() {
 function addFollowing(e) {
     if (!addFollow) return true;
 
-    var pos = getEventMousePos(e);
+    const pos = getEventMousePos(e);
 
-    var start_x = addZoomFactor(addX[0]),
+    const start_x = addZoomFactor(addX[0]),
         start_y = addZoomFactor(addY[0]);
 
-    var end_x = addZoomFactor(pos[0]),
+    const end_x = addZoomFactor(pos[0]),
         end_y = addZoomFactor(pos[1]);
 
     addShape.clear();
@@ -760,7 +761,7 @@ function gridParse() {
     if (!useGrid()) return;
 
     // Create grid container and append to map
-    var oGrid = document.getElementById("grid");
+    let oGrid = document.getElementById("grid");
     if (!oGrid) {
         oGrid = document.createElement("div");
         oGrid.setAttribute("id", "grid");
@@ -772,17 +773,17 @@ function gridParse() {
     }
 
     // Add options: grid_show, grid_steps, grid_color
-    var line = document.createElement("div");
+    const line = document.createElement("div");
     line.style.backgroundColor = oViewProperties.grid_color;
 
-    var gridStep = addZoomFactor(oViewProperties.grid_steps);
-    var gridYStart = 0;
-    var gridXStart = 0;
-    var gridYEnd = pageHeight() - getHeaderHeight();
-    var gridXEnd = pageWidth();
+    const gridStep = addZoomFactor(oViewProperties.grid_steps);
+    const gridYStart = 0;
+    const gridXStart = 0;
+    const gridYEnd = pageHeight() - getHeaderHeight();
+    const gridXEnd = pageWidth();
 
-    var vline = null;
-    for (var gridX = gridStep; gridX < gridXEnd; gridX = gridX + gridStep) {
+    let vline = null;
+    for (let gridX = gridStep; gridX < gridXEnd; gridX = gridX + gridStep) {
         vline = line.cloneNode();
         vline.className = "vertical";
         vline.style.left = gridX + "px";
@@ -791,8 +792,8 @@ function gridParse() {
         oGrid.appendChild(vline);
     }
 
-    var hline;
-    for (var gridY = gridStep; gridY < gridYEnd; gridY = gridY + gridStep) {
+    let hline;
+    for (let gridY = gridStep; gridY < gridYEnd; gridY = gridY + gridStep) {
         hline = line.cloneNode();
         hline.className = "horizontal";
         hline.style.top = gridY + "px";
@@ -806,7 +807,7 @@ function gridParse() {
 }
 
 function gridRemove() {
-    var oGrid = document.getElementById("grid");
+    const oGrid = document.getElementById("grid");
     if (oGrid) oGrid.parentNode.removeChild(oGrid);
 
     removeEvent(window, "resize", gridRedraw);
@@ -851,7 +852,7 @@ function coordsToGrid(x, y) {
     if (x.indexOf(",") !== -1) {
         x = x.split(",");
         y = y.split(",");
-        for (var i = 0; i < x.length; i++) {
+        for (let i = 0; i < x.length; i++) {
             x[i] = x[i] - (x[i] % addZoomFactor(oViewProperties.grid_steps));
             y[i] = y[i] - (y[i] % addZoomFactor(oViewProperties.grid_steps));
         }
@@ -859,22 +860,22 @@ function coordsToGrid(x, y) {
     } else {
         x = +x;
         y = +y;
-        var gridMoveX = x - (x % addZoomFactor(oViewProperties.grid_steps));
-        var gridMoveY = y - (y % addZoomFactor(oViewProperties.grid_steps));
+        const gridMoveX = x - (x % addZoomFactor(oViewProperties.grid_steps));
+        const gridMoveY = y - (y % addZoomFactor(oViewProperties.grid_steps));
         return [gridMoveX, gridMoveY];
     }
 }
 
 function toggle_section(sec) {
-    var sections = document.getElementsByClassName("section");
-    for (var i = 0; i < sections.length; i++) {
+    const sections = document.getElementsByClassName("section");
+    for (let i = 0; i < sections.length; i++) {
         if (sections[i].id == "sec_" + sec) sections[i].style.display = "";
         else sections[i].style.display = "none";
     }
 
     // update the navigation
-    var nav_items = document.getElementById("nav").childNodes;
-    for (i = 0; i < nav_items.length; i++) {
+    const nav_items = document.getElementById("nav").childNodes;
+    for (let i = 0; i < nav_items.length; i++) {
         if (nav_items[i].id == "nav_" + sec) add_class(nav_items[i], "active");
         else remove_class(nav_items[i], "active");
     }
@@ -885,8 +886,8 @@ function toggle_section(sec) {
 
 // Toggles the state of an option (Showing inherited value or the current configured value)
 function toggle_option(name) {
-    var field = document.getElementById(name);
-    var txt = document.getElementById("_txt_" + name);
+    let field = document.getElementById(name);
+    let txt = document.getElementById("_txt_" + name);
 
     if (field && txt) {
         if (field.style.display === "none") {
@@ -902,14 +903,14 @@ function toggle_option(name) {
 }
 
 function togglePicker(id, state) {
-    var o = document.getElementById(id);
+    let o = document.getElementById(id);
     if (jscolor.picker && jscolor.picker.owner == o.color) o.color.hidePicker();
     else o.color.showPicker();
     o = null;
 }
 
 function pickWindowSize(id, dimension) {
-    var o = document.getElementById(id);
+    let o = document.getElementById(id);
     if (dimension == "width") {
         o.value = pageWidth();
     } else {
@@ -919,10 +920,10 @@ function pickWindowSize(id, dimension) {
 }
 
 function updateUserRoles(bAdd) {
-    var user_roles = document.getElementById("user_roles");
-    var available = document.getElementById("roles_available");
-    var selected = document.getElementById("roles_selected");
-    var source, target;
+    const user_roles = document.getElementById("user_roles");
+    const available = document.getElementById("roles_available");
+    const selected = document.getElementById("roles_selected");
+    let source, target;
     if (bAdd) {
         source = available;
         target = selected;
@@ -935,23 +936,23 @@ function updateUserRoles(bAdd) {
     if (source.selectedIndex === -1) return false;
 
     // Save strings
-    var optName = source.options[source.selectedIndex].text;
-    var optValue = source.options[source.selectedIndex].value;
+    const optName = source.options[source.selectedIndex].text;
+    const optValue = source.options[source.selectedIndex].value;
 
     // Move from source to target
     source.options.remove(source.selectedIndex);
     target.options[target.options.length] = new Option(optName, optValue, false, false);
 
     // now update the internal helper field with the selected options
-    var selected_values = [];
-    for (var i = 0; i < selected.options.length; i++) {
+    const selected_values = [];
+    for (let i = 0; i < selected.options.length; i++) {
         selected_values.push(selected.options[i].value);
     }
     user_roles.value = selected_values.join(",");
 }
 
 function addOption(form) {
-    var field = form.num_options;
+    const field = form.num_options;
     field.value = parseInt(field.value) + 1;
     updateForm(form);
 }

--- a/share/frontend/nagvis-js/js/edit.js
+++ b/share/frontend/nagvis-js/js/edit.js
@@ -27,8 +27,7 @@ function getTargetRaw(event) {
 
 function getTargetByClass(event, className) {
     var target = getTargetRaw(event);
-    while (target && !has_class(target, className))
-        target = target.parentNode;
+    while (target && !has_class(target, className)) target = target.parentNode;
     return target;
 }
 
@@ -41,13 +40,10 @@ function toggleMapObjectLock(event, object_id) {
 function toggleAllMapObjectsLock(event) {
     var lock = g_view.hasUnlocked();
 
-    for (var object_id in g_view.objects)
-        g_view.toggleObjectLock(object_id, lock);
+    for (var object_id in g_view.objects) g_view.toggleObjectLock(object_id, lock);
 
-    if (!lock)
-        storeUserOption('unlocked-' + oPageProperties.map_name, '*');
-    else
-        storeUserOption('unlocked-' + oPageProperties.map_name, '');
+    if (!lock) storeUserOption("unlocked-" + oPageProperties.map_name, "*");
+    else storeUserOption("unlocked-" + oPageProperties.map_name, "");
     return preventDefaultEvents(event);
 }
 
@@ -59,16 +55,16 @@ var dragObjectStartPos = null;
 var dragObjectChilds = {};
 var dragStopHandlers = {};
 var dragMoveHandlers = {};
-var dragObjects      = {};
+var dragObjects = {};
 
 var g_resize_obj = null; //This gets a value as soon as a resize start
 
 /** Object resizing **/
 
 function g_resize_object() {
-    this.el        = null; //pointer to the object
-    this.dir    = "";      //type of current resize (n, s, e, w, ne, nw, se, sw)
-    this.grabx = null;     //Some useful values
+    this.el = null; //pointer to the object
+    this.dir = ""; //type of current resize (n, s, e, w, ne, nw, se, sw)
+    this.grabx = null; //Some useful values
     this.graby = null;
     this.width = null;
     this.height = null;
@@ -90,13 +86,13 @@ function getDirection(event, el) {
 
     if (yPos < offset) {
         dir += "n";
-    }	else if (yPos > el.offsetHeight - offset) {
+    } else if (yPos > el.offsetHeight - offset) {
         dir += "s";
     }
 
-    if(xPos < offset) {
+    if (xPos < offset) {
         dir += "w";
-    }	else if (xPos > el.offsetWidth - offset) {
+    } else if (xPos > el.offsetWidth - offset) {
         dir += "e";
     }
 
@@ -105,14 +101,12 @@ function getDirection(event, el) {
 
 function resizeMouseDown(event) {
     event = event || window.event;
-    var target = getTargetByClass(event, 'resizeable');
+    var target = getTargetByClass(event, "resizeable");
 
-    if (!target || target.id == '')
-        return true;
+    if (!target || target.id == "") return true;
 
     var dir = getDirection(event, target);
-    if (dir == "")
-        return true;
+    if (dir == "") return true;
 
     // Disable dragging while resizing
     draggingEnabled = false;
@@ -123,20 +117,19 @@ function resizeMouseDown(event) {
     g_resize_obj.el = target;
     g_resize_obj.dir = dir;
 
-    g_resize_obj.grabx  = event.clientX;
-    g_resize_obj.graby  = event.clientY;
-    g_resize_obj.width  = pxToInt(target.style.width);
+    g_resize_obj.grabx = event.clientX;
+    g_resize_obj.graby = event.clientY;
+    g_resize_obj.width = pxToInt(target.style.width);
     g_resize_obj.height = pxToInt(target.style.height);
-    g_resize_obj.left   = pxToInt(target.style.left);
-    g_resize_obj.top    = pxToInt(target.style.top);
+    g_resize_obj.left = pxToInt(target.style.left);
+    g_resize_obj.top = pxToInt(target.style.top);
 
     return preventDefaultEvents(event);
 }
 
 function resizeMouseUp(event) {
     event = event || window.event;
-    if (g_resize_obj === null)
-        return true;
+    if (g_resize_obj === null) return true;
 
     // Re-enable dragging
     draggingEnabled = true;
@@ -144,7 +137,7 @@ function resizeMouseUp(event) {
 
     var dom_obj = g_resize_obj.el;
 
-    var objId = dom_obj.id.split('-')[0];
+    var objId = dom_obj.id.split("-")[0];
     var objX = rmZoomFactor(pxToInt(dom_obj.style.left), true);
     var objY = rmZoomFactor(pxToInt(dom_obj.style.top), true);
     var objW = rmZoomFactor(parseInt(dom_obj.style.width));
@@ -154,17 +147,17 @@ function resizeMouseUp(event) {
     var objMarginTop = rmZoomFactor(pxToInt(dom_obj.style.marginTop), true);
     var objMarginLeft = rmZoomFactor(pxToInt(dom_obj.style.marginLeft), true);
     if (objMarginLeft && objMarginTop) {
-      objX = Math.round(objX + objMarginLeft + objW/2);
-      objY = Math.round(objY + objMarginTop + objH/2);
+        objX = Math.round(objX + objMarginLeft + objW / 2);
+        objY = Math.round(objY + objMarginTop + objH / 2);
     }
 
     var parts = g_view.unproject(objX, objY);
 
     saveObjectAttr(objId, {
-        'x': parts[0],
-        'y': parts[1],
-        'w': objW,
-        'h': objH
+        x: parts[0],
+        y: parts[1],
+        w: objW,
+        h: objH
     });
 
     g_resize_obj = null;
@@ -174,7 +167,7 @@ function resizeMouseUp(event) {
 
 function resizeMouseMove(event) {
     event = event || window.event;
-    var target = getTargetByClass(event, 'resizeable');
+    var target = getTargetByClass(event, "resizeable");
 
     // First update the cursor. This needs to be done even
     // when not yet resizing to visualize that it is possible
@@ -183,17 +176,14 @@ function resizeMouseMove(event) {
         var str = getDirection(event, target);
 
         // Fix the cursor
-        if (str == "")
-            str = "";
-        else
-            str += "-resize";
+        if (str == "") str = "";
+        else str += "-resize";
         target.style.cursor = str;
     }
 
     // The following code is only relevant when already resizing
 
-    if (g_resize_obj === null)
-        return true;
+    if (g_resize_obj === null) return true;
 
     var scale = g_resize_obj.el.dataset.theScale ? g_resize_obj.el.dataset.theScale : 1;
 
@@ -203,68 +193,68 @@ function resizeMouseMove(event) {
     let grabOffsetX = event.clientX - g_resize_obj.grabx;
     let grabOffsetY = event.clientY - g_resize_obj.graby;
 
-    if(g_resize_obj.dir.indexOf("e") != -1) {
-        grabOffsetX = Math.max(grabOffsetX, -g_resize_obj.width*scale + minWidth);
+    if (g_resize_obj.dir.indexOf("e") != -1) {
+        grabOffsetX = Math.max(grabOffsetX, -g_resize_obj.width * scale + minWidth);
 
-        let newWidth = g_resize_obj.width + grabOffsetX/scale;
-        let newLeft = g_resize_obj.left + grabOffsetX/2;
-        let newMarginLeft = -newWidth/2;
+        let newWidth = g_resize_obj.width + grabOffsetX / scale;
+        let newLeft = g_resize_obj.left + grabOffsetX / 2;
+        let newMarginLeft = -newWidth / 2;
 
         g_resize_obj.el.style.width = newWidth + "px";
         g_resize_obj.el.style.left = newLeft + "px";
         g_resize_obj.el.style.marginLeft = newMarginLeft + "px";
     }
-    if(g_resize_obj.dir.indexOf("s") != -1) {
-        grabOffsetY = Math.max(grabOffsetY, -g_resize_obj.height*scale + minHeight);
+    if (g_resize_obj.dir.indexOf("s") != -1) {
+        grabOffsetY = Math.max(grabOffsetY, -g_resize_obj.height * scale + minHeight);
 
-        let newHeight = g_resize_obj.height + grabOffsetY/scale;
-        let newTop = g_resize_obj.top + grabOffsetY/2;
-        let newMarginTop = -newHeight/2;
+        let newHeight = g_resize_obj.height + grabOffsetY / scale;
+        let newTop = g_resize_obj.top + grabOffsetY / 2;
+        let newMarginTop = -newHeight / 2;
 
         g_resize_obj.el.style.height = newHeight + "px";
         g_resize_obj.el.style.top = newTop + "px";
         g_resize_obj.el.style.marginTop = newMarginTop + "px";
     }
 
-    if(g_resize_obj.dir.indexOf("w") != -1) {
-        grabOffsetX = Math.min(grabOffsetX, g_resize_obj.width*scale - minWidth);
+    if (g_resize_obj.dir.indexOf("w") != -1) {
+        grabOffsetX = Math.min(grabOffsetX, g_resize_obj.width * scale - minWidth);
 
-        let newWidth = g_resize_obj.width - grabOffsetX/scale;
-        let newLeft = g_resize_obj.left + grabOffsetX/2;
-        let newMarginLeft = -newWidth/2;
+        let newWidth = g_resize_obj.width - grabOffsetX / scale;
+        let newLeft = g_resize_obj.left + grabOffsetX / 2;
+        let newMarginLeft = -newWidth / 2;
 
         g_resize_obj.el.style.width = newWidth + "px";
         g_resize_obj.el.style.left = newLeft + "px";
         g_resize_obj.el.style.marginLeft = newMarginLeft + "px";
     }
-    if(g_resize_obj.dir.indexOf("n") != -1) {
-        grabOffsetY = Math.min(grabOffsetY, g_resize_obj.height*scale - minHeight);
+    if (g_resize_obj.dir.indexOf("n") != -1) {
+        grabOffsetY = Math.min(grabOffsetY, g_resize_obj.height * scale - minHeight);
 
-        let newHeight = g_resize_obj.height - grabOffsetY/scale;
-        let newTop = g_resize_obj.top + grabOffsetY/2;
-        let newMarginTop = -newHeight/2;
+        let newHeight = g_resize_obj.height - grabOffsetY / scale;
+        let newTop = g_resize_obj.top + grabOffsetY / 2;
+        let newMarginTop = -newHeight / 2;
 
         g_resize_obj.el.style.height = newHeight + "px";
         g_resize_obj.el.style.top = newTop + "px";
         g_resize_obj.el.style.marginTop = newMarginTop + "px";
-  }
+    }
 
     return preventDefaultEvents(event);
 }
 
 function makeResizeable(trigger_obj) {
-    add_class(trigger_obj, 'resizeable');
-    addEvent(trigger_obj, 'mousedown', resizeMouseDown);
-    addEvent(trigger_obj, 'mouseup', resizeMouseUp);
+    add_class(trigger_obj, "resizeable");
+    addEvent(trigger_obj, "mousedown", resizeMouseDown);
+    addEvent(trigger_obj, "mouseup", resizeMouseUp);
 }
 
 function makeUnresizeable(trigger_obj) {
     // when locking the object while the cursor is a resize cursor,
     // it will stay as it is, when not removing them.
-    trigger_obj.style.cursor = '';
-    remove_class(trigger_obj, 'resizeable');
-    removeEvent(trigger_obj, 'mousedown', resizeMouseDown);
-    removeEvent(trigger_obj, 'mouseup', resizeMouseUp);
+    trigger_obj.style.cursor = "";
+    remove_class(trigger_obj, "resizeable");
+    removeEvent(trigger_obj, "mousedown", resizeMouseDown);
+    removeEvent(trigger_obj, "mouseup", resizeMouseUp);
 }
 
 /*** Handles the object dragging ***/
@@ -272,10 +262,10 @@ function makeUnresizeable(trigger_obj) {
 function getButton(event) {
     if (event.which == null)
         /* IE case */
-        return (event.button < 2) ? "LEFT" : ((event.button == 4) ? "MIDDLE" : "RIGHT");
+        return event.button < 2 ? "LEFT" : event.button == 4 ? "MIDDLE" : "RIGHT";
     else
         /* All others */
-        return (event.which < 2) ? "LEFT" : ((event.which == 2) ? "MIDDLE" : "RIGHT");
+        return event.which < 2 ? "LEFT" : event.which == 2 ? "MIDDLE" : "RIGHT";
 }
 
 function makeUndragable(trigger_obj) {
@@ -283,10 +273,10 @@ function makeUndragable(trigger_obj) {
     delete dragMoveHandlers[trigger_obj.id];
     delete dragObjects[trigger_obj.id];
 
-    remove_class(trigger_obj, 'dragger');
+    remove_class(trigger_obj, "dragger");
 
-    removeEvent(trigger_obj, 'mousedown', dragStart);
-    removeEvent(document, 'mouseup', dragStop);
+    removeEvent(trigger_obj, "mousedown", dragStart);
+    removeEvent(document, "mouseup", dragStop);
 }
 
 function makeDragable(trigger_obj, obj, dragStopHandler, dragMoveHandler) {
@@ -294,7 +284,7 @@ function makeDragable(trigger_obj, obj, dragStopHandler, dragMoveHandler) {
     dragMoveHandlers[trigger_obj.id] = dragMoveHandler;
     dragObjects[trigger_obj.id] = obj;
 
-    add_class(trigger_obj, 'dragger');
+    add_class(trigger_obj, "dragger");
 
     addEvent(trigger_obj, "mousedown", dragStart);
     // The drag stop event is registered globally on the whole document to prevent
@@ -309,33 +299,31 @@ function makeDragable(trigger_obj, obj, dragStopHandler, dragMoveHandler) {
 function dragStart(event) {
     event = event || window.event;
 
-    var target = getTargetByClass(event, 'dragger');
+    var target = getTargetByClass(event, "dragger");
     var button = getButton(event);
 
     // Skip calls when already dragging or other button than left mouse
-    if (draggingObject !== null || button != 'LEFT' || !target || !draggingEnabled)
-        return true;
+    if (draggingObject !== null || button != "LEFT" || !target || !draggingEnabled) return true;
 
     contextHide();
 
     var parts = getEventMousePos(event),
-        posx  = parts[0],
-        posy  = parts[1];
+        posx = parts[0],
+        posy = parts[1];
 
     draggingObject = target;
     draggingObject.x = rmZoomFactor(pxToInt(draggingObject.style.left), true);
     draggingObject.y = rmZoomFactor(pxToInt(draggingObject.style.top), true);
 
     // Save relative offset of the mouse
-    dragObjectOffset   = [ posx - draggingObject.x, posy - draggingObject.y ];
-    dragObjectStartPos = [ draggingObject.x, draggingObject.y ];
+    dragObjectOffset = [posx - draggingObject.x, posy - draggingObject.y];
+    dragObjectStartPos = [draggingObject.x, draggingObject.y];
 
     // Save diff coords of relative objects
-    var sLabelName = target.id.replace('box_', 'rel_label_');
+    var sLabelName = target.id.replace("box_", "rel_label_");
     var oLabel = document.getElementById(sLabelName);
-    if(oLabel) {
-        dragObjectChilds[sLabelName] = [ oLabel.offsetLeft - draggingObject.x,
-                                         oLabel.offsetTop - draggingObject.y ];
+    if (oLabel) {
+        dragObjectChilds[sLabelName] = [oLabel.offsetLeft - draggingObject.x, oLabel.offsetTop - draggingObject.y];
     }
     return preventDefaultEvents(event);
 }
@@ -346,22 +334,20 @@ function dragStart(event) {
 function dragObject(event) {
     event = event || window.event;
 
-    if (draggingObject === null || !draggingEnabled)
-        return true;
+    if (draggingObject === null || !draggingEnabled) return true;
 
     var parts = getEventMousePos(event),
-        posx  = parts[0],
-        posy  = parts[1],
+        posx = parts[0],
+        posy = parts[1],
         newLeft = posx - dragObjectOffset[0],
-        newTop  = posy - dragObjectOffset[1];
+        newTop = posy - dragObjectOffset[1];
 
     // skip further handling when moving out of screen
-    if (typeof posx === 'undefined' || typeof posy === undefined)
-        return preventDefaultEvents(event);
+    if (typeof posx === "undefined" || typeof posy === undefined) return preventDefaultEvents(event);
 
-    draggingObject.style.position = 'absolute';
-    draggingObject.style.left = addZoomFactor(newLeft) + 'px';
-    draggingObject.style.top  = addZoomFactor(newTop) + 'px';
+    draggingObject.style.position = "absolute";
+    draggingObject.style.left = addZoomFactor(newLeft) + "px";
+    draggingObject.style.top = addZoomFactor(newTop) + "px";
     draggingObject.x = newLeft;
     draggingObject.y = newTop;
 
@@ -369,10 +355,10 @@ function dragObject(event) {
     moveRelativeObject(draggingObject.id, newTop, newLeft);
 
     // Is this object currently relative positioned?
-    var idParts = draggingObject.id.split('-');
+    var idParts = draggingObject.id.split("-");
     var obj = g_view.objects[idParts[0]];
     var parents;
-    if (obj.conf.view_type === 'line') {
+    if (obj.conf.view_type === "line") {
         var anchorId = idParts[2];
         parents = obj.getParentObjectIds(anchorId);
     } else {
@@ -381,13 +367,10 @@ function dragObject(event) {
     var isRel = Object.keys(parents).length > 0;
 
     // Unhighlight all other objects
-    for(var i in g_view.objects)
-        g_view.objects[i].highlight(false);
-
+    for (var i in g_view.objects) g_view.objects[i].highlight(false);
 
     // Highlight parents when relative
-    for (var objectId in parents)
-        g_view.objects[objectId].highlight(true);
+    for (var objectId in parents) g_view.objects[objectId].highlight(true);
 
     // With pressed CTRL key the icon should be docked
     // This means the object will be positioned relative to that object
@@ -395,40 +378,33 @@ function dragObject(event) {
     // when dropping the object the currently moved object will be positioned
     // relative to this object.
     var msg = null;
-    if(event.ctrlKey) {
+    if (event.ctrlKey) {
         // Find the nearest object to the current position and highlight it
-        var o = getNearestObject(draggingObject, newLeft, newTop)
-        if(o) {
+        var o = getNearestObject(draggingObject, newLeft, newTop);
+        if (o) {
             o.highlight(true);
             o = null;
         }
 
-        if (!isRel)
-            msg = 'Hold CTRL till drop for relative positioning';
+        if (!isRel) msg = "Hold CTRL till drop for relative positioning";
     }
 
     // Shift key makes the object absolute positioned when still held during dropping
     else if (event.shiftKey) {
         // Unhighlight all objects
-        for(var a in g_view.objects)
-            g_view.objects[a].highlight(false);
+        for (var a in g_view.objects) g_view.objects[a].highlight(false);
 
-        if (isRel)
-            msg = 'Hold SHIFT till drop for absolute positioning';
+        if (isRel) msg = "Hold SHIFT till drop for absolute positioning";
     } else {
-        if (isRel)
-            msg = 'Press SHIFT for absolute positioning';
-        else
-            msg = 'Press CTRL for relative positioning';
+        if (isRel) msg = "Press SHIFT for absolute positioning";
+        else msg = "Press CTRL for relative positioning";
     }
 
-    if (msg !== null)
-        displayStatusMessage(msg, 'notice', true);
+    if (msg !== null) displayStatusMessage(msg, "notice", true);
 
     // Call the dragging handler when one is set
-    if(dragMoveHandlers[draggingObject.id])
-        dragMoveHandlers[draggingObject.id](draggingObject,
-                                            dragObjects[draggingObject.id], event);
+    if (dragMoveHandlers[draggingObject.id])
+        dragMoveHandlers[draggingObject.id](draggingObject, dragObjects[draggingObject.id], event);
     return preventDefaultEvents(event);
 }
 
@@ -439,37 +415,35 @@ function dragObject(event) {
  */
 function getNearestObject(draggingObject, x, y) {
     var nearest = null;
-    var min     = null;
+    var min = null;
     var dist;
 
     var obj;
-    for(var i in g_view.objects) {
+    for (var i in g_view.objects) {
         obj = g_view.objects[i];
 
         // Skip own object
-        if(draggingObject.id.split('-')[0] == obj.conf.object_id)
-            continue;
+        if (draggingObject.id.split("-")[0] == obj.conf.object_id) continue;
 
         // FIXME: Also handle lines
-        if(obj.conf.view_type !== 'icon' || obj.conf.type == 'line')
-            continue;
+        if (obj.conf.view_type !== "icon" || obj.conf.type == "line") continue;
 
-        var objX = obj.parseCoord(obj.conf.x, 'x');
-        var objY = obj.parseCoord(obj.conf.y, 'y');
-        dist = Math.sqrt(((objX - x) * (objX - x)) + ((objY - y) * (objY - y)));
-        if(min === null || dist < min) {
+        var objX = obj.parseCoord(obj.conf.x, "x");
+        var objY = obj.parseCoord(obj.conf.y, "y");
+        dist = Math.sqrt((objX - x) * (objX - x) + (objY - y) * (objY - y));
+        if (min === null || dist < min) {
             // Got a nearer one. Ok. But does it have a reference to us?
-            if(coordsReferTo(obj, draggingObject.id.split('-')[0])) {
+            if (coordsReferTo(obj, draggingObject.id.split("-")[0])) {
                 continue;
             }
-            min     = dist;
+            min = dist;
             nearest = obj;
         }
     }
 
-    obj     = null;
-    min     = null;
-    dist    = null;
+    obj = null;
+    min = null;
+    dist = null;
     return nearest;
 }
 
@@ -484,14 +458,14 @@ function coordsReferTo(obj, target_object_id) {
 
     if (isRelativeCoord(obj.conf.x)) {
         var xParent = getMapObjByDomObjId(obj.getCoordParent(obj.conf.x, -1));
-        if(coordsReferTo(xParent, target_object_id)) {
+        if (coordsReferTo(xParent, target_object_id)) {
             return true;
         }
     }
 
     if (isRelativeCoord(obj.conf.y)) {
         var yParent = getMapObjByDomObjId(obj.getCoordParent(obj.conf.y, -1));
-        if(coordsReferTo(yParent, target_object_id)) {
+        if (coordsReferTo(yParent, target_object_id)) {
             return true;
         }
     }
@@ -500,13 +474,13 @@ function coordsReferTo(obj, target_object_id) {
 }
 
 function moveRelativeObject(parentId, parentTop, parentLeft) {
-    var sLabelName = parentId.replace('box_', 'rel_label_');
-    if(typeof dragObjectChilds[sLabelName] !== 'undefined') {
+    var sLabelName = parentId.replace("box_", "rel_label_");
+    if (typeof dragObjectChilds[sLabelName] !== "undefined") {
         var oLabel = document.getElementById(sLabelName);
-        if(oLabel) {
-            oLabel.style.position = 'absolute';
-            oLabel.style.left = (dragObjectChilds[sLabelName][0] + parentLeft) + 'px';
-            oLabel.style.top  = (dragObjectChilds[sLabelName][1] + parentTop) + 'px';
+        if (oLabel) {
+            oLabel.style.position = "absolute";
+            oLabel.style.left = dragObjectChilds[sLabelName][0] + parentLeft + "px";
+            oLabel.style.top = dragObjectChilds[sLabelName][1] + parentTop + "px";
             oLabel = null;
         }
     }
@@ -514,23 +488,27 @@ function moveRelativeObject(parentId, parentTop, parentLeft) {
 }
 
 function dragStop(event) {
-    if(draggingObject === null || !draggingEnabled
-       || typeof draggingObject.y == 'undefined' || typeof draggingObject.x == 'undefined')
+    if (
+        draggingObject === null ||
+        !draggingEnabled ||
+        typeof draggingObject.y == "undefined" ||
+        typeof draggingObject.x == "undefined"
+    )
         return;
 
     hideStatusMessage();
 
     // When x or y are negative just return this and make no change
-    if(draggingObject.y < 0 || draggingObject.x < 0) {
-        draggingObject.style.left = dragObjectStartPos[0] + 'px';
-        draggingObject.style.top  = dragObjectStartPos[1] + 'px';
+    if (draggingObject.y < 0 || draggingObject.x < 0) {
+        draggingObject.style.left = dragObjectStartPos[0] + "px";
+        draggingObject.style.top = dragObjectStartPos[1] + "px";
         draggingObject.x = dragObjectStartPos[0];
         draggingObject.y = dragObjectStartPos[1];
 
         moveRelativeObject(draggingObject.id, dragObjectStartPos[1], dragObjectStartPos[0]);
 
         // Call the dragging handler when one is set
-        if(dragMoveHandlers[draggingObject.id])
+        if (dragMoveHandlers[draggingObject.id])
             dragMoveHandlers[draggingObject.id](draggingObject, dragObjects[draggingObject.id], event);
 
         draggingObject = null;
@@ -538,29 +516,27 @@ function dragStop(event) {
     }
 
     // Skip when the object has not been moved
-    if(draggingObject.y == dragObjectStartPos[1] && draggingObject.x == dragObjectStartPos[0]) {
+    if (draggingObject.y == dragObjectStartPos[1] && draggingObject.x == dragObjectStartPos[0]) {
         draggingObject = null;
         return;
     }
 
     var oParent = null;
-    if(event.ctrlKey) {
+    if (event.ctrlKey) {
         oParent = getNearestObject(draggingObject, draggingObject.x, draggingObject.y);
-        if(oParent)
-            oParent.highlight(false);
+        if (oParent) oParent.highlight(false);
     }
 
-    if(event.shiftKey)
-        oParent = false;
+    if (event.shiftKey) oParent = false;
 
     // Unhilight parent objects
-    for(var objectId in getMapObjByDomObjId(draggingObject.id.split('-')[0]).getParentObjectIds())
+    for (var objectId in getMapObjByDomObjId(draggingObject.id.split("-")[0]).getParentObjectIds())
         getMapObjByDomObjId(objectId).highlight(false);
 
     dragStopHandlers[draggingObject.id](draggingObject, dragObjects[draggingObject.id], oParent);
 
     oParent = null;
-    draggingObject    = null;
+    draggingObject = null;
 }
 
 /**
@@ -572,25 +548,30 @@ function dragging() {
 
 /** add object code **/
 
-var addObjType  = null,
+var addObjType = null,
     addViewType = null,
-    addNumLeft  = null,
-    addAction   = null,
-    addX        = [],
-    addY        = [],
-    addFollow   = false,
-    addShape    = null,
-    cloneId     = null;
+    addNumLeft = null,
+    addAction = null,
+    addX = [],
+    addY = [],
+    addFollow = false,
+    addShape = null,
+    cloneId = null;
 
 function cloneObject(e, objId) {
     cloneId = objId;
     var obj = getMapObjByDomObjId(objId);
 
     var numClicks = 1;
-    if(obj.conf.type == 'textbox'|| obj.conf.type == 'container' || obj.conf.view_type == 'line' || obj.type == 'line')
+    if (
+        obj.conf.type == "textbox" ||
+        obj.conf.type == "container" ||
+        obj.conf.view_type == "line" ||
+        obj.type == "line"
+    )
         numClicks = 2;
 
-    return addObject(e, obj.conf.type, obj.conf.view_type, numClicks, 'clone');
+    return addObject(e, obj.conf.type, obj.conf.view_type, numClicks, "clone");
 }
 
 /**
@@ -599,12 +580,12 @@ function cloneObject(e, objId) {
 function addObject(event, objType, viewType, numLeft, action) {
     event = event || window.event;
 
-    addObjType  = objType;
+    addObjType = objType;
     addViewType = viewType;
-    addNumLeft  = numLeft;
-    addAction   = action;
+    addNumLeft = numLeft;
+    addAction = action;
 
-    add_class(document.body, 'add');
+    add_class(document.body, "add");
 
     return preventDefaultEvents(event);
 }
@@ -613,14 +594,13 @@ function getEventMousePos(event) {
     event = event || window.event;
 
     // Only accept "left" mouse clicks
-    if(getButton(event) != 'LEFT')
-        return null;
+    if (getButton(event) != "LEFT") return null;
 
     // Ignore clicks on the header menu
-    if(event.target) {
+    if (event.target) {
         var target = event.target;
-        while(target) {
-            if(target.id && target.id == 'header') {
+        while (target) {
+            if (target.id && target.id == "header") {
                 return false;
             }
             target = target.parentNode;
@@ -645,24 +625,23 @@ function getEventMousePos(event) {
     posx = rmZoomFactor(posx, true);
     posy = rmZoomFactor(posy, true);
 
-    return [ posx, posy ];
+    return [posx, posy];
 }
 
 function stopAdding() {
-    remove_class(document.body, 'add');
-    addObjType  = null,
-    addViewType = null,
-    addNumLeft  = null,
-    addAction   = null,
-    addX        = [],
-    addY        = [],
-    addFollow   = false,
-    addShape    = null;
+    remove_class(document.body, "add");
+    ((addObjType = null),
+        (addViewType = null),
+        (addNumLeft = null),
+        (addAction = null),
+        (addX = []),
+        (addY = []),
+        (addFollow = false),
+        (addShape = null));
 }
 
 function addClick(e) {
-    if(!adding())
-        return true;
+    if (!adding()) return true;
 
     var pos = getEventMousePos(e);
     if (pos === false) {
@@ -677,25 +656,26 @@ function addClick(e) {
     pos = null;
 
     // Draw a line to illustrate the progress of drawing the current line
-    if((addViewType === 'line' || addObjType === 'textbox' || addObjType === 'container' || addObjType === 'line')
-       && addShape === null) {
-        addShape = new jsGraphics('map');
-        addShape.cnv.setAttribute('id', 'drawing');
+    if (
+        (addViewType === "line" || addObjType === "textbox" || addObjType === "container" || addObjType === "line") &&
+        addShape === null
+    ) {
+        addShape = new jsGraphics("map");
+        addShape.cnv.setAttribute("id", "drawing");
 
-        addShape.setColor('#06B606');
+        addShape.setColor("#06B606");
         addShape.setStroke(1);
 
         addFollow = true;
     }
 
-    if(addNumLeft > 0)
-        return false;
+    if (addNumLeft > 0) return false;
 
     //
     // If this is reached all object coords have been collected
     //
 
-    if(addObjType == 'textbox' || addObjType == 'container') {
+    if (addObjType == "textbox" || addObjType == "container") {
         var w = addX.pop() - addX[0];
         var h = addY.pop() - addY[0];
     }
@@ -704,34 +684,42 @@ function addClick(e) {
     addX = parts[0];
     addY = parts[1];
 
-    var sUrl = '';
-    if(addAction == 'add' || addAction == 'clone')
-        sUrl = oGeneralProperties.path_server + '?mod=Map&act=addModify'
-               + '&show=' + oPageProperties.map_name
-               + '&type=' + addObjType
-               + '&x=' + addX.join(',')
-               + '&y=' + addY.join(',');
+    var sUrl = "";
+    if (addAction == "add" || addAction == "clone")
+        sUrl =
+            oGeneralProperties.path_server +
+            "?mod=Map&act=addModify" +
+            "&show=" +
+            oPageProperties.map_name +
+            "&type=" +
+            addObjType +
+            "&x=" +
+            addX.join(",") +
+            "&y=" +
+            addY.join(",");
 
-    if(addObjType != 'textbox' && addObjType != 'container'
-       && addObjType != 'shape' && addViewType != 'icon' && addViewType != '')
-        sUrl += '&view_type=' + addViewType;
+    if (
+        addObjType != "textbox" &&
+        addObjType != "container" &&
+        addObjType != "shape" &&
+        addViewType != "icon" &&
+        addViewType != ""
+    )
+        sUrl += "&view_type=" + addViewType;
 
-    if(addAction == 'clone' && cloneId !== null)
-        sUrl += '&clone_id=' + cloneId;
+    if (addAction == "clone" && cloneId !== null) sUrl += "&clone_id=" + cloneId;
 
-    if(addObjType == 'textbox' || addObjType == 'container')
-        sUrl += '&w=' + w+ '&h=' + h;
+    if (addObjType == "textbox" || addObjType == "container") sUrl += "&w=" + w + "&h=" + h;
 
-    if(sUrl === '')
-        return false;
+    if (sUrl === "") return false;
 
     // remove the drawing area. Once reached this it is not needed anymore
-    if(addShape !== null) {
+    if (addShape !== null) {
         addShape.clear();
-        document.getElementById('map').removeChild(addShape.cnv);
+        document.getElementById("map").removeChild(addShape.cnv);
     }
 
-    showFrontendDialog(sUrl, _('Create Object'));
+    showFrontendDialog(sUrl, _("Create Object"));
     stopAdding();
     return false;
 }
@@ -741,8 +729,7 @@ function adding() {
 }
 
 function addFollowing(e) {
-    if(!addFollow)
-        return true;
+    if (!addFollow) return true;
 
     var pos = getEventMousePos(e);
 
@@ -754,11 +741,9 @@ function addFollowing(e) {
 
     addShape.clear();
 
-    if(addViewType === 'line' || addObjType === 'line')
+    if (addViewType === "line" || addObjType === "line")
         addShape.drawLine(start_x, start_y, end_x - getSidebarWidth(), end_y);
-    else
-        addShape.drawRect(start_x, start_y, (end_x - getSidebarWidth() - start_x),
-                                            (end_y - start_y));
+    else addShape.drawRect(start_x, start_y, end_x - getSidebarWidth() - start_x, end_y - start_y);
 
     addShape.paint();
 }
@@ -772,24 +757,22 @@ function useGrid() {
  */
 function gridParse() {
     // Only show when user configured to see a grid
-    if (!useGrid())
-        return;
+    if (!useGrid()) return;
 
     // Create grid container and append to map
-    var oGrid = document.getElementById('grid');
+    var oGrid = document.getElementById("grid");
     if (!oGrid) {
-        oGrid = document.createElement('div');
-        oGrid.setAttribute('id', 'grid');
-        document.getElementById('map').appendChild(oGrid);
-    }
-    else {
+        oGrid = document.createElement("div");
+        oGrid.setAttribute("id", "grid");
+        document.getElementById("map").appendChild(oGrid);
+    } else {
         while (oGrid.firstChild) {
             oGrid.removeChild(oGrid.firstChild);
         }
     }
 
     // Add options: grid_show, grid_steps, grid_color
-    var line = document.createElement('div');
+    var line = document.createElement("div");
     line.style.backgroundColor = oViewProperties.grid_color;
 
     var gridStep = addZoomFactor(oViewProperties.grid_steps);
@@ -799,22 +782,22 @@ function gridParse() {
     var gridXEnd = pageWidth();
 
     var vline = null;
-    for(var gridX = gridStep; gridX < gridXEnd; gridX = gridX + gridStep) {
+    for (var gridX = gridStep; gridX < gridXEnd; gridX = gridX + gridStep) {
         vline = line.cloneNode();
         vline.className = "vertical";
-        vline.style.left   = gridX + 'px';
-        vline.style.top    = gridYStart + 'px';
+        vline.style.left = gridX + "px";
+        vline.style.top = gridYStart + "px";
         vline.style.bottom = 0;
         oGrid.appendChild(vline);
     }
 
     var hline;
-    for(var gridY = gridStep; gridY < gridYEnd; gridY = gridY + gridStep) {
+    for (var gridY = gridStep; gridY < gridYEnd; gridY = gridY + gridStep) {
         hline = line.cloneNode();
         hline.className = "horizontal";
-        hline.style.top    = gridY +'px';
-        hline.style.left   = gridXStart + 'px';
-        hline.style.right  = 0;
+        hline.style.top = gridY + "px";
+        hline.style.left = gridXStart + "px";
+        hline.style.right = 0;
         oGrid.appendChild(hline);
     }
 
@@ -823,9 +806,8 @@ function gridParse() {
 }
 
 function gridRemove() {
-    var oGrid = document.getElementById('grid');
-    if (oGrid)
-        oGrid.parentNode.removeChild(oGrid);
+    var oGrid = document.getElementById("grid");
+    if (oGrid) oGrid.parentNode.removeChild(oGrid);
 
     removeEvent(window, "resize", gridRedraw);
     removeEvent(window, "scroll", gridRedraw);
@@ -842,7 +824,7 @@ function gridRedraw() {
  */
 function gridToggle() {
     // Toggle the grid state
-    if(useGrid()) {
+    if (useGrid()) {
         oViewProperties.grid_show = 0;
         gridRemove();
     } else {
@@ -851,8 +833,13 @@ function gridToggle() {
     }
 
     // Send current option to server for persistance
-    call_ajax(oGeneralProperties.path_server+'?mod=Map&act=modifyObject&map='
-              + oPageProperties.map_name+'&type=global&id=0&grid_show='+oViewProperties.grid_show);
+    call_ajax(
+        oGeneralProperties.path_server +
+            "?mod=Map&act=modifyObject&map=" +
+            oPageProperties.map_name +
+            "&type=global&id=0&grid_show=" +
+            oViewProperties.grid_show
+    );
 }
 
 /**
@@ -861,57 +848,53 @@ function gridToggle() {
 function coordsToGrid(x, y) {
     x = "" + x;
     y = "" + y;
-    if(x.indexOf(',') !== -1) {
-        x = x.split(',');
-        y = y.split(',');
-        for(var i = 0; i < x.length; i++) {
+    if (x.indexOf(",") !== -1) {
+        x = x.split(",");
+        y = y.split(",");
+        for (var i = 0; i < x.length; i++) {
             x[i] = x[i] - (x[i] % addZoomFactor(oViewProperties.grid_steps));
             y[i] = y[i] - (y[i] % addZoomFactor(oViewProperties.grid_steps));
         }
-        return [ x.join(','), y.join(',') ];
+        return [x.join(","), y.join(",")];
     } else {
         x = +x;
         y = +y;
         var gridMoveX = x - (x % addZoomFactor(oViewProperties.grid_steps));
         var gridMoveY = y - (y % addZoomFactor(oViewProperties.grid_steps));
-        return [ gridMoveX, gridMoveY ];
+        return [gridMoveX, gridMoveY];
     }
 }
 
 function toggle_section(sec) {
-    var sections = document.getElementsByClassName('section');
+    var sections = document.getElementsByClassName("section");
     for (var i = 0; i < sections.length; i++) {
-        if (sections[i].id == 'sec_' + sec)
-            sections[i].style.display = '';
-        else
-            sections[i].style.display = 'none';
+        if (sections[i].id == "sec_" + sec) sections[i].style.display = "";
+        else sections[i].style.display = "none";
     }
 
     // update the navigation
-    var nav_items = document.getElementById('nav').childNodes;
+    var nav_items = document.getElementById("nav").childNodes;
     for (var i = 0; i < nav_items.length; i++) {
-        if (nav_items[i].id == 'nav_' + sec)
-            add_class(nav_items[i], 'active');
-        else
-            remove_class(nav_items[i], 'active');
+        if (nav_items[i].id == "nav_" + sec) add_class(nav_items[i], "active");
+        else remove_class(nav_items[i], "active");
     }
 
     // update the helper field value
-    document.getElementById('sec').value = sec;
+    document.getElementById("sec").value = sec;
 }
 
 // Toggles the state of an option (Showing inherited value or the current configured value)
 function toggle_option(name) {
     var field = document.getElementById(name);
-    var txt   = document.getElementById('_txt_' + name);
+    var txt = document.getElementById("_txt_" + name);
 
-    if(field && txt) {
-        if(field.style.display === 'none') {
-            field.style.display = '';
-            txt.style.display = 'none';
+    if (field && txt) {
+        if (field.style.display === "none") {
+            field.style.display = "";
+            txt.style.display = "none";
         } else {
-            field.style.display = 'none';
-            txt.style.display = '';
+            field.style.display = "none";
+            txt.style.display = "";
         }
         txt = null;
         field = null;
@@ -920,16 +903,14 @@ function toggle_option(name) {
 
 function togglePicker(id, state) {
     var o = document.getElementById(id);
-    if(jscolor.picker && jscolor.picker.owner == o.color)
-        o.color.hidePicker();
-    else
-        o.color.showPicker();
+    if (jscolor.picker && jscolor.picker.owner == o.color) o.color.hidePicker();
+    else o.color.showPicker();
     o = null;
 }
 
 function pickWindowSize(id, dimension) {
     var o = document.getElementById(id);
-    if(dimension == 'width') {
+    if (dimension == "width") {
         o.value = pageWidth();
     } else {
         o.value = pageHeight() - getHeaderHeight();
@@ -938,9 +919,9 @@ function pickWindowSize(id, dimension) {
 }
 
 function updateUserRoles(bAdd) {
-    var user_roles = document.getElementById('user_roles');
-    var available  = document.getElementById('roles_available');
-    var selected   = document.getElementById('roles_selected');
+    var user_roles = document.getElementById("user_roles");
+    var available = document.getElementById("roles_available");
+    var selected = document.getElementById("roles_selected");
     var source, target;
     if (bAdd) {
         source = available;
@@ -951,11 +932,10 @@ function updateUserRoles(bAdd) {
     }
 
     // Quit when no source selected
-    if (source.selectedIndex === -1)
-        return false;
+    if (source.selectedIndex === -1) return false;
 
     // Save strings
-    var optName  = source.options[source.selectedIndex].text;
+    var optName = source.options[source.selectedIndex].text;
     var optValue = source.options[source.selectedIndex].value;
 
     // Move from source to target
@@ -964,10 +944,10 @@ function updateUserRoles(bAdd) {
 
     // now update the internal helper field with the selected options
     var selected_values = [];
-    for(var i = 0; i < selected.options.length; i++) {
+    for (var i = 0; i < selected.options.length; i++) {
         selected_values.push(selected.options[i].value);
     }
-    user_roles.value = selected_values.join(',');
+    user_roles.value = selected_values.join(",");
 }
 
 function addOption(form) {
@@ -987,12 +967,10 @@ function removeMapObject(event, object_id) {
  * Register events
  *************************************************/
 
-addEvent(document, 'mousemove', function(event) {
-    return resizeMouseMove(event)
-            && dragObject(event)
-            && addFollowing(event);
+addEvent(document, "mousemove", function (event) {
+    return resizeMouseMove(event) && dragObject(event) && addFollowing(event);
 });
 
-addEvent(document, 'click', function(event) {
+addEvent(document, "click", function (event) {
     return addClick(event);
 });

--- a/share/frontend/nagvis-js/js/edit.js
+++ b/share/frontend/nagvis-js/js/edit.js
@@ -874,7 +874,7 @@ function toggle_section(sec) {
 
     // update the navigation
     var nav_items = document.getElementById("nav").childNodes;
-    for (var i = 0; i < nav_items.length; i++) {
+    for (i = 0; i < nav_items.length; i++) {
         if (nav_items[i].id == "nav_" + sec) add_class(nav_items[i], "active");
         else remove_class(nav_items[i], "active");
     }

--- a/share/frontend/nagvis-js/js/edit.js
+++ b/share/frontend/nagvis-js/js/edit.js
@@ -343,7 +343,7 @@ function dragObject(event) {
         newTop = posy - dragObjectOffset[1];
 
     // skip further handling when moving out of screen
-    if (typeof posx === "undefined" || typeof posy === undefined) return preventDefaultEvents(event);
+    if (typeof posx === "undefined" || typeof posy === "undefined") return preventDefaultEvents(event);
 
     draggingObject.style.position = "absolute";
     draggingObject.style.left = addZoomFactor(newLeft) + "px";

--- a/share/frontend/nagvis-js/js/frontend.js
+++ b/share/frontend/nagvis-js/js/frontend.js
@@ -39,7 +39,7 @@ var g_view = null;
  * to check if the mainentance mode has finished
  */
 function inMaintenance(displayMsg) {
-    if (!isset(displayMsg)) var displayMsg = true;
+    if (!isset(displayMsg)) displayMsg = true;
     if (oPageProperties && oPageProperties.in_maintenance === "1") {
         hideStatusMessage();
         if (displayMsg)
@@ -212,7 +212,7 @@ function searchObjects(sMatch) {
     // Actions for the results:
     // When multiple found: highlight all
     // When single found: highlight and focus the object
-    for (var i = 0, len = aResults.length; i < len; i++) {
+    for (i = 0, len = aResults.length; i < len; i++) {
         var objectId = aResults[i];
 
         // - highlight the object
@@ -639,12 +639,13 @@ function renderZoombar() {
 function getViewParams(update, userParams) {
     if (!isset(userParams)) userParams = false;
 
+    var params;
     if (!userParams && isset(oViewProperties) && isset(oViewProperties["params"])) {
-        var params = oViewProperties["params"];
+        params = oViewProperties["params"];
     } else if (isset(oViewProperties) && isset(oViewProperties["user_params"])) {
-        var params = oViewProperties["user_params"];
+        params = oViewProperties["user_params"];
     } else if (update) {
-        var params = {};
+        params = {};
     } else {
         return "";
     }
@@ -665,7 +666,7 @@ function getViewParams(update, userParams) {
     }
 
     var sParams = "";
-    for (var param in params) {
+    for (param in params) {
         if (params[param] != "") {
             sParams += "&" + param + "=" + escapeUrlValues(params[param]);
         }

--- a/share/frontend/nagvis-js/js/frontend.js
+++ b/share/frontend/nagvis-js/js/frontend.js
@@ -23,15 +23,17 @@
  *****************************************************************************/
 
 // Contains the number of pixels the header menu currently consumes
-var g_header_height_cache = null;
+let g_header_height_cache = null;
 // Points to the timer object of the worker timer
-var g_worker_id = null;
+let g_worker_id = null;
 // Holds the global JS map object (e.g. leaflet js map object)
-var g_map = null;
+// eslint-disable-next-line prefer-const
+let g_map = null;
 // Holds all map objects
-var g_map_objects = null;
+// eslint-disable-next-line prefer-const
+let g_map_objects = null;
 // Holds the view management object
-var g_view = null;
+let g_view = null;
 
 /**
  * Checks if a view is in maintenance mode and shows a message if
@@ -63,9 +65,9 @@ function inMaintenance(displayMsg) {
 function getHeaderHeight() {
     // Only gather the header height once.
     if (g_header_height_cache === null) {
-        var ret = 0;
+        let ret = 0;
 
-        var oHeader = document.getElementById("header");
+        const oHeader = document.getElementById("header");
         if (oHeader) {
             // Only return header height when header is shown
             if (oHeader.style.display != "none") ret = oHeader.clientHeight;
@@ -91,7 +93,7 @@ function logout() {
  * And simply reprints the response in the currently open window
  */
 function submitForm(sUrl, sFormId) {
-    var oResult = call_ajax(sUrl, {
+    const oResult = call_ajax(sUrl, {
         method: "POST",
         post_data: getFormParams(sFormId, false),
         response_handler: function (oResult) {
@@ -145,7 +147,7 @@ function showFrontendDialog(sUrl, sTitle, sWidth) {
  * @author  Lars Michelsen <lm@larsmichelsen.com>
  */
 function searchObjectsKeyCheck(sMatch, e) {
-    var charCode;
+    let charCode;
 
     if (e && e.which) {
         charCode = e.which;
@@ -169,15 +171,15 @@ function searchObjectsKeyCheck(sMatch, e) {
  * @author  Lars Michelsen <lm@larsmichelsen.com>
  */
 function searchObjects(sMatch) {
-    var aResults = [];
-    var bMatch = false;
+    const aResults = [];
+    let bMatch = false;
 
     // Skip empty searches or searches on non initialized views
     if (sMatch === "" || g_view === null) return false;
 
     // Loop all map objects and search the matching attributes
-    var obj;
-    for (var i in g_view.objects) {
+    let obj;
+    for (const i in g_view.objects) {
         obj = g_view.objects[i];
         // Don't search shapes/textboxes/lines
         if (
@@ -187,7 +189,7 @@ function searchObjects(sMatch) {
             obj.conf.type != "line"
         ) {
             bMatch = false;
-            var regex = new RegExp(sMatch, "g");
+            let regex = new RegExp(sMatch, "g");
 
             // Current matching attributes:
             // - type
@@ -212,8 +214,8 @@ function searchObjects(sMatch) {
     // Actions for the results:
     // When multiple found: highlight all
     // When single found: highlight and focus the object
-    for (i = 0, len = aResults.length; i < len; i++) {
-        var objectId = aResults[i];
+    for (let i = 0, len = aResults.length; i < len; i++) {
+        let objectId = aResults[i];
 
         // - highlight the object
         if (g_view.objects[objectId].conf.view_type && g_view.objects[objectId].conf.view_type === "icon") {
@@ -288,9 +290,9 @@ function refreshMapObject(event, objectId, only_state) {
     if (typeof only_state === "undefined") only_state = true;
 
     // Only append map param if it is a known map
-    var sMapPart = "";
-    var sMod = "";
-    var sAddPart = "";
+    let sMapPart = "";
+    let sMod = "";
+    let sAddPart = "";
     if (g_view.type === "map") {
         sMod = "Map";
         sMapPart = "&show=" + escapeUrlValues(g_view.id);
@@ -300,7 +302,7 @@ function refreshMapObject(event, objectId, only_state) {
         sMapPart = "";
     }
 
-    var ty = only_state ? "state" : "full";
+    const ty = only_state ? "state" : "full";
 
     // Start the ajax request to update this single object
     call_ajax(
@@ -336,9 +338,9 @@ function refreshMapObject(event, objectId, only_state) {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function playSound(objectId, iNumTimes) {
-    var sSound = "";
-    var id = g_view.objects[objectId].dom_obj.id;
-    var sState = g_view.objects[objectId].conf.summary_state;
+    let sSound = "";
+    const id = g_view.objects[objectId].dom_obj.id;
+    const sState = g_view.objects[objectId].conf.summary_state;
 
     if (oStates[sState] && oStates[sState].sound && oStates[sState].sound !== "") {
         sSound = oStates[sState].sound;
@@ -382,7 +384,7 @@ function flashIcon(objectId, iDuration, iInterval) {
     if (isset(g_view.objects[objectId])) {
         g_view.objects[objectId].highlight(!g_view.objects[objectId].bIsFlashing);
 
-        var iDurationNew = iDuration - iInterval;
+        const iDurationNew = iDuration - iInterval;
 
         // Flash again until timer counted down and the border is hidden
         if (iDurationNew > 0 || (iDurationNew <= 0 && g_view.objects[objectId].bIsFlashing === true))
@@ -400,13 +402,13 @@ function flashIcon(objectId, iDuration, iInterval) {
  * viewport, this function calculates the correct zoom factor.
  */
 function set_fill_zoom_factor() {
-    var obj, zoom;
-    var c_top = null,
+    let obj, zoom;
+    let c_top = null,
         c_left = null,
         c_bottom = null,
         c_right = null;
-    var o_top, o_left, o_bottom, o_right;
-    for (var i in g_view.objects) {
+    let o_top, o_left, o_bottom, o_right;
+    for (const i in g_view.objects) {
         obj = g_view.objects[i];
         if (obj && obj.getObjLeft && obj.getObjTop && obj.getObjHeight && obj.getObjWidth) {
             o_top = obj.getObjTop();
@@ -426,9 +428,9 @@ function set_fill_zoom_factor() {
     // In both cases c_bottom / c_right are null or 0, making the division below produce
     // NaN or Infinity which would corrupt the URL (zoom=NaN) and break the next load.
     if (!c_bottom || !c_right) return;
-    var border = 40; // border per side in px * 2
-    var zoom_y = parseInt(((pageHeight() - border - getHeaderHeight()) / parseFloat(c_bottom)) * 100);
-    var zoom_x = parseInt(((pageWidth() - border - getSidebarWidth()) / parseFloat(c_right)) * 100);
+    const border = 40; // border per side in px * 2
+    const zoom_y = parseInt(((pageHeight() - border - getHeaderHeight()) / parseFloat(c_bottom)) * 100);
+    const zoom_x = parseInt(((pageWidth() - border - getSidebarWidth()) / parseFloat(c_right)) * 100);
     if (!isFinite(zoom_y) || !isFinite(zoom_x)) return;
     set_zoom(Math.min(zoom_y, zoom_x));
 }
@@ -440,10 +442,10 @@ function set_zoom(val) {
 }
 
 function zoom(how) {
-    var cur_zoom = getZoomFactor();
+    let cur_zoom = getZoomFactor();
     // This is not really correct. Assume
     if (cur_zoom == "fill") cur_zoom = 100;
-    var new_zoom = 100;
+    let new_zoom = 100;
     if (how != 0) {
         new_zoom = cur_zoom + how;
 
@@ -458,7 +460,7 @@ function zoom(how) {
 function wheel_zoom(event) {
     if (!event) event = window.event;
 
-    var delta = 0;
+    let delta = 0;
 
     if (!event.altKey) return; // only proceed with pressed ALT
 
@@ -479,7 +481,7 @@ function wheel_zoom(event) {
     return preventDefaultEvents(event);
 }
 
-var g_drag_ind = null;
+let g_drag_ind = null;
 
 function zoombarDragStart(event) {
     if (!event) event = window.event;
@@ -501,9 +503,9 @@ function zoombarDrag(event) {
         return;
     }
 
-    var top_offset = 62;
-    var ind_offset = 3; // height / 2
-    var pos = event.clientY - top_offset;
+    const top_offset = 62;
+    const ind_offset = 3; // height / 2
+    let pos = event.clientY - top_offset;
 
     if (pos > g_drag_ind.parentNode.clientHeight) {
         pos = g_drag_ind.parentNode.clientHeight;
@@ -524,8 +526,8 @@ function zoombarDragStop(event) {
     g_left_clicked = false;
 
     // Get the zoom value
-    var zoom = getZoomFactor();
-    var val = parseInt(((100 - (parseInt(g_drag_ind.style.top.replace("px", "")) + 3)) / 100) * 200);
+    const zoom = getZoomFactor();
+    let val = parseInt(((100 - (parseInt(g_drag_ind.style.top.replace("px", "")) + 3)) / 100) * 200);
     if (val != zoom) {
         if (val <= 0) val = 10;
         set_zoom(val);
@@ -535,7 +537,7 @@ function zoombarDragStop(event) {
     return preventDefaultEvents(event);
 }
 
-var g_left_clicked = false;
+let g_left_clicked = false;
 
 function mouse_click(event) {
     if (!event) event = window.event;
@@ -556,8 +558,8 @@ function mouse_release(event) {
 }
 
 function updateZoomIndicator() {
-    var zoom = getZoomFactor();
-    var ind = document.getElementById("zoombar-drag_ind");
+    const zoom = getZoomFactor();
+    let ind = document.getElementById("zoombar-drag_ind");
 
     // zoom is 0 to 200, the bar is 0px to 100px, the
     // indicator has a heihgt of 6px
@@ -571,10 +573,10 @@ function updateZoomIndicator() {
 function renderZoombar() {
     if (getViewParam("zoombar") == 0) return;
 
-    var bar = document.createElement("div");
+    const bar = document.createElement("div");
     bar.setAttribute("id", "zoombar");
 
-    var plus = document.createElement("a");
+    const plus = document.createElement("a");
     plus.setAttribute("id", "zoombar-plus");
     plus.setAttribute("class", "plus");
     plus.appendChild(document.createTextNode("+"));
@@ -583,12 +585,12 @@ function renderZoombar() {
     };
     bar.appendChild(plus);
 
-    var drag = document.createElement("div");
+    const drag = document.createElement("div");
     drag.setAttribute("id", "zoombar-drag");
     drag.setAttribute("class", "drag");
     bar.appendChild(drag);
 
-    var drag_ind = document.createElement("div");
+    const drag_ind = document.createElement("div");
     drag_ind.setAttribute("id", "zoombar-drag_ind");
     drag_ind.setAttribute("class", "drag_ind");
     addEvent(drag_ind, "mousedown", zoombarDragStart);
@@ -596,7 +598,7 @@ function renderZoombar() {
     addEvent(drag, "mouseup", zoombarDragStop);
     drag.appendChild(drag_ind);
 
-    var minus = document.createElement("a");
+    const minus = document.createElement("a");
     minus.setAttribute("id", "zoombar-minus");
     minus.setAttribute("class", "minus");
     minus.appendChild(document.createTextNode("-"));
@@ -605,7 +607,7 @@ function renderZoombar() {
     };
     bar.appendChild(minus);
 
-    var norm = document.createElement("a");
+    const norm = document.createElement("a");
     norm.setAttribute("class", "norm");
     norm.appendChild(document.createTextNode("o"));
     norm.onclick = function () {
@@ -614,7 +616,7 @@ function renderZoombar() {
     bar.appendChild(norm);
 
     // Register scroll events (mouse wheel)
-    var wheel_event = /Firefox/i.test(navigator.userAgent) ? "DOMMouseScroll" : "mousewheel";
+    const wheel_event = /Firefox/i.test(navigator.userAgent) ? "DOMMouseScroll" : "mousewheel";
     addEvent(document, wheel_event, wheel_zoom);
     addEvent(document, "mousedown", mouse_click);
     addEvent(document, "mouseup", mouse_release);
@@ -639,7 +641,7 @@ function renderZoombar() {
 function getViewParams(update, userParams) {
     if (!isset(userParams)) userParams = false;
 
-    var params;
+    let params;
     if (!userParams && isset(oViewProperties) && isset(oViewProperties["params"])) {
         params = oViewProperties["params"];
     } else if (isset(oViewProperties) && isset(oViewProperties["user_params"])) {
@@ -652,7 +654,7 @@ function getViewParams(update, userParams) {
 
     // Udate the params before processing url
     if (isset(update)) {
-        for (var param in update) {
+        for (const param in update) {
             params[param] = update[param];
         }
     }
@@ -665,8 +667,8 @@ function getViewParams(update, userParams) {
         params["bbox"] = bounds.toBBoxString();
     }
 
-    var sParams = "";
-    for (param in params) {
+    let sParams = "";
+    for (const param in params) {
         if (params[param] != "") {
             sParams += "&" + param + "=" + escapeUrlValues(params[param]);
         }
@@ -705,7 +707,7 @@ function usesSource(source) {
 // features. If not, an error message is shown and further page processing
 // will be terminated.
 function hasNeededJSFeatures() {
-    var msg = null;
+    let msg = null;
     if (typeof JSON === "undefined") {
         msg =
             "It seems you are using an outdated browser to access NagVis. " +

--- a/share/frontend/nagvis-js/js/frontend.js
+++ b/share/frontend/nagvis-js/js/frontend.js
@@ -39,16 +39,18 @@ var g_view = null;
  * to check if the mainentance mode has finished
  */
 function inMaintenance(displayMsg) {
-    if(!isset(displayMsg))
-        var displayMsg = true;
-    if(oPageProperties && oPageProperties.in_maintenance === '1') {
+    if (!isset(displayMsg)) var displayMsg = true;
+    if (oPageProperties && oPageProperties.in_maintenance === "1") {
         hideStatusMessage();
-        if(displayMsg)
-            frontendMessage({
-                'type': 'note',
-                'title': 'Maintenance',
-                'message': 'The current page is in maintenance mode.<br />Please be patient.'
-            }, 'maintenance');
+        if (displayMsg)
+            frontendMessage(
+                {
+                    type: "note",
+                    title: "Maintenance",
+                    message: "The current page is in maintenance mode.<br />Please be patient."
+                },
+                "maintenance"
+            );
         return true;
     } else {
         return false;
@@ -60,14 +62,13 @@ function inMaintenance(displayMsg) {
  */
 function getHeaderHeight() {
     // Only gather the header height once.
-    if(g_header_height_cache === null) {
+    if (g_header_height_cache === null) {
         var ret = 0;
 
-        var oHeader = document.getElementById('header');
-        if(oHeader) {
+        var oHeader = document.getElementById("header");
+        if (oHeader) {
             // Only return header height when header is shown
-            if(oHeader.style.display != 'none')
-                ret = oHeader.clientHeight;
+            if (oHeader.style.display != "none") ret = oHeader.clientHeight;
         }
 
         g_header_height_cache = ret;
@@ -77,10 +78,9 @@ function getHeaderHeight() {
 }
 
 function logout() {
-    call_ajax(oGeneralProperties.path_server+'?mod=Auth&act=logout', {
-        response_handler: function(response) {
-            if (response)
-                window.location.reload();
+    call_ajax(oGeneralProperties.path_server + "?mod=Auth&act=logout", {
+        response_handler: function (response) {
+            if (response) window.location.reload();
         },
         decode_json: false
     });
@@ -92,14 +92,13 @@ function logout() {
  */
 function submitForm(sUrl, sFormId) {
     var oResult = call_ajax(sUrl, {
-        method    : "POST",
-        post_data : getFormParams(sFormId, false),
-        response_handler : function(oResult) {
+        method: "POST",
+        post_data: getFormParams(sFormId, false),
+        response_handler: function (oResult) {
             if (oResult && oResult.type) {
                 // In case of an error show message and close the window
                 frontendMessage(oResult);
-                if (typeof popupWindowClose == 'function')
-                    popupWindowClose();
+                if (typeof popupWindowClose == "function") popupWindowClose();
             } else {
                 popupWindowPutContent(oResult);
             }
@@ -108,24 +107,24 @@ function submitForm(sUrl, sFormId) {
 }
 
 function updateForm(form) {
-    form._update.value = '1';
+    form._update.value = "1";
     form._submit.click();
 }
 
 function clearFormValue(id) {
-    document.getElementById(id).value = '';
+    document.getElementById(id).value = "";
 }
 
 function showFrontendDialog(sUrl, sTitle, sWidth) {
     call_ajax(sUrl, {
-        response_handler: function(response, data) {
+        response_handler: function (response, data) {
             if (isset(response)) {
                 // Store url for maybe later refresh
                 response.url = sUrl;
 
-                if(typeof response !== 'undefined' && typeof response.code !== 'undefined') {
+                if (typeof response !== "undefined" && typeof response.code !== "undefined") {
                     let width = data.sWidth || 450;
-                    if (response.object_type === 'textbox') width = 800
+                    if (response.object_type === "textbox") width = 800;
                     popupWindow(data.title, response, width);
                 }
             }
@@ -135,7 +134,6 @@ function showFrontendDialog(sUrl, sTitle, sWidth) {
             width: sWidth
         }
     });
-
 }
 
 /**
@@ -149,15 +147,15 @@ function showFrontendDialog(sUrl, sTitle, sWidth) {
 function searchObjectsKeyCheck(sMatch, e) {
     var charCode;
 
-    if(e && e.which) {
+    if (e && e.which) {
         charCode = e.which;
-    } else if(window.event) {
+    } else if (window.event) {
         e = window.event;
         charCode = e.keyCode;
     }
 
     // Search on enter key press
-    if(charCode == 13) {
+    if (charCode == 13) {
         searchObjects(sMatch);
     }
 }
@@ -175,42 +173,38 @@ function searchObjects(sMatch) {
     var bMatch = false;
 
     // Skip empty searches or searches on non initialized views
-    if (sMatch === '' || g_view === null)
-        return false;
+    if (sMatch === "" || g_view === null) return false;
 
     // Loop all map objects and search the matching attributes
     var obj;
-    for(var i in g_view.objects) {
+    for (var i in g_view.objects) {
         obj = g_view.objects[i];
         // Don't search shapes/textboxes/lines
-        if(obj.conf.type != 'shape'
-           && obj.conf.type != 'textbox'
-           && obj.conf.type != 'container'
-             && obj.conf.type != 'line') {
+        if (
+            obj.conf.type != "shape" &&
+            obj.conf.type != "textbox" &&
+            obj.conf.type != "container" &&
+            obj.conf.type != "line"
+        ) {
             bMatch = false;
-            var regex = new RegExp(sMatch, 'g');
+            var regex = new RegExp(sMatch, "g");
 
             // Current matching attributes:
             // - type
             // - name1
             // - name2
 
-            if(obj.conf.type.search(regex) !== -1)
-                bMatch = true;
+            if (obj.conf.type.search(regex) !== -1) bMatch = true;
 
-            if(obj.conf.name.search(regex) !== -1)
-                bMatch = true;
+            if (obj.conf.name.search(regex) !== -1) bMatch = true;
 
             // only search the service_description on service objects
-            if(obj.conf.type === 'service'
-                   && obj.conf.service_description.search(regex) !== -1)
-                bMatch = true;
+            if (obj.conf.type === "service" && obj.conf.service_description.search(regex) !== -1) bMatch = true;
 
             regex = null;
 
             // Found some match?
-            if(bMatch === true)
-                aResults.push(i);
+            if (bMatch === true) aResults.push(i);
         }
     }
     obj = null;
@@ -218,23 +212,35 @@ function searchObjects(sMatch) {
     // Actions for the results:
     // When multiple found: highlight all
     // When single found: highlight and focus the object
-    for(var i = 0, len = aResults.length; i < len; i++) {
+    for (var i = 0, len = aResults.length; i < len; i++) {
         var objectId = aResults[i];
 
         // - highlight the object
-        if(g_view.objects[objectId].conf.view_type && g_view.objects[objectId].conf.view_type === 'icon') {
+        if (g_view.objects[objectId].conf.view_type && g_view.objects[objectId].conf.view_type === "icon") {
             // Detach the handler
             //  Had problems with this. Could not give the index to function:
             //  function() { flashIcon(iIndex, 10); iIndex = null; }
-            setTimeout('flashIcon("'+objectId+'", '+oPageProperties.event_highlight_duration+', '+oPageProperties.event_highlight_interval+')', 0);
+            setTimeout(
+                'flashIcon("' +
+                    objectId +
+                    '", ' +
+                    oPageProperties.event_highlight_duration +
+                    ", " +
+                    oPageProperties.event_highlight_interval +
+                    ")",
+                0
+            );
         } else {
             // FIXME: Atm only flash icons, not lines or gadgets
         }
 
         // - Scroll to object
-        if(len == 1) {
+        if (len == 1) {
             // Detach the handler
-            setTimeout('scrollSlow('+g_view.objects[objectId].parsedX()+', '+g_view.objects[objectId].parsedY()+', 1)', 0);
+            setTimeout(
+                "scrollSlow(" + g_view.objects[objectId].parsedX() + ", " + g_view.objects[objectId].parsedY() + ", 1)",
+                0
+            );
         }
 
         objectId = null;
@@ -244,7 +250,7 @@ function searchObjects(sMatch) {
 function getMapObjByDomObjId(id) {
     try {
         return g_view.objects[id];
-    } catch(er) {
+    } catch (er) {
         return null;
     }
 }
@@ -253,55 +259,71 @@ function getMapObjByDomObjId(id) {
  * Shows the add/modify frontend dialog for the given object
  */
 function showAddModifyDialog(mapname, objectId) {
-    showFrontendDialog(oGeneralProperties.path_server
-                       + '?mod=Map&act=addModify&show='
-                       + escapeUrlValues(mapname)
-                       + '&object_id=' + escapeUrlValues(objectId), 'Modify Object');
-
+    showFrontendDialog(
+        oGeneralProperties.path_server +
+            "?mod=Map&act=addModify&show=" +
+            escapeUrlValues(mapname) +
+            "&object_id=" +
+            escapeUrlValues(objectId),
+        "Modify Object"
+    );
 }
 
 /**
  * Shows the dialog to acknowledge host/service problems
  */
 function showAckDialog(map_name, objectId) {
-    showFrontendDialog(oGeneralProperties.path_server
-                       + '?mod=Action&act=acknowledge&map=' + escapeUrlValues(map_name)
-                       + '&object_id=' + escapeUrlValues(objectId), 'Acknowledge Problem');
+    showFrontendDialog(
+        oGeneralProperties.path_server +
+            "?mod=Action&act=acknowledge&map=" +
+            escapeUrlValues(map_name) +
+            "&object_id=" +
+            escapeUrlValues(objectId),
+        "Acknowledge Problem"
+    );
 }
 
 // Handles manual map object update triggered by e.g. the context menu
 function refreshMapObject(event, objectId, only_state) {
-    if (typeof only_state === 'undefined')
-        only_state = true;
+    if (typeof only_state === "undefined") only_state = true;
 
     // Only append map param if it is a known map
-    var sMapPart = '';
-    var sMod = '';
-    var sAddPart = '';
-    if (g_view.type === 'map') {
-        sMod = 'Map';
-        sMapPart = '&show='+escapeUrlValues(g_view.id);
+    var sMapPart = "";
+    var sMod = "";
+    var sAddPart = "";
+    if (g_view.type === "map") {
+        sMod = "Map";
+        sMapPart = "&show=" + escapeUrlValues(g_view.id);
         sAddPart = getViewParams();
-    }
-    else if (g_view.type === 'overview') {
-        sMod = 'Overview';
-        sMapPart = '';
+    } else if (g_view.type === "overview") {
+        sMod = "Overview";
+        sMapPart = "";
     }
 
-    var ty = only_state ? 'state' : 'full';
+    var ty = only_state ? "state" : "full";
 
     // Start the ajax request to update this single object
-    call_ajax(oGeneralProperties.path_server+'?mod=' + sMod + '&act=getObjectStates'
-              + sMapPart + '&ty='+ty+'&i[]=' + objectId + sAddPart, {
-        response_handler: function(response) {
-            g_view.updateObjects(response, only_state);
+    call_ajax(
+        oGeneralProperties.path_server +
+            "?mod=" +
+            sMod +
+            "&act=getObjectStates" +
+            sMapPart +
+            "&ty=" +
+            ty +
+            "&i[]=" +
+            objectId +
+            sAddPart,
+        {
+            response_handler: function (response) {
+                g_view.updateObjects(response, only_state);
+            }
         }
-    });
+    );
 
     // event might be null in case this is not called by context menu,
     // but instead directly when adding/modifying an object
-    if (event)
-        return preventDefaultEvents(event);
+    if (event) return preventDefaultEvents(event);
 }
 
 /**
@@ -313,26 +335,35 @@ function refreshMapObject(event, objectId, only_state) {
  * @param   Integer  Iterator for number of left runs
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
-function playSound(objectId, iNumTimes){
-    var sSound = '';
+function playSound(objectId, iNumTimes) {
+    var sSound = "";
     var id = g_view.objects[objectId].dom_obj.id;
     var sState = g_view.objects[objectId].conf.summary_state;
 
-    if(oStates[sState] && oStates[sState].sound && oStates[sState].sound !== '') {
+    if (oStates[sState] && oStates[sState].sound && oStates[sState].sound !== "") {
         sSound = oStates[sState].sound;
     }
 
-    eventlog("state-change", "debug", "Sound to play: "+sSound);
+    eventlog("state-change", "debug", "Sound to play: " + sSound);
 
-    if(sSound !== '') {
-        const audio = new Audio(window.location.protocol + '//' + window.location.hostname + ':'
-                                                 	+ window.location.port + oGeneralProperties.path_sounds+sSound);
+    if (sSound !== "") {
+        const audio = new Audio(
+            window.location.protocol +
+                "//" +
+                window.location.hostname +
+                ":" +
+                window.location.port +
+                oGeneralProperties.path_sounds +
+                sSound
+        );
         audio.play();
 
         iNumTimes = iNumTimes - 1;
 
-        if(iNumTimes > 0) {
-            setTimeout(function() { playSound(objectId, iNumTimes); }, 500);
+        if (iNumTimes > 0) {
+            setTimeout(function () {
+                playSound(objectId, iNumTimes);
+            }, 500);
         }
     }
 }
@@ -347,15 +378,17 @@ function playSound(objectId, iNumTimes){
  * @param   Integer  Interval in miliseconds
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
-function flashIcon(objectId, iDuration, iInterval){
-    if(isset(g_view.objects[objectId])) {
+function flashIcon(objectId, iDuration, iInterval) {
+    if (isset(g_view.objects[objectId])) {
         g_view.objects[objectId].highlight(!g_view.objects[objectId].bIsFlashing);
 
         var iDurationNew = iDuration - iInterval;
 
         // Flash again until timer counted down and the border is hidden
-        if(iDurationNew > 0 || (iDurationNew <= 0 && g_view.objects[objectId].bIsFlashing === true))
-            setTimeout(function() { flashIcon(objectId, iDurationNew, iInterval); }, iInterval);
+        if (iDurationNew > 0 || (iDurationNew <= 0 && g_view.objects[objectId].bIsFlashing === true))
+            setTimeout(function () {
+                flashIcon(objectId, iDurationNew, iInterval);
+            }, iInterval);
     }
 }
 
@@ -368,59 +401,53 @@ function flashIcon(objectId, iDuration, iInterval){
  */
 function set_fill_zoom_factor() {
     var obj, zoom;
-    var c_top = null, c_left = null, c_bottom = null, c_right = null;
+    var c_top = null,
+        c_left = null,
+        c_bottom = null,
+        c_right = null;
     var o_top, o_left, o_bottom, o_right;
-    for(var i in g_view.objects) {
+    for (var i in g_view.objects) {
         obj = g_view.objects[i];
         if (obj && obj.getObjLeft && obj.getObjTop && obj.getObjHeight && obj.getObjWidth) {
             o_top = obj.getObjTop();
-            if (c_top === null || o_top < c_top)
-                c_top = o_top;
+            if (c_top === null || o_top < c_top) c_top = o_top;
 
             o_left = obj.getObjLeft();
-            if (c_left === null || o_left < c_left)
-                c_left = o_left;
+            if (c_left === null || o_left < c_left) c_left = o_left;
 
             o_bottom = o_top + obj.getObjHeight();
-            if (c_bottom === null || o_bottom > c_bottom)
-                c_bottom = o_bottom;
+            if (c_bottom === null || o_bottom > c_bottom) c_bottom = o_bottom;
 
             o_right = o_left + obj.getObjWidth();
-            if (c_right === null || o_right > c_right)
-                c_right = o_right;
+            if (c_right === null || o_right > c_right) c_right = o_right;
         }
     }
     // Guard: no objects on the map, or all objects sit at y=0 with zero height/width.
     // In both cases c_bottom / c_right are null or 0, making the division below produce
     // NaN or Infinity which would corrupt the URL (zoom=NaN) and break the next load.
-    if (!c_bottom || !c_right)
-        return;
+    if (!c_bottom || !c_right) return;
     var border = 40; // border per side in px * 2
-    var zoom_y = parseInt((pageHeight() - border - getHeaderHeight()) / parseFloat(c_bottom) * 100);
-    var zoom_x = parseInt((pageWidth() - border - getSidebarWidth())/ parseFloat(c_right) * 100);
-    if (!isFinite(zoom_y) || !isFinite(zoom_x))
-        return;
+    var zoom_y = parseInt(((pageHeight() - border - getHeaderHeight()) / parseFloat(c_bottom)) * 100);
+    var zoom_x = parseInt(((pageWidth() - border - getSidebarWidth()) / parseFloat(c_right)) * 100);
+    if (!isFinite(zoom_y) || !isFinite(zoom_x)) return;
     set_zoom(Math.min(zoom_y, zoom_x));
 }
 
 function set_zoom(val) {
-    setViewParam('zoom', val);
-    if (g_worker_id)
-        window.clearTimeout(g_worker_id);
-    window.location = makeuri({'zoom': val});
+    setViewParam("zoom", val);
+    if (g_worker_id) window.clearTimeout(g_worker_id);
+    window.location = makeuri({ zoom: val });
 }
 
 function zoom(how) {
     var cur_zoom = getZoomFactor();
     // This is not really correct. Assume
-    if (cur_zoom == 'fill')
-        cur_zoom = 100;
+    if (cur_zoom == "fill") cur_zoom = 100;
     var new_zoom = 100;
     if (how != 0) {
         new_zoom = cur_zoom + how;
 
-        if (new_zoom <= 0 || new_zoom >= 200)
-            return;
+        if (new_zoom <= 0 || new_zoom >= 200) return;
     }
 
     if (cur_zoom != new_zoom) {
@@ -429,18 +456,18 @@ function zoom(how) {
 }
 
 function wheel_zoom(event) {
-    if (!event)
-        event = window.event;
+    if (!event) event = window.event;
 
     var delta = 0;
 
-    if (!event.altKey)
-        return; // only proceed with pressed ALT
+    if (!event.altKey) return; // only proceed with pressed ALT
 
-    if (event.wheelDelta) { // IE/Opera.
-        delta = event.wheelDelta/120;
-    } else if (event.detail) { // firefox
-        delta = -event.detail/3;
+    if (event.wheelDelta) {
+        // IE/Opera.
+        delta = event.wheelDelta / 120;
+    } else if (event.detail) {
+        // firefox
+        delta = -event.detail / 3;
     }
 
     if (delta > 0) {
@@ -455,22 +482,18 @@ function wheel_zoom(event) {
 var g_drag_ind = null;
 
 function zoombarDragStart(event) {
-    if (!event)
-        event = window.event;
+    if (!event) event = window.event;
 
-    if ((event.which === null && event.button >= 2) || (event.which !== null && event.which >= 2))
-        return; // skip clicks with other than left mouse
+    if ((event.which === null && event.button >= 2) || (event.which !== null && event.which >= 2)) return; // skip clicks with other than left mouse
 
     g_left_clicked = true;
-    g_drag_ind = document.getElementById('zoombar-drag_ind');
+    g_drag_ind = document.getElementById("zoombar-drag_ind");
 }
 
 function zoombarDrag(event) {
-    if (!event)
-        event = window.event;
+    if (!event) event = window.event;
 
-    if (g_drag_ind === null)
-        return true;
+    if (g_drag_ind === null) return true;
 
     // Is the mouse still pressed? if not, stop dragging!
     if (!g_left_clicked) {
@@ -480,7 +503,7 @@ function zoombarDrag(event) {
 
     var top_offset = 62;
     var ind_offset = 3; // height / 2
-    var pos = (event.clientY - top_offset);
+    var pos = event.clientY - top_offset;
 
     if (pos > g_drag_ind.parentNode.clientHeight) {
         pos = g_drag_ind.parentNode.clientHeight;
@@ -488,27 +511,23 @@ function zoombarDrag(event) {
         pos = 0;
     }
 
-    g_drag_ind.style.top = (pos - ind_offset) + 'px';
+    g_drag_ind.style.top = pos - ind_offset + "px";
 }
 
 function zoombarDragStop(event) {
-    if (!event)
-        event = window.event;
+    if (!event) event = window.event;
 
-    if (g_drag_ind === null)
-        return true;
+    if (g_drag_ind === null) return true;
 
-    if ((event.which === null && event.button >= 2) || (event.which !== null && event.which >= 2))
-        return; // skip clicks with other than left mouse
+    if ((event.which === null && event.button >= 2) || (event.which !== null && event.which >= 2)) return; // skip clicks with other than left mouse
 
     g_left_clicked = false;
 
     // Get the zoom value
     var zoom = getZoomFactor();
-    var val = parseInt((100 - (parseInt(g_drag_ind.style.top.replace('px', '')) + 3)) / 100 * 200);
+    var val = parseInt(((100 - (parseInt(g_drag_ind.style.top.replace("px", "")) + 3)) / 100) * 200);
     if (val != zoom) {
-        if (val <= 0)
-            val = 10;
+        if (val <= 0) val = 10;
         set_zoom(val);
     }
 
@@ -519,21 +538,17 @@ function zoombarDragStop(event) {
 var g_left_clicked = false;
 
 function mouse_click(event) {
-    if (!event)
-        event = window.event;
+    if (!event) event = window.event;
 
-    if ((event.which === null && event.button >= 2) || (event.which !== null && event.which >= 2))
-        return; // skip clicks with other than left mouse
+    if ((event.which === null && event.button >= 2) || (event.which !== null && event.which >= 2)) return; // skip clicks with other than left mouse
 
     g_left_clicked = true;
 }
 
 function mouse_release(event) {
-    if (!event)
-        event = window.event;
+    if (!event) event = window.event;
 
-    if ((event.which === null && event.button >= 2) || (event.which !== null && event.which >= 2))
-        return; // skip clicks with other than left mouse
+    if ((event.which === null && event.button >= 2) || (event.which !== null && event.which >= 2)) return; // skip clicks with other than left mouse
 
     g_left_clicked = false;
 
@@ -542,11 +557,11 @@ function mouse_release(event) {
 
 function updateZoomIndicator() {
     var zoom = getZoomFactor();
-    var ind = document.getElementById('zoombar-drag_ind');
+    var ind = document.getElementById("zoombar-drag_ind");
 
     // zoom is 0 to 200, the bar is 0px to 100px, the
     // indicator has a heihgt of 6px
-    ind.style.top = (100 - ((zoom / 200 * 100)) - 3) + 'px';
+    ind.style.top = 100 - (zoom / 200) * 100 - 3 + "px";
     ind = null;
 }
 
@@ -554,56 +569,55 @@ function updateZoomIndicator() {
  * Zoom bar rendering
  */
 function renderZoombar() {
-    if (getViewParam('zoombar') == 0)
-        return;
+    if (getViewParam("zoombar") == 0) return;
 
-    var bar = document.createElement('div');
-    bar.setAttribute('id', 'zoombar');
+    var bar = document.createElement("div");
+    bar.setAttribute("id", "zoombar");
 
-    var plus = document.createElement('a');
-    plus.setAttribute('id', 'zoombar-plus');
-    plus.setAttribute('class', 'plus');
-    plus.appendChild(document.createTextNode('+'));
-    plus.onclick = function() {
+    var plus = document.createElement("a");
+    plus.setAttribute("id", "zoombar-plus");
+    plus.setAttribute("class", "plus");
+    plus.appendChild(document.createTextNode("+"));
+    plus.onclick = function () {
         zoom(10);
     };
     bar.appendChild(plus);
 
-    var drag = document.createElement('div');
-    drag.setAttribute('id', 'zoombar-drag');
-    drag.setAttribute('class', 'drag');
+    var drag = document.createElement("div");
+    drag.setAttribute("id", "zoombar-drag");
+    drag.setAttribute("class", "drag");
     bar.appendChild(drag);
 
-    var drag_ind = document.createElement('div');
-    drag_ind.setAttribute('id', 'zoombar-drag_ind');
-    drag_ind.setAttribute('class', 'drag_ind');
-    addEvent(drag_ind, 'mousedown', zoombarDragStart);
-    addEvent(drag,     'mousemove', zoombarDrag);
-    addEvent(drag,     'mouseup',   zoombarDragStop);
+    var drag_ind = document.createElement("div");
+    drag_ind.setAttribute("id", "zoombar-drag_ind");
+    drag_ind.setAttribute("class", "drag_ind");
+    addEvent(drag_ind, "mousedown", zoombarDragStart);
+    addEvent(drag, "mousemove", zoombarDrag);
+    addEvent(drag, "mouseup", zoombarDragStop);
     drag.appendChild(drag_ind);
 
-    var minus = document.createElement('a');
-    minus.setAttribute('id', 'zoombar-minus');
-    minus.setAttribute('class', 'minus');
-    minus.appendChild(document.createTextNode('-'));
-    minus.onclick = function() {
+    var minus = document.createElement("a");
+    minus.setAttribute("id", "zoombar-minus");
+    minus.setAttribute("class", "minus");
+    minus.appendChild(document.createTextNode("-"));
+    minus.onclick = function () {
         zoom(-10);
     };
     bar.appendChild(minus);
 
-    var norm = document.createElement('a');
-    norm.setAttribute('class', 'norm');
-    norm.appendChild(document.createTextNode('o'));
-    norm.onclick = function() {
+    var norm = document.createElement("a");
+    norm.setAttribute("class", "norm");
+    norm.appendChild(document.createTextNode("o"));
+    norm.onclick = function () {
         zoom(0);
     };
     bar.appendChild(norm);
 
     // Register scroll events (mouse wheel)
-    var wheel_event = (/Firefox/i.test(navigator.userAgent)) ? "DOMMouseScroll" : "mousewheel";
+    var wheel_event = /Firefox/i.test(navigator.userAgent) ? "DOMMouseScroll" : "mousewheel";
     addEvent(document, wheel_event, wheel_zoom);
-    addEvent(document, 'mousedown', mouse_click);
-    addEvent(document, 'mouseup',   mouse_release);
+    addEvent(document, "mousedown", mouse_click);
+    addEvent(document, "mouseup", mouse_release);
 
     document.body.appendChild(bar);
     updateZoomIndicator();
@@ -623,39 +637,37 @@ function renderZoombar() {
  * complete set of final parameters is returned.
  */
 function getViewParams(update, userParams) {
-    if(!isset(userParams))
-        userParams = false;
+    if (!isset(userParams)) userParams = false;
 
-    if(!userParams && isset(oViewProperties) && isset(oViewProperties['params'])) {
-        var params = oViewProperties['params'];
-    } else if(isset(oViewProperties) && isset(oViewProperties['user_params'])) {
-        var params = oViewProperties['user_params'];
-    } else if(update) {
-        var params = {}
+    if (!userParams && isset(oViewProperties) && isset(oViewProperties["params"])) {
+        var params = oViewProperties["params"];
+    } else if (isset(oViewProperties) && isset(oViewProperties["user_params"])) {
+        var params = oViewProperties["user_params"];
+    } else if (update) {
+        var params = {};
     } else {
-        return '';
+        return "";
     }
 
     // Udate the params before processing url
-    if(isset(update)) {
-        for(var param in update) {
+    if (isset(update)) {
+        for (var param in update) {
             params[param] = update[param];
         }
     }
 
-    if(!isset(params))
-        return '';
+    if (!isset(params)) return "";
 
-    if (g_map && usesSource('worldmap')) {
+    if (g_map && usesSource("worldmap")) {
         let bounds = g_map.getBounds();
         bounds = bounds.pad(0.95); // also load objects within 95% beyond actual viewport (better dragging experience)
-        params['bbox'] = bounds.toBBoxString();
+        params["bbox"] = bounds.toBBoxString();
     }
 
-    var sParams = '';
-    for(var param in params) {
-        if(params[param] != '') {
-            sParams += '&' + param + '=' + escapeUrlValues(params[param]);
+    var sParams = "";
+    for (var param in params) {
+        if (params[param] != "") {
+            sParams += "&" + param + "=" + escapeUrlValues(params[param]);
         }
     }
 
@@ -671,24 +683,21 @@ function getViewParams(update, userParams) {
  * The PHP backend computes all the parameters
  */
 function getViewParam(param) {
-    if (oViewProperties && isset(oViewProperties['params'])
-        && isset(oViewProperties['params'][param]))
-        return oViewProperties['params'][param];
+    if (oViewProperties && isset(oViewProperties["params"]) && isset(oViewProperties["params"][param]))
+        return oViewProperties["params"][param];
     return null;
 }
 
 function setViewParam(param, val) {
-    oViewProperties['params'][param] = val;
-    oViewProperties['user_params'][param] = val;
+    oViewProperties["params"][param] = val;
+    oViewProperties["user_params"][param] = val;
 }
 
 // Returns true if the current view is
 // a) a map
 // b) uses the given source
 function usesSource(source) {
-    return oPageProperties
-        && oPageProperties.sources
-        && oPageProperties.sources.indexOf(source) !== -1;
+    return oPageProperties && oPageProperties.sources && oPageProperties.sources.indexOf(source) !== -1;
 }
 
 // Checks whether or not the users browser has the needed javascript
@@ -696,18 +705,19 @@ function usesSource(source) {
 // will be terminated.
 function hasNeededJSFeatures() {
     var msg = null;
-    if (typeof JSON === 'undefined') {
-        msg = 'It seems you are using an outdated browser to access NagVis. '
-             +'I am sorry, but you will not be able to use NagVis with this '
-             +'old browser. Please consider updating. (Missing JSON)';
+    if (typeof JSON === "undefined") {
+        msg =
+            "It seems you are using an outdated browser to access NagVis. " +
+            "I am sorry, but you will not be able to use NagVis with this " +
+            "old browser. Please consider updating. (Missing JSON)";
     }
 
     if (msg) {
         frontendMessage({
-            'type'     : 'error',
-            'title'    : 'Error: Outdated Browser',
-            'message'  : msg,
-            'closable' : false
+            type: "error",
+            title: "Error: Outdated Browser",
+            message: msg,
+            closable: false
         });
         return false;
     } else {
@@ -717,35 +727,32 @@ function hasNeededJSFeatures() {
 
 // Does the initial parsing of the pages
 function workerInitialize(type, ident) {
-    displayStatusMessage('Loading...', 'loading', true);
+    displayStatusMessage("Loading...", "loading", true);
 
     // Initialize the view objects. This code should not perform any rendering
     // taks. This is only meant to initialize all needed objects
     switch (type) {
-        case 'map':
-            if (usesSource('worldmap'))
-                g_view = new ViewWorldmap(ident);
-            else
-                g_view = new ViewMap(ident);
-        break;
-        case 'overview':
+        case "map":
+            if (usesSource("worldmap")) g_view = new ViewWorldmap(ident);
+            else g_view = new ViewMap(ident);
+            break;
+        case "overview":
             g_view = new ViewOverview();
-        break;
-        case 'url':
+            break;
+        case "url":
             g_view = new ViewUrl(ident);
-        break;
+            break;
         default:
-            eventlog("worker", "error", "Unknown view type: "+type);
+            eventlog("worker", "error", "Unknown view type: " + type);
             hideStatusMessage();
             return;
     }
     g_view.init();
 }
 
-
 // Updates the page on a regular base
 function workerUpdate(iCount, sType, sIdentifier) {
-    eventlog("worker", "debug", "Update (Run-ID: "+iCount+")");
+    eventlog("worker", "debug", "Update (Run-ID: " + iCount + ")");
     oWorkerProperties.last_run = iNow;
     g_view.update();
     updateWorkerCounter(); // Update the worker last run time on maps
@@ -774,9 +781,8 @@ function workerUpdate(iCount, sType, sIdentifier) {
 function runWorker(iCount, sType, sIdentifier) {
     // If the iterator is 0 it is the first run of the worker. Its only task is
     // to render the page
-    if(iCount === 0) {
-        if (!hasNeededJSFeatures())
-            return; // sorry!
+    if (iCount === 0) {
+        if (!hasNeededJSFeatures()) return; // sorry!
         workerInitialize(sType, sIdentifier);
     } else {
         /**
@@ -789,7 +795,7 @@ function runWorker(iCount, sType, sIdentifier) {
         // Not handled by ajax frontend. Reload the page with the new url
         // If it returns true this means that the page is being changed: Stop the
         // worker.
-        if(rotationCountdown() === true) {
+        if (rotationCountdown() === true) {
             eventlog("worker", "debug", "Worker stopped: Rotate/Refresh detected");
             return false;
         }
@@ -797,12 +803,11 @@ function runWorker(iCount, sType, sIdentifier) {
         /**
          * Do these actions every X runs (Every worker_interval seconds)
          */
-        if(iCount % oWorkerProperties.worker_interval === 0)
-            workerUpdate(iCount, sType, sIdentifier);
+        if (iCount % oWorkerProperties.worker_interval === 0) workerUpdate(iCount, sType, sIdentifier);
     }
 
     // Sleep until next worker run (1 Second)
-    g_worker_id = window.setTimeout(function() {
-        runWorker((iCount+1), sType, sIdentifier);
+    g_worker_id = window.setTimeout(function () {
+        runWorker(iCount + 1, sType, sIdentifier);
     }, 1000);
 }

--- a/share/frontend/nagvis-js/js/frontendEventlog.js
+++ b/share/frontend/nagvis-js/js/frontendEventlog.js
@@ -25,9 +25,9 @@
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 
-var _eventlog = null;
+let _eventlog = null;
 
-var oSeverity = {
+const oSeverity = {
     debug: 4,
     info: 3,
     warning: 2,
@@ -36,8 +36,8 @@ var oSeverity = {
 };
 
 function eventlogToggle(store) {
-    var oLog = document.getElementById("eventlog");
-    var oLogControl = document.getElementById("eventlogControl");
+    let oLog = document.getElementById("eventlog");
+    const oLogControl = document.getElementById("eventlogControl");
 
     if (store === true) storeUserOption("eventlog", oLog.style.display == "none");
 
@@ -61,13 +61,13 @@ function eventlogToggle(store) {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function eventlogInitialize() {
-    var doc = document;
-    var oEventlog = doc.createElement("div");
+    let doc = document;
+    let oEventlog = doc.createElement("div");
     oEventlog.setAttribute("id", "eventlog");
     oEventlog.style.overflow = "auto";
     oEventlog.style.height = oPageProperties.event_log_height + "px";
 
-    var oEventlogControl = doc.createElement("div");
+    let oEventlogControl = doc.createElement("div");
     oEventlogControl.setAttribute("id", "eventlogControl");
     oEventlogControl.style.bottom = parseInt(oPageProperties.event_log_height, 10) + 5 + "px";
     oEventlogControl.appendChild(doc.createTextNode("_"));
@@ -119,13 +119,13 @@ function eventlog(sComponent, sSeverity, sText) {
         oPageProperties.event_log &&
         oPageProperties.event_log != "0"
     ) {
-        var doc = document;
+        let doc = document;
 
         if (_eventlog === null) {
             eventlogInitialize();
             eventlog("eventlog", "info", "Eventlog initialized (Level: " + oPageProperties.event_log_level + ")");
         }
-        var oEventlog = _eventlog;
+        let oEventlog = _eventlog;
 
         if (typeof oSeverity[sSeverity] === "undefined") {
             eventlog(
@@ -148,7 +148,7 @@ function eventlog(sComponent, sSeverity, sText) {
             }
 
             // Format the new log entry
-            var oEntry = doc.createTextNode(getCurrentTime() + " " + sSeverity + " " + sComponent + ": " + sText);
+            let oEntry = doc.createTextNode(getCurrentTime() + " " + sSeverity + " " + sComponent + ": " + sText);
 
             // Append new message to log
             oEventlog.appendChild(oEntry);

--- a/share/frontend/nagvis-js/js/frontendEventlog.js
+++ b/share/frontend/nagvis-js/js/frontendEventlog.js
@@ -28,27 +28,26 @@
 var _eventlog = null;
 
 var oSeverity = {
-    'debug':    4,
-    'info':     3,
-    'warning':  2,
-    'critical': 1,
-    'error':    1
+    debug: 4,
+    info: 3,
+    warning: 2,
+    critical: 1,
+    error: 1
 };
 
 function eventlogToggle(store) {
-    var oLog = document.getElementById('eventlog');
-    var oLogControl = document.getElementById('eventlogControl');
+    var oLog = document.getElementById("eventlog");
+    var oLogControl = document.getElementById("eventlogControl");
 
-    if(store === true)
-        storeUserOption('eventlog', oLog.style.display == 'none');
+    if (store === true) storeUserOption("eventlog", oLog.style.display == "none");
 
-    if(oLog.style.display != 'none') {
-        oLog.style.display = 'none';
-        oLogControl.style.bottom = '0px';
+    if (oLog.style.display != "none") {
+        oLog.style.display = "none";
+        oLogControl.style.bottom = "0px";
     } else {
-        oLog.style.display = '';
-        oLog.style.height = oPageProperties.event_log_height+'px';
-        oLogControl.style.bottom = (parseInt(oPageProperties.event_log_height, 10)+5)+'px';
+        oLog.style.display = "";
+        oLog.style.height = oPageProperties.event_log_height + "px";
+        oLogControl.style.bottom = parseInt(oPageProperties.event_log_height, 10) + 5 + "px";
     }
 
     oLog = null;
@@ -63,24 +62,24 @@ function eventlogToggle(store) {
  */
 function eventlogInitialize() {
     var doc = document;
-    var oEventlog = doc.createElement('div');
-    oEventlog.setAttribute("id","eventlog");
-    oEventlog.style.overflow = 'auto';
-    oEventlog.style.height = oPageProperties.event_log_height+'px';
+    var oEventlog = doc.createElement("div");
+    oEventlog.setAttribute("id", "eventlog");
+    oEventlog.style.overflow = "auto";
+    oEventlog.style.height = oPageProperties.event_log_height + "px";
 
-    var oEventlogControl = doc.createElement('div');
-    oEventlogControl.setAttribute("id","eventlogControl");
-    oEventlogControl.style.bottom = (parseInt(oPageProperties.event_log_height, 10)+5)+'px';
-    oEventlogControl.appendChild(doc.createTextNode('_'));
-    oEventlogControl.onmouseover = function() {
-        document.body.style.cursor='pointer';
+    var oEventlogControl = doc.createElement("div");
+    oEventlogControl.setAttribute("id", "eventlogControl");
+    oEventlogControl.style.bottom = parseInt(oPageProperties.event_log_height, 10) + 5 + "px";
+    oEventlogControl.appendChild(doc.createTextNode("_"));
+    oEventlogControl.onmouseover = function () {
+        document.body.style.cursor = "pointer";
     };
 
-    oEventlogControl.onmouseout = function() {
-        document.body.style.cursor='auto';
+    oEventlogControl.onmouseout = function () {
+        document.body.style.cursor = "auto";
     };
 
-    oEventlogControl.onclick = function() {
+    oEventlogControl.onclick = function () {
         eventlogToggle(true);
     };
 
@@ -90,8 +89,10 @@ function eventlogInitialize() {
     oEventlogControl = null;
 
     // Hide eventlog when configured
-    if((typeof(oUserProperties.eventlog) !== 'undefined' && oUserProperties.eventlog === false)
-       || oPageProperties.event_log_hidden == 1)
+    if (
+        (typeof oUserProperties.eventlog !== "undefined" && oUserProperties.eventlog === false) ||
+        oPageProperties.event_log_hidden == 1
+    )
         eventlogToggle(false);
 
     _eventlog = oEventlog;
@@ -112,24 +113,33 @@ function eventlogInitialize() {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function eventlog(sComponent, sSeverity, sText) {
-    if(typeof(oPageProperties) != 'undefined' && oPageProperties !== null && oPageProperties.event_log && oPageProperties.event_log != '0') {
+    if (
+        typeof oPageProperties != "undefined" &&
+        oPageProperties !== null &&
+        oPageProperties.event_log &&
+        oPageProperties.event_log != "0"
+    ) {
         var doc = document;
 
-        if(_eventlog === null) {
+        if (_eventlog === null) {
             eventlogInitialize();
-            eventlog("eventlog", "info", "Eventlog initialized (Level: "+oPageProperties.event_log_level+")");
+            eventlog("eventlog", "info", "Eventlog initialized (Level: " + oPageProperties.event_log_level + ")");
         }
         var oEventlog = _eventlog;
 
-        if(typeof oSeverity[sSeverity] === 'undefined') {
-            eventlog('eventlog', 'error', 'Unknown severity used, skipping: '+sSeverity+' '+sComponent+': '+sText)
+        if (typeof oSeverity[sSeverity] === "undefined") {
+            eventlog(
+                "eventlog",
+                "error",
+                "Unknown severity used, skipping: " + sSeverity + " " + sComponent + ": " + sText
+            );
             oEventlog = null;
         }
 
-        if(oSeverity[sSeverity] <= oSeverity[oPageProperties.event_log_level]) {
+        if (oSeverity[sSeverity] <= oSeverity[oPageProperties.event_log_level]) {
             // When the message limit is reached truncate the first log entry
             // 24 lines is the current limit
-            if(oEventlog.childNodes && oEventlog.childNodes.length >= oPageProperties.event_log_events * 2) {
+            if (oEventlog.childNodes && oEventlog.childNodes.length >= oPageProperties.event_log_events * 2) {
                 // Remove line
                 oEventlog.removeChild(oEventlog.firstChild);
 
@@ -138,14 +148,14 @@ function eventlog(sComponent, sSeverity, sText) {
             }
 
             // Format the new log entry
-            var oEntry = doc.createTextNode(getCurrentTime()+" "+sSeverity+" "+sComponent+": "+sText);
+            var oEntry = doc.createTextNode(getCurrentTime() + " " + sSeverity + " " + sComponent + ": " + sText);
 
             // Append new message to log
             oEventlog.appendChild(oEntry);
             oEntry = null;
 
             // Add line break after the line
-            oEventlog.appendChild(doc.createElement('br'));
+            oEventlog.appendChild(doc.createElement("br"));
 
             // Scroll down
             oEventlog.scrollTop = oEventlog.scrollHeight;

--- a/share/frontend/nagvis-js/js/frontendMessage.js
+++ b/share/frontend/nagvis-js/js/frontendMessage.js
@@ -28,7 +28,7 @@ function frontendMessagePresent(key) {
 }
 
 function frontendMessageRemove(key) {
-    if(frontendMessagePresent(key)) {
+    if (frontendMessagePresent(key)) {
         popupWindowClose();
         delete frontendMessages[key];
     }
@@ -43,35 +43,38 @@ function frontendMessage(oMessage, key) {
         throw "Could not display empty frontendMessage()";
     }
 
-    var sTitle = '';
-    if (typeof oMessage.title !== 'undefined')
-        sTitle = oMessage.title;
+    var sTitle = "";
+    if (typeof oMessage.title !== "undefined") sTitle = oMessage.title;
 
     var closable = true;
-    if (typeof oMessage.closable !== 'undefined')
-        closable = oMessage.closable;
+    if (typeof oMessage.closable !== "undefined") closable = oMessage.closable;
 
     // Skip processing when message with same key already shown
-    if (isset(key) && frontendMessagePresent(key))
-        return;
+    if (isset(key) && frontendMessagePresent(key)) return;
 
-    var container = popupWindow(sTitle, {'code': '<div class="'+oMessage.type.toLowerCase()+'">'
-                                 +oMessage.message+'</div>'}, 500, closable);
+    var container = popupWindow(
+        sTitle,
+        { code: '<div class="' + oMessage.type.toLowerCase() + '">' + oMessage.message + "</div>" },
+        500,
+        closable
+    );
     frontendMessageAdd(key, container);
 
     // Maybe there is a request for a reload/redirect
-    if (typeof oMessage.reloadTime !== 'undefined' && oMessage.reloadTime !== null) {
+    if (typeof oMessage.reloadTime !== "undefined" && oMessage.reloadTime !== null) {
         var sUrl = window.location.href;
 
         // Maybe enable redirect
-        if(typeof oMessage.reloadUrl !== 'undefined' && oMessage.reloadUrl !== null) {
+        if (typeof oMessage.reloadUrl !== "undefined" && oMessage.reloadUrl !== null) {
             sUrl = oMessage.reloadUrl;
         }
 
         // Remove # signs. Seems to prevent firefox from performing the reload
-        sUrl = sUrl.replace('#', '');
+        sUrl = sUrl.replace("#", "");
 
         // Register reload/redirect
-        window.setTimeout(function() { window.location.href = sUrl; }, oMessage.reloadTime*1000);
+        window.setTimeout(function () {
+            window.location.href = sUrl;
+        }, oMessage.reloadTime * 1000);
     }
 }

--- a/share/frontend/nagvis-js/js/frontendMessage.js
+++ b/share/frontend/nagvis-js/js/frontendMessage.js
@@ -21,7 +21,7 @@
  *
  *****************************************************************************/
 
-var frontendMessages = {};
+const frontendMessages = {};
 
 function frontendMessagePresent(key) {
     return isset(frontendMessages[key]);
@@ -43,16 +43,16 @@ function frontendMessage(oMessage, key) {
         throw "Could not display empty frontendMessage()";
     }
 
-    var sTitle = "";
+    let sTitle = "";
     if (typeof oMessage.title !== "undefined") sTitle = oMessage.title;
 
-    var closable = true;
+    let closable = true;
     if (typeof oMessage.closable !== "undefined") closable = oMessage.closable;
 
     // Skip processing when message with same key already shown
     if (isset(key) && frontendMessagePresent(key)) return;
 
-    var container = popupWindow(
+    const container = popupWindow(
         sTitle,
         { code: '<div class="' + oMessage.type.toLowerCase() + '">' + oMessage.message + "</div>" },
         500,
@@ -62,7 +62,7 @@ function frontendMessage(oMessage, key) {
 
     // Maybe there is a request for a reload/redirect
     if (typeof oMessage.reloadTime !== "undefined" && oMessage.reloadTime !== null) {
-        var sUrl = window.location.href;
+        let sUrl = window.location.href;
 
         // Maybe enable redirect
         if (typeof oMessage.reloadUrl !== "undefined" && oMessage.reloadUrl !== null) {

--- a/share/frontend/nagvis-js/js/nagvis.js
+++ b/share/frontend/nagvis-js/js/nagvis.js
@@ -26,7 +26,9 @@
  */
 
 /* Comments for jslint */
+// eslint-disable-next-line no-redeclare
 /*global document, location, navigator, window, setTimeout, ActiveXObject */
+// eslint-disable-next-line no-redeclare
 /*global XMLHttpRequest, alert */
 
 /*jslint evil: true, */
@@ -507,7 +509,7 @@ function makeuri(addparams) {
 
     // Build list of key/value pairs
     var aparams = [];
-    for (var key in params) {
+    for (key in params) {
         aparams.push(key + "=" + params[key]);
     }
 
@@ -935,7 +937,7 @@ addDOMLoadEvent = (function () {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function handleJSError(sMsg, sUrl, iLine) {
-    if (!isset(sUrl)) var sUrl = "<Empty URL>";
+    if (!isset(sUrl)) sUrl = "<Empty URL>";
 
     // Log to javascript eventlog
     eventlog("js-error", "critical", "JS-Error occured: " + sMsg + " " + sUrl + " (" + iLine + ")");
@@ -1106,7 +1108,7 @@ function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, cust
                 var result = regex.exec(aOpt[0]);
 
                 if (result !== null) {
-                    for (var i = 1; i < result.length; i++) {
+                    for (i = 1; i < result.length; i++) {
                         var fixed = result[i].replace("-", "").toUpperCase();
                         sKey = sKey.replace(result[i], fixed);
                     }
@@ -1143,7 +1145,7 @@ function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, cust
         } else {
             // Only take zoom into account if the fontSize is set in px
             if (fontSize.indexOf("px") !== -1) {
-                var fontSize = parseFloat(fontSize.replace("px", ""));
+                fontSize = parseFloat(fontSize.replace("px", ""));
                 oLabelSpan.style.fontSize = addZoomFactor(fontSize) + "px";
             } else {
                 eventlog(
@@ -1378,7 +1380,7 @@ function isZoomed() {
  * might be a coordinate or a dimension of an object
  */
 function addZoomFactor(coord, forced) {
-    if (typeof forced === "undefined") var forced = false;
+    if (typeof forced === "undefined") forced = false;
 
     if (!forced && oGeneralProperties.zoom_scale_objects && oGeneralProperties.zoom_scale_objects != 1)
         return parseInt(coord);
@@ -1387,7 +1389,7 @@ function addZoomFactor(coord, forced) {
 }
 
 function rmZoomFactor(coord, forced) {
-    if (typeof forced === "undefined") var forced = false;
+    if (typeof forced === "undefined") forced = false;
 
     if (!forced && oGeneralProperties.zoom_scale_objects && oGeneralProperties.zoom_scale_objects != 1)
         return parseInt(coord);
@@ -1400,7 +1402,7 @@ function zoomHandler(event, obj, forced_zoom) {
     // not the raising object
     if (obj == window) {
         if (event.srcElement) {
-            var obj = event.srcElement;
+            obj = event.srcElement;
         }
     }
 
@@ -1444,7 +1446,7 @@ function zoomHandler(event, obj, forced_zoom) {
 function addZoomHandler(oImage, forced_zoom) {
     if (!isZoomed()) return; // If not zoomed, no handler is needed
 
-    if (typeof forced_zoom == "undefined") var forced_zoom = false;
+    if (typeof forced_zoom == "undefined") forced_zoom = false;
 
     oImage.style.display = "none";
 

--- a/share/frontend/nagvis-js/js/nagvis.js
+++ b/share/frontend/nagvis-js/js/nagvis.js
@@ -736,7 +736,7 @@ function scrollSlow(iTargetX, iTargetY, iSpeed) {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function escapeUrlValues(sStr) {
-    if (typeof sStr === undefined || sStr === null || sStr === "") {
+    if (typeof sStr === "undefined" || sStr === null || sStr === "") {
         return sStr;
     }
 
@@ -957,7 +957,7 @@ function handleException(e) {
 // Enable javascript error handler
 try {
     window.onerror = handleJSError;
-} catch (er) {}
+} catch (er) {} // eslint-disable-line no-empty
 
 /**
  * Cross browser mapper to add an event to an object
@@ -1274,7 +1274,7 @@ Object.size = function (obj) {
     var size = 0,
         key;
     for (key in obj) {
-        if (obj.hasOwnProperty(key)) size++;
+        if (obj.hasOwnProperty(key)) size++; // eslint-disable-line no-prototype-builtins
     }
     return size;
 };
@@ -1345,7 +1345,7 @@ function getEffectiveStyle(e, attr) {
         return document.defaultView.getComputedStyle(e, null).getPropertyValue(attr);
     } else if (e.currentStyle) {
         // IE
-        var ie_attr = attr.replace(/\-(\w)/g, function (strMatch, p1) {
+        var ie_attr = attr.replace(/-(\w)/g, function (strMatch, p1) {
             return p1.toUpperCase();
         });
         var f = e.currentStyle[ie_attr];

--- a/share/frontend/nagvis-js/js/nagvis.js
+++ b/share/frontend/nagvis-js/js/nagvis.js
@@ -46,7 +46,7 @@ var iNow = Math.floor(Date.parse(new Date()) / 1000);
 // Define some state options
 var oStates = {};
 
-var isIE  = navigator.appVersion.indexOf("MSIE") != -1;
+var isIE = navigator.appVersion.indexOf("MSIE") != -1;
 
 // These vars are used to stop earlier scrollings that mess between
 var crawlX = 0;
@@ -114,20 +114,41 @@ function date(format, timestamp) {
     // *     example 9: date('W Y-m-d', 1293974054); // 2011-01-02
     // *     returns 9: '52 2011-01-02'
     var that = this,
-        jsdate, f, formatChr = /\\?([a-z])/gi, formatChrCb,
+        jsdate,
+        f,
+        formatChr = /\\?([a-z])/gi,
+        formatChrCb,
         // Keep this here (works, but for code commented-out
         // below for file size reasons)
         //, tal= [],
         _pad = function (n, c) {
             if ((n = n + "").length < c) {
-                return new Array((++c) - n.length).join("0") + n;
+                return new Array(++c - n.length).join("0") + n;
             } else {
                 return n;
             }
         },
-        txt_words = ["Sun", "Mon", "Tues", "Wednes", "Thurs", "Fri", "Satur",
-        "January", "February", "March", "April", "May", "June", "July",
-        "August", "September", "October", "November", "December"],
+        txt_words = [
+            "Sun",
+            "Mon",
+            "Tues",
+            "Wednes",
+            "Thurs",
+            "Fri",
+            "Satur",
+            "January",
+            "February",
+            "March",
+            "April",
+            "May",
+            "June",
+            "July",
+            "August",
+            "September",
+            "October",
+            "November",
+            "December"
+        ],
         txt_ordin = {
             1: "st",
             2: "nd",
@@ -141,137 +162,172 @@ function date(format, timestamp) {
         return f[t] ? f[t]() : s;
     };
     f = {
-    // Day
-        d: function () { // Day of month w/leading 0; 01..31
+        // Day
+        d: function () {
+            // Day of month w/leading 0; 01..31
             return _pad(f.j(), 2);
         },
-        D: function () { // Shorthand day name; Mon...Sun
+        D: function () {
+            // Shorthand day name; Mon...Sun
             return f.l().slice(0, 3);
         },
-        j: function () { // Day of month; 1..31
+        j: function () {
+            // Day of month; 1..31
             return jsdate.getDate();
         },
-        l: function () { // Full day name; Monday...Sunday
-            return txt_words[f.w()] + 'day';
+        l: function () {
+            // Full day name; Monday...Sunday
+            return txt_words[f.w()] + "day";
         },
-        N: function () { // ISO-8601 day of week; 1[Mon]..7[Sun]
+        N: function () {
+            // ISO-8601 day of week; 1[Mon]..7[Sun]
             return f.w() || 7;
         },
-        S: function () { // Ordinal suffix for day of month; st, nd, rd, th
-            return txt_ordin[f.j()] || 'th';
+        S: function () {
+            // Ordinal suffix for day of month; st, nd, rd, th
+            return txt_ordin[f.j()] || "th";
         },
-        w: function () { // Day of week; 0[Sun]..6[Sat]
+        w: function () {
+            // Day of week; 0[Sun]..6[Sat]
             return jsdate.getDay();
         },
-        z: function () { // Day of year; 0..365
+        z: function () {
+            // Day of year; 0..365
             var a = new Date(f.Y(), f.n() - 1, f.j()),
                 b = new Date(f.Y(), 0, 1);
             return Math.round((a - b) / 864e5) + 1;
         },
 
-    // Week
-        W: function () { // ISO-8601 week number
+        // Week
+        W: function () {
+            // ISO-8601 week number
             var a = new Date(f.Y(), f.n() - 1, f.j() - f.N() + 3),
                 b = new Date(a.getFullYear(), 0, 4);
             return 1 + Math.round((a - b) / 864e5 / 7);
         },
 
-    // Month
-        F: function () { // Full month name; January...December
+        // Month
+        F: function () {
+            // Full month name; January...December
             return txt_words[6 + f.n()];
         },
-        m: function () { // Month w/leading 0; 01...12
+        m: function () {
+            // Month w/leading 0; 01...12
             return _pad(f.n(), 2);
         },
-        M: function () { // Shorthand month name; Jan...Dec
+        M: function () {
+            // Shorthand month name; Jan...Dec
             return f.F().slice(0, 3);
         },
-        n: function () { // Month; 1...12
+        n: function () {
+            // Month; 1...12
             return jsdate.getMonth() + 1;
         },
-        t: function () { // Days in month; 28...31
-            return (new Date(f.Y(), f.n(), 0)).getDate();
+        t: function () {
+            // Days in month; 28...31
+            return new Date(f.Y(), f.n(), 0).getDate();
         },
 
-    // Year
-        L: function () { // Is leap year?; 0 or 1
-            return new Date(f.Y(), 1, 29).getMonth() === 1 | 0;
+        // Year
+        L: function () {
+            // Is leap year?; 0 or 1
+            return (new Date(f.Y(), 1, 29).getMonth() === 1) | 0;
         },
-        o: function () { // ISO-8601 year
-            var n = f.n(), W = f.W(), Y = f.Y();
+        o: function () {
+            // ISO-8601 year
+            var n = f.n(),
+                W = f.W(),
+                Y = f.Y();
             return Y + (n === 12 && W < 9 ? -1 : n === 1 && W > 9);
         },
-        Y: function () { // Full year; e.g. 1980...2010
+        Y: function () {
+            // Full year; e.g. 1980...2010
             return jsdate.getFullYear();
         },
-        y: function () { // Last two digits of year; 00...99
+        y: function () {
+            // Last two digits of year; 00...99
             return (f.Y() + "").slice(-2);
         },
 
-    // Time
-        a: function () { // am or pm
+        // Time
+        a: function () {
+            // am or pm
             return jsdate.getHours() > 11 ? "pm" : "am";
         },
-        A: function () { // AM or PM
+        A: function () {
+            // AM or PM
             return f.a().toUpperCase();
         },
-        B: function () { // Swatch Internet time; 000..999
+        B: function () {
+            // Swatch Internet time; 000..999
             var H = jsdate.getUTCHours() * 36e2, // Hours
                 i = jsdate.getUTCMinutes() * 60, // Minutes
                 s = jsdate.getUTCSeconds(); // Seconds
             return _pad(Math.floor((H + i + s + 36e2) / 86.4) % 1e3, 3);
         },
-        g: function () { // 12-Hours; 1..12
+        g: function () {
+            // 12-Hours; 1..12
             return f.G() % 12 || 12;
         },
-        G: function () { // 24-Hours; 0..23
+        G: function () {
+            // 24-Hours; 0..23
             return jsdate.getHours();
         },
-        h: function () { // 12-Hours w/leading 0; 01..12
+        h: function () {
+            // 12-Hours w/leading 0; 01..12
             return _pad(f.g(), 2);
         },
-        H: function () { // 24-Hours w/leading 0; 00..23
+        H: function () {
+            // 24-Hours w/leading 0; 00..23
             return _pad(f.G(), 2);
         },
-        i: function () { // Minutes w/leading 0; 00..59
+        i: function () {
+            // Minutes w/leading 0; 00..59
             return _pad(jsdate.getMinutes(), 2);
         },
-        s: function () { // Seconds w/leading 0; 00..59
+        s: function () {
+            // Seconds w/leading 0; 00..59
             return _pad(jsdate.getSeconds(), 2);
         },
-        u: function () { // Microseconds; 000000-999000
+        u: function () {
+            // Microseconds; 000000-999000
             return _pad(jsdate.getMilliseconds() * 1000, 6);
         },
 
-    // Timezone
-        e: function () { // Timezone identifier; e.g. Atlantic/Azores, ...
-// The following works, but requires inclusion of the very large
-// timezone_abbreviations_list() function.
-/*              return this.date_default_timezone_get();
-*/
-            throw 'Not supported (see source code of date() for timezone on how to add support)';
+        // Timezone
+        e: function () {
+            // Timezone identifier; e.g. Atlantic/Azores, ...
+            // The following works, but requires inclusion of the very large
+            // timezone_abbreviations_list() function.
+            /*              return this.date_default_timezone_get();
+             */
+            throw "Not supported (see source code of date() for timezone on how to add support)";
         },
-        I: function () { // DST observed?; 0 or 1
+        I: function () {
+            // DST observed?; 0 or 1
             // Compares Jan 1 minus Jan 1 UTC to Jul 1 minus Jul 1 UTC.
             // If they are not equal, then DST is observed.
             var a = new Date(f.Y(), 0), // Jan 1
                 c = Date.UTC(f.Y(), 0), // Jan 1 UTC
                 b = new Date(f.Y(), 6), // Jul 1
                 d = Date.UTC(f.Y(), 6); // Jul 1 UTC
-            return 0 + ((a - c) !== (b - d));
+            return 0 + (a - c !== b - d);
         },
-        O: function () { // Difference to GMT in hour format; e.g. +0200
+        O: function () {
+            // Difference to GMT in hour format; e.g. +0200
             var a = jsdate.getTimezoneOffset();
-            return (a > 0 ? "-" : "+") + _pad(Math.abs(a / 60 * 100), 4);
+            return (a > 0 ? "-" : "+") + _pad(Math.abs((a / 60) * 100), 4);
         },
-        P: function () { // Difference to GMT w/colon; e.g. +02:00
+        P: function () {
+            // Difference to GMT w/colon; e.g. +02:00
             var O = f.O();
-            return (O.substr(0, 3) + ":" + O.substr(3, 2));
+            return O.substr(0, 3) + ":" + O.substr(3, 2);
         },
-        T: function () { // Timezone abbreviation; e.g. EST, MDT, ...
-// The following works, but requires inclusion of the very
-// large timezone_abbreviations_list() function.
-/*              var abbr = '', i = 0, os = 0, default = 0;
+        T: function () {
+            // Timezone abbreviation; e.g. EST, MDT, ...
+            // The following works, but requires inclusion of the very
+            // large timezone_abbreviations_list() function.
+            /*              var abbr = '', i = 0, os = 0, default = 0;
             if (!tal.length) {
                 tal = that.timezone_abbreviations_list();
             }
@@ -294,30 +350,35 @@ function date(format, timestamp) {
                 }
             }
 */
-            return 'UTC';
+            return "UTC";
         },
-        Z: function () { // Timezone offset in seconds (-43200...50400)
+        Z: function () {
+            // Timezone offset in seconds (-43200...50400)
             return -jsdate.getTimezoneOffset() * 60;
         },
 
-    // Full Date/Time
-        c: function () { // ISO-8601 date.
-            return 'Y-m-d\\Th:i:sP'.replace(formatChr, formatChrCb);
+        // Full Date/Time
+        c: function () {
+            // ISO-8601 date.
+            return "Y-m-d\\Th:i:sP".replace(formatChr, formatChrCb);
         },
-        r: function () { // RFC 2822
-            return 'D, d M Y H:i:s O'.replace(formatChr, formatChrCb);
+        r: function () {
+            // RFC 2822
+            return "D, d M Y H:i:s O".replace(formatChr, formatChrCb);
         },
-        U: function () { // Seconds since UNIX epoch
-            return jsdate.getTime() / 1000 | 0;
+        U: function () {
+            // Seconds since UNIX epoch
+            return (jsdate.getTime() / 1000) | 0;
         }
     };
     this.date = function (format, timestamp) {
         that = this;
-        jsdate = (
-            (typeof timestamp === 'undefined') ? new Date() : // Not provided
-            (timestamp instanceof Date) ? new Date(timestamp) : // JS Date()
-            new Date(timestamp * 1000) // UNIX timestamp (auto-convert to int)
-        );
+        jsdate =
+            typeof timestamp === "undefined"
+                ? new Date() // Not provided
+                : timestamp instanceof Date
+                  ? new Date(timestamp) // JS Date()
+                  : new Date(timestamp * 1000); // UNIX timestamp (auto-convert to int)
         return format.replace(formatChr, formatChrCb);
     };
     return this.date(format, timestamp);
@@ -329,10 +390,10 @@ function date(format, timestamp) {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function updateWorkerCounter() {
-    var oWorkerCounter = document.getElementById('workerLastRunCounter');
+    var oWorkerCounter = document.getElementById("workerLastRunCounter");
     // write the time to refresh to header counter
-    if(oWorkerCounter) {
-        if(oWorkerProperties.last_run) {
+    if (oWorkerCounter) {
+        if (oWorkerProperties.last_run) {
             oWorkerCounter.innerHTML = date(oGeneralProperties.date_format, oWorkerProperties.last_run);
         }
     }
@@ -346,8 +407,8 @@ function updateWorkerCounter() {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function rotatePage() {
-    if(oRotationProperties.nextStepUrl !== '') {
-        if(oRotationProperties.rotationEnabled == true) {
+    if (oRotationProperties.nextStepUrl !== "") {
+        if (oRotationProperties.rotationEnabled == true) {
             window.open(oRotationProperties.nextStepUrl, "_self");
             return true;
         }
@@ -367,23 +428,28 @@ function rotatePage() {
 function rotationCountdown() {
     // Only proceed with counting when rotation is enabled and the next step time
     // has a proper value
-    if(oRotationProperties.rotationEnabled && oRotationProperties.rotationEnabled == true && oRotationProperties.nextStepTime && oRotationProperties.nextStepTime !== '') {
+    if (
+        oRotationProperties.rotationEnabled &&
+        oRotationProperties.rotationEnabled == true &&
+        oRotationProperties.nextStepTime &&
+        oRotationProperties.nextStepTime !== ""
+    ) {
         // Countdown one second
         oRotationProperties.nextStepTime -= 1;
 
-        if(oRotationProperties.nextStepTime <= 0) {
+        if (oRotationProperties.nextStepTime <= 0) {
             return rotatePage();
         } else {
-            var oRefCountHead = document.getElementById('refreshCounterHead');
+            var oRefCountHead = document.getElementById("refreshCounterHead");
             // write the time to refresh to header counter
-            if(oRefCountHead) {
+            if (oRefCountHead) {
                 oRefCountHead.innerHTML = oRotationProperties.nextStepTime;
                 oRefCountHead = null;
             }
 
-            var oRefCount = document.getElementById('refreshCounter');
+            var oRefCount = document.getElementById("refreshCounter");
             // write the time to refresh to the normal counter
-            if(oRefCount) {
+            if (oRefCount) {
                 oRefCount.innerHTML = oRotationProperties.nextStepTime;
                 oRefCount = null;
             }
@@ -398,12 +464,12 @@ function rotationCountdown() {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function getUrlParam(name) {
-    var name2 = name.replace('[', '\\[').replace(']', '\\]');
-    var regexS = "[\\?&]"+name2+"=([^&#]*)";
-    var regex = new RegExp( regexS );
+    var name2 = name.replace("[", "\\[").replace("]", "\\]");
+    var regexS = "[\\?&]" + name2 + "=([^&#]*)";
+    var regex = new RegExp(regexS);
     var results = regex.exec(window.location);
-    if(results === null) {
-        return '';
+    if (results === null) {
+        return "";
     } else {
         return results[1];
     }
@@ -415,27 +481,26 @@ function getUrlParam(name) {
  * - Can remove parameters by adding "null" values
  */
 function makeuri(addparams) {
-    var tmp = window.location.href.split('?');
+    var tmp = window.location.href.split("?");
     var base = tmp[0];
-    tmp = tmp[1].split('#');
-    tmp = tmp[0].split('&');
+    tmp = tmp[1].split("#");
+    tmp = tmp[0].split("&");
     var len = tmp.length;
     var params = {};
     var pair = null;
 
-    for(var i = 0; i < tmp.length; i++) {
-        pair = tmp[i].split('=');
+    for (var i = 0; i < tmp.length; i++) {
+        pair = tmp[i].split("=");
 
         // Skip unwanted params
-        if(addparams[pair[0]] !== undefined && addparams[pair[0]] == null)
-            continue;
+        if (addparams[pair[0]] !== undefined && addparams[pair[0]] == null) continue;
 
         params[pair[0]] = pair[1];
     }
 
     // Add new params to the existing params. Overwrite duplicates
     for (var key in addparams) {
-        if(addparams[key] != null) {
+        if (addparams[key] != null) {
             params[key] = addparams[key];
         }
     }
@@ -443,10 +508,10 @@ function makeuri(addparams) {
     // Build list of key/value pairs
     var aparams = [];
     for (var key in params) {
-        aparams.push(key + '=' + params[key]);
+        aparams.push(key + "=" + params[key]);
     }
 
-    return base + '?' + aparams.join('&');
+    return base + "?" + aparams.join("&");
 }
 
 /**
@@ -455,12 +520,12 @@ function makeuri(addparams) {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function setRotationLabel() {
-    if(oRotationProperties.rotationEnabled == true) {
-        document.getElementById('rotationStart').style.display = 'none';
-        document.getElementById('rotationStop').style.display = 'inline';
+    if (oRotationProperties.rotationEnabled == true) {
+        document.getElementById("rotationStart").style.display = "none";
+        document.getElementById("rotationStop").style.display = "inline";
     } else {
-        document.getElementById('rotationStart').style.display = 'inline';
-        document.getElementById('rotationStop').style.display = 'none';
+        document.getElementById("rotationStart").style.display = "inline";
+        document.getElementById("rotationStop").style.display = "none";
     }
 }
 
@@ -470,7 +535,7 @@ function setRotationLabel() {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function switchRotation() {
-    if(oRotationProperties.rotationEnabled == true) {
+    if (oRotationProperties.rotationEnabled == true) {
         oRotationProperties.rotationEnabled = false;
 
         setRotationLabel();
@@ -484,39 +549,39 @@ function switchRotation() {
 function getCurrentTime() {
     var oDate = new Date();
     var sHours = oDate.getHours();
-    sHours = (( sHours < 10) ? "0"+sHours : sHours);
+    sHours = sHours < 10 ? "0" + sHours : sHours;
     var sMinutes = oDate.getMinutes();
-    sMinutes = (( sMinutes < 10) ? "0"+sMinutes : sMinutes);
+    sMinutes = sMinutes < 10 ? "0" + sMinutes : sMinutes;
     var sSeconds = oDate.getSeconds();
-    sSeconds = (( sSeconds < 10) ? "0"+sSeconds : sSeconds);
+    sSeconds = sSeconds < 10 ? "0" + sSeconds : sSeconds;
 
-    return sHours+":"+sMinutes+":"+sSeconds;
+    return sHours + ":" + sMinutes + ":" + sSeconds;
 }
 
 function getRandomLowerCaseLetter() {
-   return String.fromCharCode(97 + Math.round(Math.random() * 25));
+    return String.fromCharCode(97 + Math.round(Math.random() * 25));
 }
 
 function getRandom(min, max) {
-    if( min > max ) {
+    if (min > max) {
         return -1;
     }
 
-    if( min == max ) {
+    if (min == max) {
         return min;
     }
 
-    return min + parseInt(Math.random() * (max-min+1), 0);
+    return min + parseInt(Math.random() * (max - min + 1), 0);
 }
 
 function pageWidth() {
     var w;
 
-    if(window.innerWidth !== null  && typeof window.innerWidth !== 'undefined') {
+    if (window.innerWidth !== null && typeof window.innerWidth !== "undefined") {
         w = window.innerWidth;
-    } else if(document.documentElement && document.documentElement.clientWidth) {
+    } else if (document.documentElement && document.documentElement.clientWidth) {
         w = document.documentElement.clientWidth;
-    } else if(document.body !== null) {
+    } else if (document.body !== null) {
         w = document.body.clientWidth;
     } else {
         w = null;
@@ -528,11 +593,11 @@ function pageWidth() {
 function pageHeight() {
     var h;
 
-    if(window.innerHeight !== null && typeof window.innerHeight !== 'undefined') {
+    if (window.innerHeight !== null && typeof window.innerHeight !== "undefined") {
         h = window.innerHeight;
-    } else if(document.documentElement && document.documentElement.clientHeight) {
+    } else if (document.documentElement && document.documentElement.clientHeight) {
         h = document.documentElement.clientHeight;
-    } else if(document.body !== null) {
+    } else if (document.body !== null) {
         h = document.body.clientHeight;
     } else {
         h = null;
@@ -542,23 +607,18 @@ function pageHeight() {
 }
 
 function getScrollTop() {
-    if (typeof window.pageYOffset !== 'undefined')
-        return window.pageYOffset;
-    else if (typeof document.compatMode !== 'undefined' && document.compatMode !== 'BackCompat')
+    if (typeof window.pageYOffset !== "undefined") return window.pageYOffset;
+    else if (typeof document.compatMode !== "undefined" && document.compatMode !== "BackCompat")
         return document.documentElement.scrollTop;
-    else if (typeof document.body !== 'undefined')
-        return document.body.scrollTop;
+    else if (typeof document.body !== "undefined") return document.body.scrollTop;
 }
 
 function getScrollLeft() {
-    if (typeof window.pageXOffset !== 'undefined')
-        return window.pageXOffset;
-    else if (typeof document.compatMode != 'undefined' && document.compatMode !== 'BackCompat')
+    if (typeof window.pageXOffset !== "undefined") return window.pageXOffset;
+    else if (typeof document.compatMode != "undefined" && document.compatMode !== "BackCompat")
         return document.documentElement.scrollLeft;
-    else if (typeof document.body !== 'undefined')
-        return document.body.scrollLeft;
+    else if (typeof document.body !== "undefined") return document.body.scrollLeft;
 }
-
 
 /**
  * Scrolls the screen to the defined coordinates
@@ -579,16 +639,16 @@ function scrollSlow(iTargetX, iTargetY, iSpeed) {
     iTargetX = parseInt(iTargetX);
     iTargetY = parseInt(iTargetY);
 
-    if((iTargetX !== crawlX || iTargetY !== crawlY) && crawlX !== 0 && crawlY !== 0) {
+    if ((iTargetX !== crawlX || iTargetY !== crawlY) && crawlX !== 0 && crawlY !== 0) {
         crawling = 1;
-    } else if(crawlX == 0 && crawlY == 0) {
+    } else if (crawlX == 0 && crawlY == 0) {
         crawlX = iTargetX;
         crawlY = iTargetY;
     }
 
     // Get offset of the map div
-    var oMap = document.getElementById('map');
-    if(oMap && oMap.offsetTop) {
+    var oMap = document.getElementById("map");
+    if (oMap && oMap.offsetTop) {
         iMapOffsetTop = oMap.offsetTop;
     } else {
         iMapOffsetTop = 0;
@@ -596,49 +656,75 @@ function scrollSlow(iTargetX, iTargetY, iSpeed) {
     oMap = null;
 
     // Get measure of the screen
-    iWidth  = pageWidth();
+    iWidth = pageWidth();
     iHeight = pageHeight() - iMapOffsetTop;
 
-    if((iTargetY < (currentScrollTop+iHeight/2+iStep) && iTargetY >= (currentScrollTop+iHeight/2-iStep)) || (currentScrollTop<iStep && iTargetY<iHeight/2)) {
+    if (
+        (iTargetY < currentScrollTop + iHeight / 2 + iStep && iTargetY >= currentScrollTop + iHeight / 2 - iStep) ||
+        (currentScrollTop < iStep && iTargetY < iHeight / 2)
+    ) {
         // Target is in current view
         scrollTop = 0;
-    } else if(iTargetY < (currentScrollTop+iHeight/2) && currentScrollTop>iStep) {
+    } else if (iTargetY < currentScrollTop + iHeight / 2 && currentScrollTop > iStep) {
         // Target is above current view
         scrollTop = -iStep;
-    } else if(iTargetY > (currentScrollTop+iHeight/2)) {
+    } else if (iTargetY > currentScrollTop + iHeight / 2) {
         // Target is below current view
         scrollTop = iStep;
     } else {
-        eventlog("js-error", "critical", "JS-Error occured: iTargetY: " +iTargetY);
+        eventlog("js-error", "critical", "JS-Error occured: iTargetY: " + iTargetY);
         scrollTop = 0;
     }
 
-    if((iTargetX < (currentScrollLeft+iWidth/2+iStep) && iTargetX >= (currentScrollLeft+iWidth/2-iStep)) || (currentScrollLeft<iStep && iTargetX<iWidth/2)) {
+    if (
+        (iTargetX < currentScrollLeft + iWidth / 2 + iStep && iTargetX >= currentScrollLeft + iWidth / 2 - iStep) ||
+        (currentScrollLeft < iStep && iTargetX < iWidth / 2)
+    ) {
         // Target is in current view
         scrollLeft = 0;
-    } else if(iTargetX < (currentScrollLeft+iWidth/2) && currentScrollLeft>iStep) {
+    } else if (iTargetX < currentScrollLeft + iWidth / 2 && currentScrollLeft > iStep) {
         // Target is left from current view
         scrollLeft = -iStep;
-    } else if(iTargetX > (currentScrollLeft+iWidth/2)) {
+    } else if (iTargetX > currentScrollLeft + iWidth / 2) {
         // Target is right from current view
         scrollLeft = iStep;
     } else {
-        eventlog("js-error", "critical", "JS-Error occured: iTargetX: " +iTargetX);
+        eventlog("js-error", "critical", "JS-Error occured: iTargetX: " + iTargetX);
         scrollLeft = 0;
     }
 
-    eventlog("scroll", "debug", currentScrollLeft+" to "+iTargetX+" = "+scrollLeft+", "+currentScrollTop+" to "+iTargetY+" = "+scrollTop);
+    eventlog(
+        "scroll",
+        "debug",
+        currentScrollLeft +
+            " to " +
+            iTargetX +
+            " = " +
+            scrollLeft +
+            ", " +
+            currentScrollTop +
+            " to " +
+            iTargetY +
+            " = " +
+            scrollTop
+    );
 
-    if((scrollTop !== 0 || scrollLeft !== 0) && crawling == 0) {
+    if ((scrollTop !== 0 || scrollLeft !== 0) && crawling == 0) {
         window.scrollBy(scrollLeft, scrollTop);
         if (currentScrollTop !== getScrollTop() || currentScrollLeft !== getScrollLeft()) {
-            setTimeout(function() { scrollSlow(iTargetX, iTargetY, iSpeed); }, iSpeed);
-        };
+            setTimeout(function () {
+                scrollSlow(iTargetX, iTargetY, iSpeed);
+            }, iSpeed);
+        }
     } else {
-        eventlog("scroll", "debug", 'No need to scroll: '+currentScrollLeft+' - '+iTargetX+', '+currentScrollTop+' - '+iTargetY);
-        crawlX=0;
-        crawlY=0;
-        crawling=0;
+        eventlog(
+            "scroll",
+            "debug",
+            "No need to scroll: " + currentScrollLeft + " - " + iTargetX + ", " + currentScrollTop + " - " + iTargetY
+        );
+        crawlX = 0;
+        crawlY = 0;
+        crawling = 0;
     }
 }
 
@@ -650,43 +736,42 @@ function scrollSlow(iTargetX, iTargetY, iSpeed) {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function escapeUrlValues(sStr) {
-    if(typeof sStr === undefined || sStr === null || sStr === '') {
+    if (typeof sStr === undefined || sStr === null || sStr === "") {
         return sStr;
     }
 
     sStr = new String(sStr);
 
-    if(sStr.search('\\+') !== -1) {
-        sStr = sStr.replace(/\+/g, '%2B');
+    if (sStr.search("\\+") !== -1) {
+        sStr = sStr.replace(/\+/g, "%2B");
     }
 
-    if(sStr.search('&') !== -1) {
-        sStr = sStr.replace(/&/g, '%26');
+    if (sStr.search("&") !== -1) {
+        sStr = sStr.replace(/&/g, "%26");
     }
 
-    if(sStr.search('#') !== -1) {
-        sStr = sStr.replace(/#/g, '%23');
+    if (sStr.search("#") !== -1) {
+        sStr = sStr.replace(/#/g, "%23");
     }
 
-    if(sStr.search(':') !== -1) {
-        sStr = sStr.replace(/:/g, '%3A');
+    if (sStr.search(":") !== -1) {
+        sStr = sStr.replace(/:/g, "%3A");
     }
 
-    if(sStr.search(' ') !== -1) {
-        sStr = sStr.replace(/ /g, '%20');
+    if (sStr.search(" ") !== -1) {
+        sStr = sStr.replace(/ /g, "%20");
     }
 
-    if(sStr.search('=') !== -1) {
-        sStr = sStr.replace(/=/g, '%3D');
+    if (sStr.search("=") !== -1) {
+        sStr = sStr.replace(/=/g, "%3D");
     }
 
-    if(sStr.search('\\?') !== -1) {
-        sStr = sStr.replace(/\?/g, '%3F');
+    if (sStr.search("\\?") !== -1) {
+        sStr = sStr.replace(/\?/g, "%3F");
     }
 
     return sStr;
 }
-
 
 /**
  * Function to map html special characters into their html entities before
@@ -695,15 +780,14 @@ function escapeUrlValues(sStr) {
 
 function htmlspecialchars(sStr) {
     const map = {
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&#39;'
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;"
     };
-    return sStr.replace(/[&<>"']/g, match => map[match]);
+    return sStr.replace(/[&<>"']/g, (match) => map[match]);
 }
-
 
 /**
  * Function to dumping arrays/objects in javascript for debugging purposes
@@ -711,7 +795,7 @@ function htmlspecialchars(sStr) {
  *
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
-function oDump(object, depth, max){
+function oDump(object, depth, max) {
     depth = depth || 0;
     max = max || 2;
 
@@ -728,9 +812,15 @@ function oDump(object, depth, max){
     for (var key in object) {
         output += "\n" + indent + key + ": ";
         switch (typeof object[key]) {
-            case "object": output += oDump(object[key], depth + 1, max); break;
-            case "function": output += "function"; break;
-            default: output += object[key]; break;
+            case "object":
+                output += oDump(object[key], depth + 1, max);
+                break;
+            case "function":
+                output += "function";
+                break;
+            default:
+                output += object[key];
+                break;
         }
     }
     return output;
@@ -741,8 +831,7 @@ function oDump(object, depth, max){
  */
 function oLength(object) {
     var c = 0;
-    for(var key in object)
-        c++;
+    for (var key in object) c++;
     return c;
 }
 
@@ -752,7 +841,7 @@ function oLength(object) {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function isFirefox() {
-  return navigator.userAgent.indexOf("Firefox") > -1;
+    return navigator.userAgent.indexOf("Firefox") > -1;
 }
 
 /*
@@ -774,7 +863,7 @@ function isFirefox() {
  *
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
-addDOMLoadEvent = (function(){
+addDOMLoadEvent = (function () {
     // create event function stack
     var load_events = [],
         load_timer,
@@ -789,14 +878,13 @@ addDOMLoadEvent = (function(){
             clearInterval(load_timer);
 
             // execute each function in the stack in the order they were added
-        //
-        // LM: This small timeout seems to be needed for chrome to have the
-        // clientWidth attribute calculated which is needed by the controls
-        // of the map objects.
-            while (exec = load_events.shift())
-                setTimeout(exec, 50);
+            //
+            // LM: This small timeout seems to be needed for chrome to have the
+            // clientWidth attribute calculated which is needed by the controls
+            // of the map objects.
+            while ((exec = load_events.shift())) setTimeout(exec, 50);
 
-            if (script) script.onreadystatechange = '';
+            if (script) script.onreadystatechange = "";
         };
 
     return function (func) {
@@ -805,8 +893,7 @@ addDOMLoadEvent = (function(){
 
         if (!load_events[0]) {
             // for Mozilla/Opera9/Chrome
-            if (document.addEventListener)
-                document.addEventListener("DOMContentLoaded", init, false);
+            if (document.addEventListener) document.addEventListener("DOMContentLoaded", init, false);
 
             // for Internet Explorer
             /*@cc_on @*/
@@ -821,23 +908,23 @@ addDOMLoadEvent = (function(){
             @*/
 
             // for Safari
-            if (/KHTML|WebKit|iCab/i.test(navigator.userAgent)) { // sniff
-                load_timer = setInterval(function() {
-                    if (/loaded|complete/.test(document.readyState))
-                        init(); // call the onload handler
+            if (/KHTML|WebKit|iCab/i.test(navigator.userAgent)) {
+                // sniff
+                load_timer = setInterval(function () {
+                    if (/loaded|complete/.test(document.readyState)) init(); // call the onload handler
                 }, 10);
             }
 
             // for other browsers set the window.onload, but also execute the old window.onload
             old_onload = window.onload;
-            window.onload = function() {
+            window.onload = function () {
                 init();
                 if (old_onload) old_onload();
             };
         }
 
         load_events.push(func);
-    }
+    };
 })();
 
 /**
@@ -848,32 +935,29 @@ addDOMLoadEvent = (function(){
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function handleJSError(sMsg, sUrl, iLine) {
-    if(!isset(sUrl))
-  	var sUrl = '<Empty URL>';
+    if (!isset(sUrl)) var sUrl = "<Empty URL>";
 
     // Log to javascript eventlog
     eventlog("js-error", "critical", "JS-Error occured: " + sMsg + " " + sUrl + " (" + iLine + ")");
 
     frontendMessage({
-        'type'    : 'error',
-        'title'   : 'Error: Javascript Error',
-        'message' : 'Javascript error occured:\n ' + sMsg + ' '
-                   + sUrl + ' (' + iLine + ')'
+        type: "error",
+        title: "Error: Javascript Error",
+        message: "Javascript error occured:\n " + sMsg + " " + sUrl + " (" + iLine + ")"
     });
     return false;
 }
 
 function handleException(e) {
-    var msg = e.name+': '+e.message;
-    if (e.stack)
-        msg += '<br><code>'+e.stack+'</code>';
+    var msg = e.name + ": " + e.message;
+    if (e.stack) msg += "<br><code>" + e.stack + "</code>";
     handleJSError(msg, e.fileName, e.lineNumber);
 }
 
 // Enable javascript error handler
 try {
     window.onerror = handleJSError;
-} catch(er) {}
+} catch (er) {}
 
 /**
  * Cross browser mapper to add an event to an object
@@ -881,29 +965,26 @@ try {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function addEvent(obj, type, fn) {
-   if(obj.addEventListener) {
-      obj.addEventListener(type, fn, false);
-   } else if (obj.attachEvent) {
-      obj.attachEvent("on"+type, fn);
-   }
+    if (obj.addEventListener) {
+        obj.addEventListener(type, fn, false);
+    } else if (obj.attachEvent) {
+        obj.attachEvent("on" + type, fn);
+    }
 }
 
 // Same as above but inverse. Removes registered events
 function removeEvent(obj, type, fn) {
-    if(obj.removeEventListener) {
+    if (obj.removeEventListener) {
         obj.removeEventListener(type, fn, false);
     } else if (obj.detachEvent) {
-        obj.detachEvent("on"+type, fn);
+        obj.detachEvent("on" + type, fn);
     }
 }
 
 function preventDefaultEvents(event) {
-    if (event.preventDefault)
-        event.preventDefault();
-    else
-        event.returnValue = false;
-    if (event.stopPropagation)
-        event.stopPropagation();
+    if (event.preventDefault) event.preventDefault();
+    else event.returnValue = false;
+    if (event.stopPropagation) event.stopPropagation();
     return false;
 }
 
@@ -915,50 +996,53 @@ function preventDefaultEvents(event) {
 function displayStatusMessage(msg, type, hold) {
     var iMessageTime = 5000;
 
-    var oMessage = document.getElementById('statusMessage');
+    var oMessage = document.getElementById("statusMessage");
 
     // Initialize when not yet done
-    if(!oMessage) {
-        oMessage = document.createElement('div');
-        oMessage.setAttribute('id', 'statusMessage');
-        if(isIE)
-            oMessage.style.filter = 'alpha(opacity=85)';
+    if (!oMessage) {
+        oMessage = document.createElement("div");
+        oMessage.setAttribute("id", "statusMessage");
+        if (isIE) oMessage.style.filter = "alpha(opacity=85)";
 
         document.body.appendChild(oMessage);
     }
 
     // When there is another timer clear it
-    if(oStatusMessageTimer) {
+    if (oStatusMessageTimer) {
         clearTimeout(oStatusMessageTimer);
     }
 
     var cont = msg;
     if (type) {
-        cont = '<div class="'+type+'">'+cont+'</div>';
+        cont = '<div class="' + type + '">' + cont + "</div>";
     }
 
     oMessage.innerHTML = cont;
-    oMessage.style.display = 'block';
+    oMessage.style.display = "block";
 
-    if (type != 'loading') {
-        oMessage.onmousedown = function() { hideStatusMessage(); return true; };
+    if (type != "loading") {
+        oMessage.onmousedown = function () {
+            hideStatusMessage();
+            return true;
+        };
     }
 
     if (!hold) {
-        oStatusMessageTimer = window.setTimeout(function() { hideStatusMessage(); }, iMessageTime);
+        oStatusMessageTimer = window.setTimeout(function () {
+            hideStatusMessage();
+        }, iMessageTime);
     }
 
     oMessage = null;
 }
 
-
 // make a message row disapear
 function hideStatusMessage() {
-    var oMessage = document.getElementById('statusMessage');
+    var oMessage = document.getElementById("statusMessage");
 
     // Only hide when initialized
-    if(oMessage) {
-        oMessage.style.display = 'none';
+    if (oMessage) {
+        oMessage.style.display = "none";
         oMessage.onmousedown = null;
     }
 }
@@ -970,20 +1054,18 @@ function hideStatusMessage() {
  * @author  Lars Michelsen <lm@larsmichelsen.com>
  */
 function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, customStyle, scale) {
-    var oLabelDiv = document.createElement('div');
-    oLabelDiv.setAttribute('id', id);
-    oLabelDiv.className = 'box';
+    var oLabelDiv = document.createElement("div");
+    oLabelDiv.setAttribute("id", id);
+    oLabelDiv.className = "box";
     oLabelDiv.style.background = bgColor;
     oLabelDiv.style.borderColor = borderColor;
 
-    oLabelDiv.style.left = x + 'px';
-    oLabelDiv.style.top = y + 'px';
+    oLabelDiv.style.left = x + "px";
+    oLabelDiv.style.top = y + "px";
 
-    if(w && w !== '' && w !== 'auto')
-        oLabelDiv.style.width = addZoomFactor(w) + 'px';
+    if (w && w !== "" && w !== "auto") oLabelDiv.style.width = addZoomFactor(w) + "px";
 
-    if(h && h !== '' && h !== 'auto')
-        oLabelDiv.style.height = addZoomFactor(h) + 'px';
+    if (h && h !== "" && h !== "auto") oLabelDiv.style.height = addZoomFactor(h) + "px";
 
     oLabelDiv.style.zIndex = parseInt(z) + 1;
 
@@ -996,17 +1078,13 @@ function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, cust
      * IE workaround: The transparent for the color is not enough. The border
      * has really to be hidden.
      */
-    if(borderColor == 'transparent')
-        oLabelDiv.style.borderStyle = 'none';
-    else
-        oLabelDiv.style.borderStyle = 'solid';
+    if (borderColor == "transparent") oLabelDiv.style.borderStyle = "none";
+    else oLabelDiv.style.borderStyle = "solid";
 
     // Create span for text and add label text
     var oLabelSpan = null;
-    if(oLabelDiv.childNodes.length == 0)
-        oLabelSpan = document.createElement('span');
-    else
-        oLabelSpan = oLabelDiv.childNodes[0];
+    if (oLabelDiv.childNodes.length == 0) oLabelSpan = document.createElement("span");
+    else oLabelSpan = oLabelDiv.childNodes[0];
 
     // Setting custom style if someone wants the textbox to be
     // styled.
@@ -1014,23 +1092,22 @@ function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, cust
     // The problem here is that the custom style is given as content of the
     // HTML style attribute. But that can not be applied easily using plain
     // JS. So parse the string and apply the options manually.
-    if(customStyle && customStyle !== '') {
+    if (customStyle && customStyle !== "") {
         // Split up the coustom style string to apply the attributes
-        var aStyle = customStyle.split(';');
-        for(var i in aStyle) {
-            if(typeof(aStyle[i]) !== 'string')
-                continue;
-            var aOpt = aStyle[i].split(':');
+        var aStyle = customStyle.split(";");
+        for (var i in aStyle) {
+            if (typeof aStyle[i] !== "string") continue;
+            var aOpt = aStyle[i].split(":");
 
-            if(aOpt[0] && aOpt[0] != '' && aOpt[1] && aOpt[1] != '') {
-                var sKey = aOpt[0].replace(/(-[a-zA-Z])/g, '$1');
+            if (aOpt[0] && aOpt[0] != "" && aOpt[1] && aOpt[1] != "") {
+                var sKey = aOpt[0].replace(/(-[a-zA-Z])/g, "$1");
 
                 var regex = /(-[a-zA-Z])/;
                 var result = regex.exec(aOpt[0]);
 
-                if(result !== null) {
+                if (result !== null) {
                     for (var i = 1; i < result.length; i++) {
-                        var fixed = result[i].replace('-', '').toUpperCase();
+                        var fixed = result[i].replace("-", "").toUpperCase();
                         sKey = sKey.replace(result[i], fixed);
                     }
                 }
@@ -1044,39 +1121,30 @@ function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, cust
 
     let a_regex = /<a href="([^"]*)".*>.*<\/a>/g;
     let a_match = a_regex.exec(text);
-    let a_schema = a_match ? a_match[1].split(':')[0] : null;
-    const allowed_url_schemas = ['http', 'https'];
+    let a_schema = a_match ? a_match[1].split(":")[0] : null;
+    const allowed_url_schemas = ["http", "https"];
     if (!a_schema || allowed_url_schemas.includes(a_schema)) {
         oLabelSpan.innerHTML = text;
         executeJS(oLabelSpan);
-    }
-    else {
-        eventlog(
-            "renderNagVisTextbox",
-            "critical",
-            "Disallowed link schema in textbox: " + a_match[1]
-        );
+    } else {
+        eventlog("renderNagVisTextbox", "critical", "Disallowed link schema in textbox: " + a_match[1]);
     }
 
     oLabelDiv.appendChild(oLabelSpan);
 
     // Take zoom factor into account
     if (isZoomed()) {
-        oLabelDiv.width  = addZoomFactor(oLabelDiv.width);
+        oLabelDiv.width = addZoomFactor(oLabelDiv.width);
         oLabelDiv.height = addZoomFactor(oLabelDiv.height);
 
-        var fontSize = getEffectiveStyle(oLabelSpan, 'font-size');
-        if(fontSize === null) {
-            eventlog(
-                "renderNagVisTextbox",
-                "critical",
-                "Unable to fetch font-size attribute for textbox"
-            );
+        var fontSize = getEffectiveStyle(oLabelSpan, "font-size");
+        if (fontSize === null) {
+            eventlog("renderNagVisTextbox", "critical", "Unable to fetch font-size attribute for textbox");
         } else {
             // Only take zoom into account if the fontSize is set in px
-            if (fontSize.indexOf('px') !== -1) {
-                var fontSize = parseFloat(fontSize.replace('px', ''));
-                oLabelSpan.style.fontSize = addZoomFactor(fontSize) + 'px';
+            if (fontSize.indexOf("px") !== -1) {
+                var fontSize = parseFloat(fontSize.replace("px", ""));
+                oLabelSpan.style.fontSize = addZoomFactor(fontSize) + "px";
             } else {
                 eventlog(
                     "renderNagVisTextbox",
@@ -1102,13 +1170,19 @@ function lightenColor(code, rD, gD, bD) {
     var g = parseInt(code.substring(3, 5), 16);
     var b = parseInt(code.substring(5, 7), 16);
 
-    r += rD;  if (r > 255) r = 255;  if (r < 0) r = 0;
-    g += gD;  if (g > 255) g = 255;  if (g < 0) g = 0;
-    b += bD;  if (b > 255) b = 255;  if (b < 0) b = 0;
+    r += rD;
+    if (r > 255) r = 255;
+    if (r < 0) r = 0;
+    g += gD;
+    if (g > 255) g = 255;
+    if (g < 0) g = 0;
+    b += bD;
+    if (b > 255) b = 255;
+    if (b < 0) b = 0;
 
-    code  = r.length < 2 ? "0"+r.toString(16) : r.toString(16);
-    code += g.length < 2 ? "0"+g.toString(16) : g.toString(16);
-    code += b.length < 2 ? "0"+b.toString(16) : b.toString(16);
+    code = r.length < 2 ? "0" + r.toString(16) : r.toString(16);
+    code += g.length < 2 ? "0" + g.toString(16) : g.toString(16);
+    code += b.length < 2 ? "0" + b.toString(16) : b.toString(16);
 
     return "#" + code.toUpperCase();
 }
@@ -1119,16 +1193,14 @@ function lightenColor(code, rD, gD, bD) {
  * @author  Lars Michelsen <lm@larsmichelsen.com>
  */
 function getRegEx(n, exp, mod) {
-    if(typeof(regexCache[n]) !== 'undefined')
+    if (typeof regexCache[n] !== "undefined") return regexCache[n];
+    else if (mod !== undefined) {
+        regexCache[n + "-" + mod] = new RegExp(exp, mod);
+        return regexCache[n + "-" + mod];
+    } else {
+        regexCache[n] = new RegExp(exp);
         return regexCache[n];
-    else
-        if(mod !== undefined) {
-            regexCache[n+'-'+mod] = new RegExp(exp, mod);
-            return regexCache[n+'-'+mod];
-        } else {
-            regexCache[n] = new RegExp(exp);
-            return regexCache[n];
-        }
+    }
 }
 
 /**
@@ -1141,10 +1213,17 @@ function storeUserOption(key, value) {
     oUserProperties[key] = value;
 
     // And send to server
-    call_ajax(oGeneralProperties.path_server + '?mod=User&act=setOption&'
-              +'opts['+escapeUrlValues(key)+']='+escapeUrlValues(value), {
-        decode_json: false
-    });
+    call_ajax(
+        oGeneralProperties.path_server +
+            "?mod=User&act=setOption&" +
+            "opts[" +
+            escapeUrlValues(key) +
+            "]=" +
+            escapeUrlValues(value),
+        {
+            decode_json: false
+        }
+    );
 }
 
 /**
@@ -1153,7 +1232,7 @@ function storeUserOption(key, value) {
  * @author  Lars Michelsen <lm@larsmichelsen.com>
  */
 function isset(v) {
-    return typeof(v) !== 'undefined' && v !== null;
+    return typeof v !== "undefined" && v !== null;
 }
 
 /**
@@ -1162,14 +1241,14 @@ function isset(v) {
  * @author  Lars Michelsen <lm@larsmichelsen.com>
  */
 function isInt(v) {
-  return parseFloat(v) == parseInt(v) && !isNaN(v);
+    return parseFloat(v) == parseInt(v) && !isNaN(v);
 }
 
 /**
  * Checks if a variable is a float
  */
 function isFloat(v) {
-  return parseFloat(v) == v && !isNaN(v);
+    return parseFloat(v) == v && !isNaN(v);
 }
 
 /**
@@ -1178,7 +1257,7 @@ function isFloat(v) {
  * @author  Lars Michelsen <lm@larsmichelsen.com>
  */
 function pxToInt(v) {
-    return parseInt(v.replace('px', ''));
+    return parseInt(v.replace("px", ""));
 }
 
 // It's a bit problematic to detect relative coords because there is no
@@ -1187,100 +1266,90 @@ function pxToInt(v) {
 // san francisco and zooming to new your will lead to a negative 5 digit
 // negative coord).
 function isRelativeCoord(v) {
-    return typeof(v) === 'string' && v.includes('%')
+    return typeof v === "string" && v.includes("%");
 }
 
 // Helper function to determine the number of entries in an object
-Object.size = function(obj) {
-    var size = 0, key;
+Object.size = function (obj) {
+    var size = 0,
+        key;
     for (key in obj) {
         if (obj.hasOwnProperty(key)) size++;
     }
     return size;
-}
+};
 
 // Add compatibility code for browsers not supporting Function.prototype.bind().
 // see https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
 if (!Function.prototype.bind) {
-  Function.prototype.bind = function(oThis) {
-    if (typeof this !== 'function') {
-      // closest thing possible to the ECMAScript 5
-      // internal IsCallable function
-      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
-    }
+    Function.prototype.bind = function (oThis) {
+        if (typeof this !== "function") {
+            // closest thing possible to the ECMAScript 5
+            // internal IsCallable function
+            throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+        }
 
-    var aArgs   = Array.prototype.slice.call(arguments, 1),
-        fToBind = this,
-        fNOP    = function() {},
-        fBound  = function() {
-          return fToBind.apply(this instanceof fNOP
-                 ? this
-                 : oThis,
-                 aArgs.concat(Array.prototype.slice.call(arguments)));
-        };
+        var aArgs = Array.prototype.slice.call(arguments, 1),
+            fToBind = this,
+            fNOP = function () {},
+            fBound = function () {
+                return fToBind.apply(
+                    this instanceof fNOP ? this : oThis,
+                    aArgs.concat(Array.prototype.slice.call(arguments))
+                );
+            };
 
-    fNOP.prototype = this.prototype;
-    fBound.prototype = new fNOP();
+        fNOP.prototype = this.prototype;
+        fBound.prototype = new fNOP();
 
-    return fBound;
-  };
+        return fBound;
+    };
 }
 
 // Is missing in some browser, e.g. IE
 // Taken from Mozilla's (ECMA-262)
 // (https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/indexOf)
 if (!Array.prototype.indexOf) {
-  Array.prototype.indexOf = function(searchElement /*, fromIndex */) {
-    "use strict";
-    if (this === void 0 || this === null)
-      throw new TypeError();
+    Array.prototype.indexOf = function (searchElement /*, fromIndex */) {
+        "use strict";
+        if (this === void 0 || this === null) throw new TypeError();
 
-    var t = Object(this);
-    var len = t.length >>> 0;
-    if (len === 0)
-      return -1;
+        var t = Object(this);
+        var len = t.length >>> 0;
+        if (len === 0) return -1;
 
-    var n = 0;
-    if (arguments.length > 0)
-    {
-      n = Number(arguments[1]);
-      if (n !== n)
-        n = 0;
-      else if (n !== 0 && n !== (1 / 0) && n !== -(1 / 0))
-        n = (n > 0 || -1) * Math.floor(Math.abs(n));
-    }
+        var n = 0;
+        if (arguments.length > 0) {
+            n = Number(arguments[1]);
+            if (n !== n) n = 0;
+            else if (n !== 0 && n !== 1 / 0 && n !== -(1 / 0)) n = (n > 0 || -1) * Math.floor(Math.abs(n));
+        }
 
-    if (n >= len)
-      return -1;
+        if (n >= len) return -1;
 
-    var k = n >= 0
-          ? n
-          : Math.max(len - Math.abs(n), 0);
+        var k = n >= 0 ? n : Math.max(len - Math.abs(n), 0);
 
-    for (; k < len; k++)
-    {
-      if (k in t && t[k] === searchElement)
-        return k;
-    }
-    return -1;
-  };
-
+        for (; k < len; k++) {
+            if (k in t && t[k] === searchElement) return k;
+        }
+        return -1;
+    };
 }
 
 function getEffectiveStyle(e, attr) {
-    if(e.style[attr]) {
+    if (e.style[attr]) {
         // Object local
         return e.style[attr];
-    } else if(document.defaultView && document.defaultView.getComputedStyle) {
+    } else if (document.defaultView && document.defaultView.getComputedStyle) {
         // DOM
         return document.defaultView.getComputedStyle(e, null).getPropertyValue(attr);
-    } else if(e.currentStyle){
+    } else if (e.currentStyle) {
         // IE
-        var ie_attr = attr.replace(/\-(\w)/g, function (strMatch, p1){
+        var ie_attr = attr.replace(/\-(\w)/g, function (strMatch, p1) {
             return p1.toUpperCase();
         });
         var f = e.currentStyle[ie_attr];
-        if(f.length > 0) {
+        if (f.length > 0) {
             return f;
         }
     }
@@ -1289,16 +1358,13 @@ function getEffectiveStyle(e, attr) {
 
 var g_zoom_factor = null;
 function getZoomFactor() {
-    if(g_zoom_factor !== null)
-        return g_zoom_factor; // only compute once
+    if (g_zoom_factor !== null) return g_zoom_factor; // only compute once
 
-    var zoom = getViewParam('zoom');
+    var zoom = getViewParam("zoom");
     // Fill: At first use 100% zoom. Later, when everything has been rendered,
     // calculate the fill zoom factor and re-render with this option.
-    if (zoom === null || zoom == 'fill')
-        g_zoom_factor = 100;
-    else
-        g_zoom_factor = parseInt(zoom);
+    if (zoom === null || zoom == "fill") g_zoom_factor = 100;
+    else g_zoom_factor = parseInt(zoom);
 
     return g_zoom_factor;
 }
@@ -1312,36 +1378,33 @@ function isZoomed() {
  * might be a coordinate or a dimension of an object
  */
 function addZoomFactor(coord, forced) {
-    if (typeof(forced) === 'undefined')
-        var forced = false;
+    if (typeof forced === "undefined") var forced = false;
 
     if (!forced && oGeneralProperties.zoom_scale_objects && oGeneralProperties.zoom_scale_objects != 1)
         return parseInt(coord);
 
-    return parseInt(coord * getZoomFactor() / 100);
+    return parseInt((coord * getZoomFactor()) / 100);
 }
 
 function rmZoomFactor(coord, forced) {
-    if (typeof(forced) === 'undefined')
-        var forced = false;
+    if (typeof forced === "undefined") var forced = false;
 
     if (!forced && oGeneralProperties.zoom_scale_objects && oGeneralProperties.zoom_scale_objects != 1)
         return parseInt(coord);
 
-    return parseInt(coord / getZoomFactor() * 100);
+    return parseInt((coord / getZoomFactor()) * 100);
 }
 
 function zoomHandler(event, obj, forced_zoom) {
     // Another IE specific thing: "this" points to the window element,
     // not the raising object
-    if(obj == window) {
-        if(event.srcElement) {
+    if (obj == window) {
+        if (event.srcElement) {
             var obj = event.srcElement;
         }
     }
 
-    if(!obj)
-        return false;
+    if (!obj) return false;
 
     // This can not be added directly to the object beacause the
     // width/height is scaled in at least firefox automatically
@@ -1349,21 +1412,21 @@ function zoomHandler(event, obj, forced_zoom) {
     // IE FAIL: Needs to be made visible during getting obj.width/height
     // because IE can not tell us anything about the dimensions when
     // the object is not visible
-    obj.style.display = 'block';
-    var width  = addZoomFactor(obj.width, forced_zoom);
+    obj.style.display = "block";
+    var width = addZoomFactor(obj.width, forced_zoom);
     var height = addZoomFactor(obj.height, forced_zoom);
 
-    obj.style.display = 'none';
+    obj.style.display = "none";
 
-    obj.width  = width;
+    obj.width = width;
     obj.height = height;
     // Now really show the image
-    obj.style.display = 'block';
+    obj.style.display = "block";
 
     // Fix also the label position on e.g. automap nodes
-    var arr     = obj.id.split('-');
+    var arr = obj.id.split("-");
     var map_obj = getMapObjByDomObjId(arr[0]);
-    if(map_obj && typeof(map_obj.updateLabel) == 'function') {
+    if (map_obj && typeof map_obj.updateLabel == "function") {
         map_obj.updateLabel();
     }
 
@@ -1379,15 +1442,15 @@ function zoomHandler(event, obj, forced_zoom) {
  * The '.src' attribute must be assigned afterwards
  */
 function addZoomHandler(oImage, forced_zoom) {
-    if(!isZoomed())
-        return; // If not zoomed, no handler is needed
+    if (!isZoomed()) return; // If not zoomed, no handler is needed
 
-    if (typeof(forced_zoom) == 'undefined')
-        var forced_zoom = false;
+    if (typeof forced_zoom == "undefined") var forced_zoom = false;
 
-    oImage.style.display = 'none';
+    oImage.style.display = "none";
 
-    addEvent(oImage, 'load', function(event) { zoomHandler(event, this, forced_zoom); });
+    addEvent(oImage, "load", function (event) {
+        zoomHandler(event, this, forced_zoom);
+    });
     oImage = null;
 }
 
@@ -1402,29 +1465,24 @@ function addZoomHandler(oImage, forced_zoom) {
  * value to insert into the localized string.
  */
 function _(s, replace) {
-    if(typeof s === 'undefined')
-        return '';
+    if (typeof s === "undefined") return "";
 
     // Load localized version from PHP code (if available)
-    if(isset(oLocales[s])) {
+    if (isset(oLocales[s])) {
         s = oLocales[s];
     } else {
-        eventlog(
-            "localize",
-            "warning",
-            "String is not localizable '" + s + "'"
-        );
+        eventlog("localize", "warning", "String is not localizable '" + s + "'");
     }
 
     // Replace HTML codes
-    s = s.replace(/<(\/|)(i|b)>/ig, '');
-    s = s.replace('&auml;', 'ä').replace('&uuml;', 'ü');
-    s = s.replace('&ouml;', 'ö').replace('&szlig;', '');
+    s = s.replace(/<(\/|)(i|b)>/gi, "");
+    s = s.replace("&auml;", "ä").replace("&uuml;", "ü");
+    s = s.replace("&ouml;", "ö").replace("&szlig;", "");
 
     // optional replace of macros
-    if(typeof replace != "undefined") {
-        for(var i = 0; i < replace.length; i++) {
-            s = s.replace("["+replace[i][0]+"]", replace[i][1]);
+    if (typeof replace != "undefined") {
+        for (var i = 0; i < replace.length; i++) {
+            s = s.replace("[" + replace[i][0] + "]", replace[i][1]);
         }
     }
 
@@ -1437,18 +1495,16 @@ function has_class(o, cn) {
 }
 
 function remove_class(o, cn) {
-    var parts = o.className.split(' ');
+    var parts = o.className.split(" ");
     var new_parts = Array();
     for (var x = 0; x < parts.length; x++) {
-        if (parts[x] != cn)
-            new_parts.push(parts[x]);
+        if (parts[x] != cn) new_parts.push(parts[x]);
     }
     o.className = new_parts.join(" ");
 }
 
 function add_class(o, cn) {
-    if (!has_class(o, cn))
-        o.className += " " + cn;
+    if (!has_class(o, cn)) o.className += " " + cn;
 }
 
 function change_class(o, a, b) {
@@ -1488,11 +1544,11 @@ function min(arr) {
 }
 
 function newX(a, b, x, y) {
-    return Math.round(Math.cos(Math.atan2(y,x)+Math.atan2(b,a))*Math.sqrt(x*x+y*y));
+    return Math.round(Math.cos(Math.atan2(y, x) + Math.atan2(b, a)) * Math.sqrt(x * x + y * y));
 }
 
 function newY(a, b, x, y) {
-    return Math.round(Math.sin(Math.atan2(y,x)+Math.atan2(b,a))*Math.sqrt(x*x+y*y));
+    return Math.round(Math.sin(Math.atan2(y, x) + Math.atan2(b, a)) * Math.sqrt(x * x + y * y));
 }
 
 // simple implementation of function default arguments when
@@ -1510,23 +1566,22 @@ function merge_args() {
     var defaults = arguments[0];
     var args = arguments[1] || {};
 
-    for (var name in args)
-        defaults[name] = args[name];
+    for (var name in args) defaults[name] = args[name];
 
     return defaults;
 }
 
 function executeJS(obj) {
-    var aScripts = obj.getElementsByTagName('script');
+    var aScripts = obj.getElementsByTagName("script");
     for (var i = 0; i < aScripts.length; i++) {
-        if (aScripts[i].src && aScripts[i].src !== '') {
-            var oScr = document.createElement('script');
+        if (aScripts[i].src && aScripts[i].src !== "") {
+            var oScr = document.createElement("script");
             oScr.src = aScripts[i].src;
             document.getElementsByTagName("HEAD")[0].appendChild(oScr);
         } else {
             try {
                 eval(aScripts[i].text);
-            } catch(e) {
+            } catch (e) {
                 alert(aScripts[i].text + "\nError:" + e.message);
             }
         }

--- a/share/frontend/nagvis-js/js/nagvis.js
+++ b/share/frontend/nagvis-js/js/nagvis.js
@@ -34,26 +34,27 @@
 /*jslint evil: true, */
 
 /* Initiate global vars which are set later in the parsed HTML */
-var oWorkerProperties, oGeneralProperties, oRotationProperties;
-var oViewProperties;
-var oPageProperties = {};
-var oFileAges;
-var oStatusMessageTimer;
-var oMapObjects = {};
-var regexCache = {};
+let oWorkerProperties, oGeneralProperties, oRotationProperties;
+let oViewProperties;
+// eslint-disable-next-line prefer-const
+let oPageProperties = {};
+let oFileAges;
+let oStatusMessageTimer;
+const oMapObjects = {};
+const regexCache = {};
 
 // Initialize and define some other basic vars
-var iNow = Math.floor(Date.parse(new Date()) / 1000);
+const iNow = Math.floor(Date.parse(new Date()) / 1000);
 
 // Define some state options
-var oStates = {};
+const oStates = {};
 
-var isIE = navigator.appVersion.indexOf("MSIE") != -1;
+const isIE = navigator.appVersion.indexOf("MSIE") != -1;
 
 // These vars are used to stop earlier scrollings that mess between
-var crawlX = 0;
-var crawlY = 0;
-var crawling = 0;
+let crawlX = 0;
+let crawlY = 0;
+let crawling = 0;
 
 // This is a dummy fucntion which is overwritten by the definition in
 // the header template when it is enabled.
@@ -115,55 +116,53 @@ function date(format, timestamp) {
     // *     returns 8: '52'
     // *     example 9: date('W Y-m-d', 1293974054); // 2011-01-02
     // *     returns 9: '52 2011-01-02'
-    var that = this,
-        jsdate,
-        f,
-        formatChr = /\\?([a-z])/gi,
-        formatChrCb,
-        // Keep this here (works, but for code commented-out
-        // below for file size reasons)
-        //, tal= [],
-        _pad = function (n, c) {
-            if ((n = n + "").length < c) {
-                return new Array(++c - n.length).join("0") + n;
-            } else {
-                return n;
-            }
-        },
-        txt_words = [
-            "Sun",
-            "Mon",
-            "Tues",
-            "Wednes",
-            "Thurs",
-            "Fri",
-            "Satur",
-            "January",
-            "February",
-            "March",
-            "April",
-            "May",
-            "June",
-            "July",
-            "August",
-            "September",
-            "October",
-            "November",
-            "December"
-        ],
-        txt_ordin = {
-            1: "st",
-            2: "nd",
-            3: "rd",
-            21: "st",
-            22: "nd",
-            23: "rd",
-            31: "st"
-        };
-    formatChrCb = function (t, s) {
+    let that = this;
+    let jsdate;
+    const formatChr = /\\?([a-z])/gi;
+    const formatChrCb = function (t, s) {
         return f[t] ? f[t]() : s;
     };
-    f = {
+    // Keep this here (works, but for code commented-out
+    // below for file size reasons)
+    //, tal= [],
+    const _pad = function (n, c) {
+        if ((n = n + "").length < c) {
+            return new Array(++c - n.length).join("0") + n;
+        } else {
+            return n;
+        }
+    };
+    const txt_words = [
+        "Sun",
+        "Mon",
+        "Tues",
+        "Wednes",
+        "Thurs",
+        "Fri",
+        "Satur",
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December"
+    ];
+    const txt_ordin = {
+        1: "st",
+        2: "nd",
+        3: "rd",
+        21: "st",
+        22: "nd",
+        23: "rd",
+        31: "st"
+    };
+    const f = {
         // Day
         d: function () {
             // Day of month w/leading 0; 01..31
@@ -195,7 +194,7 @@ function date(format, timestamp) {
         },
         z: function () {
             // Day of year; 0..365
-            var a = new Date(f.Y(), f.n() - 1, f.j()),
+            const a = new Date(f.Y(), f.n() - 1, f.j()),
                 b = new Date(f.Y(), 0, 1);
             return Math.round((a - b) / 864e5) + 1;
         },
@@ -203,7 +202,7 @@ function date(format, timestamp) {
         // Week
         W: function () {
             // ISO-8601 week number
-            var a = new Date(f.Y(), f.n() - 1, f.j() - f.N() + 3),
+            const a = new Date(f.Y(), f.n() - 1, f.j() - f.N() + 3),
                 b = new Date(a.getFullYear(), 0, 4);
             return 1 + Math.round((a - b) / 864e5 / 7);
         },
@@ -237,7 +236,7 @@ function date(format, timestamp) {
         },
         o: function () {
             // ISO-8601 year
-            var n = f.n(),
+            const n = f.n(),
                 W = f.W(),
                 Y = f.Y();
             return Y + (n === 12 && W < 9 ? -1 : n === 1 && W > 9);
@@ -262,7 +261,7 @@ function date(format, timestamp) {
         },
         B: function () {
             // Swatch Internet time; 000..999
-            var H = jsdate.getUTCHours() * 36e2, // Hours
+            const H = jsdate.getUTCHours() * 36e2, // Hours
                 i = jsdate.getUTCMinutes() * 60, // Minutes
                 s = jsdate.getUTCSeconds(); // Seconds
             return _pad(Math.floor((H + i + s + 36e2) / 86.4) % 1e3, 3);
@@ -309,7 +308,7 @@ function date(format, timestamp) {
             // DST observed?; 0 or 1
             // Compares Jan 1 minus Jan 1 UTC to Jul 1 minus Jul 1 UTC.
             // If they are not equal, then DST is observed.
-            var a = new Date(f.Y(), 0), // Jan 1
+            const a = new Date(f.Y(), 0), // Jan 1
                 c = Date.UTC(f.Y(), 0), // Jan 1 UTC
                 b = new Date(f.Y(), 6), // Jul 1
                 d = Date.UTC(f.Y(), 6); // Jul 1 UTC
@@ -317,12 +316,12 @@ function date(format, timestamp) {
         },
         O: function () {
             // Difference to GMT in hour format; e.g. +0200
-            var a = jsdate.getTimezoneOffset();
+            const a = jsdate.getTimezoneOffset();
             return (a > 0 ? "-" : "+") + _pad(Math.abs((a / 60) * 100), 4);
         },
         P: function () {
             // Difference to GMT w/colon; e.g. +02:00
-            var O = f.O();
+            const O = f.O();
             return O.substr(0, 3) + ":" + O.substr(3, 2);
         },
         T: function () {
@@ -392,7 +391,7 @@ function date(format, timestamp) {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function updateWorkerCounter() {
-    var oWorkerCounter = document.getElementById("workerLastRunCounter");
+    let oWorkerCounter = document.getElementById("workerLastRunCounter");
     // write the time to refresh to header counter
     if (oWorkerCounter) {
         if (oWorkerProperties.last_run) {
@@ -442,14 +441,14 @@ function rotationCountdown() {
         if (oRotationProperties.nextStepTime <= 0) {
             return rotatePage();
         } else {
-            var oRefCountHead = document.getElementById("refreshCounterHead");
+            let oRefCountHead = document.getElementById("refreshCounterHead");
             // write the time to refresh to header counter
             if (oRefCountHead) {
                 oRefCountHead.innerHTML = oRotationProperties.nextStepTime;
                 oRefCountHead = null;
             }
 
-            var oRefCount = document.getElementById("refreshCounter");
+            let oRefCount = document.getElementById("refreshCounter");
             // write the time to refresh to the normal counter
             if (oRefCount) {
                 oRefCount.innerHTML = oRotationProperties.nextStepTime;
@@ -466,10 +465,10 @@ function rotationCountdown() {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function getUrlParam(name) {
-    var name2 = name.replace("[", "\\[").replace("]", "\\]");
-    var regexS = "[\\?&]" + name2 + "=([^&#]*)";
-    var regex = new RegExp(regexS);
-    var results = regex.exec(window.location);
+    const name2 = name.replace("[", "\\[").replace("]", "\\]");
+    const regexS = "[\\?&]" + name2 + "=([^&#]*)";
+    const regex = new RegExp(regexS);
+    const results = regex.exec(window.location);
     if (results === null) {
         return "";
     } else {
@@ -483,15 +482,15 @@ function getUrlParam(name) {
  * - Can remove parameters by adding "null" values
  */
 function makeuri(addparams) {
-    var tmp = window.location.href.split("?");
-    var base = tmp[0];
+    let tmp = window.location.href.split("?");
+    const base = tmp[0];
     tmp = tmp[1].split("#");
     tmp = tmp[0].split("&");
-    var len = tmp.length;
-    var params = {};
-    var pair = null;
+    const len = tmp.length;
+    const params = {};
+    let pair = null;
 
-    for (var i = 0; i < tmp.length; i++) {
+    for (let i = 0; i < tmp.length; i++) {
         pair = tmp[i].split("=");
 
         // Skip unwanted params
@@ -501,15 +500,15 @@ function makeuri(addparams) {
     }
 
     // Add new params to the existing params. Overwrite duplicates
-    for (var key in addparams) {
+    for (const key in addparams) {
         if (addparams[key] != null) {
             params[key] = addparams[key];
         }
     }
 
     // Build list of key/value pairs
-    var aparams = [];
-    for (key in params) {
+    const aparams = [];
+    for (const key in params) {
         aparams.push(key + "=" + params[key]);
     }
 
@@ -549,12 +548,12 @@ function switchRotation() {
 }
 
 function getCurrentTime() {
-    var oDate = new Date();
-    var sHours = oDate.getHours();
+    const oDate = new Date();
+    let sHours = oDate.getHours();
     sHours = sHours < 10 ? "0" + sHours : sHours;
-    var sMinutes = oDate.getMinutes();
+    let sMinutes = oDate.getMinutes();
     sMinutes = sMinutes < 10 ? "0" + sMinutes : sMinutes;
-    var sSeconds = oDate.getSeconds();
+    let sSeconds = oDate.getSeconds();
     sSeconds = sSeconds < 10 ? "0" + sSeconds : sSeconds;
 
     return sHours + ":" + sMinutes + ":" + sSeconds;
@@ -577,7 +576,7 @@ function getRandom(min, max) {
 }
 
 function pageWidth() {
-    var w;
+    let w;
 
     if (window.innerWidth !== null && typeof window.innerWidth !== "undefined") {
         w = window.innerWidth;
@@ -593,7 +592,7 @@ function pageWidth() {
 }
 
 function pageHeight() {
-    var h;
+    let h;
 
     if (window.innerHeight !== null && typeof window.innerHeight !== "undefined") {
         h = window.innerHeight;
@@ -628,15 +627,13 @@ function getScrollLeft() {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function scrollSlow(iTargetX, iTargetY, iSpeed) {
-    var currentScrollTop = getScrollTop();
-    var currentScrollLeft = getScrollLeft();
-    var iMapOffsetTop;
-    var scrollTop;
-    var scrollLeft;
-    var iWidth;
-    var iHeight;
+    const currentScrollTop = getScrollTop();
+    const currentScrollLeft = getScrollLeft();
+    let iMapOffsetTop;
+    let scrollTop;
+    let scrollLeft;
 
-    var iStep = 10;
+    const iStep = 10;
 
     iTargetX = parseInt(iTargetX);
     iTargetY = parseInt(iTargetY);
@@ -649,7 +646,7 @@ function scrollSlow(iTargetX, iTargetY, iSpeed) {
     }
 
     // Get offset of the map div
-    var oMap = document.getElementById("map");
+    let oMap = document.getElementById("map");
     if (oMap && oMap.offsetTop) {
         iMapOffsetTop = oMap.offsetTop;
     } else {
@@ -658,8 +655,8 @@ function scrollSlow(iTargetX, iTargetY, iSpeed) {
     oMap = null;
 
     // Get measure of the screen
-    iWidth = pageWidth();
-    iHeight = pageHeight() - iMapOffsetTop;
+    const iWidth = pageWidth();
+    const iHeight = pageHeight() - iMapOffsetTop;
 
     if (
         (iTargetY < currentScrollTop + iHeight / 2 + iStep && iTargetY >= currentScrollTop + iHeight / 2 - iStep) ||
@@ -805,13 +802,13 @@ function oDump(object, depth, max) {
         return false;
     }
 
-    var indent = "";
-    for (var i = 0; i < depth; i++) {
+    let indent = "";
+    for (let i = 0; i < depth; i++) {
         indent += "  ";
     }
 
-    var output = "";
-    for (var key in object) {
+    let output = "";
+    for (const key in object) {
         output += "\n" + indent + key + ": ";
         switch (typeof object[key]) {
             case "object":
@@ -832,8 +829,8 @@ function oDump(object, depth, max) {
  * This counts the elements in an object
  */
 function oLength(object) {
-    var c = 0;
-    for (var key in object) c++;
+    let c = 0;
+    for (const key in object) c++;
     return c;
 }
 
@@ -867,27 +864,23 @@ function isFirefox() {
  */
 addDOMLoadEvent = (function () {
     // create event function stack
-    var load_events = [],
-        load_timer,
-        script,
-        done,
-        exec,
-        old_onload,
-        init = function () {
-            done = true;
+    const load_events = [];
+    let load_timer, script, done, exec, old_onload;
+    const init = function () {
+        done = true;
 
-            // kill the timer
-            clearInterval(load_timer);
+        // kill the timer
+        clearInterval(load_timer);
 
-            // execute each function in the stack in the order they were added
-            //
-            // LM: This small timeout seems to be needed for chrome to have the
-            // clientWidth attribute calculated which is needed by the controls
-            // of the map objects.
-            while ((exec = load_events.shift())) setTimeout(exec, 50);
+        // execute each function in the stack in the order they were added
+        //
+        // LM: This small timeout seems to be needed for chrome to have the
+        // clientWidth attribute calculated which is needed by the controls
+        // of the map objects.
+        while ((exec = load_events.shift())) setTimeout(exec, 50);
 
-            if (script) script.onreadystatechange = "";
-        };
+        if (script) script.onreadystatechange = "";
+    };
 
     return function (func) {
         // if the init function was already ran, just run this function now and stop
@@ -951,7 +944,7 @@ function handleJSError(sMsg, sUrl, iLine) {
 }
 
 function handleException(e) {
-    var msg = e.name + ": " + e.message;
+    let msg = e.name + ": " + e.message;
     if (e.stack) msg += "<br><code>" + e.stack + "</code>";
     handleJSError(msg, e.fileName, e.lineNumber);
 }
@@ -996,9 +989,9 @@ function preventDefaultEvents(event) {
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function displayStatusMessage(msg, type, hold) {
-    var iMessageTime = 5000;
+    const iMessageTime = 5000;
 
-    var oMessage = document.getElementById("statusMessage");
+    let oMessage = document.getElementById("statusMessage");
 
     // Initialize when not yet done
     if (!oMessage) {
@@ -1014,7 +1007,7 @@ function displayStatusMessage(msg, type, hold) {
         clearTimeout(oStatusMessageTimer);
     }
 
-    var cont = msg;
+    let cont = msg;
     if (type) {
         cont = '<div class="' + type + '">' + cont + "</div>";
     }
@@ -1040,7 +1033,7 @@ function displayStatusMessage(msg, type, hold) {
 
 // make a message row disapear
 function hideStatusMessage() {
-    var oMessage = document.getElementById("statusMessage");
+    const oMessage = document.getElementById("statusMessage");
 
     // Only hide when initialized
     if (oMessage) {
@@ -1056,7 +1049,7 @@ function hideStatusMessage() {
  * @author  Lars Michelsen <lm@larsmichelsen.com>
  */
 function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, customStyle, scale) {
-    var oLabelDiv = document.createElement("div");
+    const oLabelDiv = document.createElement("div");
     oLabelDiv.setAttribute("id", id);
     oLabelDiv.className = "box";
     oLabelDiv.style.background = bgColor;
@@ -1084,7 +1077,7 @@ function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, cust
     else oLabelDiv.style.borderStyle = "solid";
 
     // Create span for text and add label text
-    var oLabelSpan = null;
+    let oLabelSpan = null;
     if (oLabelDiv.childNodes.length == 0) oLabelSpan = document.createElement("span");
     else oLabelSpan = oLabelDiv.childNodes[0];
 
@@ -1096,20 +1089,20 @@ function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, cust
     // JS. So parse the string and apply the options manually.
     if (customStyle && customStyle !== "") {
         // Split up the coustom style string to apply the attributes
-        var aStyle = customStyle.split(";");
-        for (var i in aStyle) {
+        let aStyle = customStyle.split(";");
+        for (const i in aStyle) {
             if (typeof aStyle[i] !== "string") continue;
-            var aOpt = aStyle[i].split(":");
+            let aOpt = aStyle[i].split(":");
 
             if (aOpt[0] && aOpt[0] != "" && aOpt[1] && aOpt[1] != "") {
-                var sKey = aOpt[0].replace(/(-[a-zA-Z])/g, "$1");
+                let sKey = aOpt[0].replace(/(-[a-zA-Z])/g, "$1");
 
-                var regex = /(-[a-zA-Z])/;
-                var result = regex.exec(aOpt[0]);
+                const regex = /(-[a-zA-Z])/;
+                const result = regex.exec(aOpt[0]);
 
                 if (result !== null) {
-                    for (i = 1; i < result.length; i++) {
-                        var fixed = result[i].replace("-", "").toUpperCase();
+                    for (let i = 1; i < result.length; i++) {
+                        const fixed = result[i].replace("-", "").toUpperCase();
                         sKey = sKey.replace(result[i], fixed);
                     }
                 }
@@ -1121,9 +1114,9 @@ function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, cust
         aStyle = null;
     }
 
-    let a_regex = /<a href="([^"]*)".*>.*<\/a>/g;
-    let a_match = a_regex.exec(text);
-    let a_schema = a_match ? a_match[1].split(":")[0] : null;
+    const a_regex = /<a href="([^"]*)".*>.*<\/a>/g;
+    const a_match = a_regex.exec(text);
+    const a_schema = a_match ? a_match[1].split(":")[0] : null;
     const allowed_url_schemas = ["http", "https"];
     if (!a_schema || allowed_url_schemas.includes(a_schema)) {
         oLabelSpan.innerHTML = text;
@@ -1139,7 +1132,7 @@ function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, cust
         oLabelDiv.width = addZoomFactor(oLabelDiv.width);
         oLabelDiv.height = addZoomFactor(oLabelDiv.height);
 
-        var fontSize = getEffectiveStyle(oLabelSpan, "font-size");
+        let fontSize = getEffectiveStyle(oLabelSpan, "font-size");
         if (fontSize === null) {
             eventlog("renderNagVisTextbox", "critical", "Unable to fetch font-size attribute for textbox");
         } else {
@@ -1168,9 +1161,9 @@ function renderNagVisTextbox(id, bgColor, borderColor, x, y, z, w, h, text, cust
  * @author  Lars Michelsen <lm@larsmichelsen.com>
  */
 function lightenColor(code, rD, gD, bD) {
-    var r = parseInt(code.substring(1, 3), 16);
-    var g = parseInt(code.substring(3, 5), 16);
-    var b = parseInt(code.substring(5, 7), 16);
+    let r = parseInt(code.substring(1, 3), 16);
+    let g = parseInt(code.substring(3, 5), 16);
+    let b = parseInt(code.substring(5, 7), 16);
 
     r += rD;
     if (r > 255) r = 255;
@@ -1273,7 +1266,7 @@ function isRelativeCoord(v) {
 
 // Helper function to determine the number of entries in an object
 Object.size = function (obj) {
-    var size = 0,
+    let size = 0,
         key;
     for (key in obj) {
         if (obj.hasOwnProperty(key)) size++; // eslint-disable-line no-prototype-builtins
@@ -1291,7 +1284,7 @@ if (!Function.prototype.bind) {
             throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
         }
 
-        var aArgs = Array.prototype.slice.call(arguments, 1),
+        const aArgs = Array.prototype.slice.call(arguments, 1),
             fToBind = this,
             fNOP = function () {},
             fBound = function () {
@@ -1316,11 +1309,11 @@ if (!Array.prototype.indexOf) {
         "use strict";
         if (this === void 0 || this === null) throw new TypeError();
 
-        var t = Object(this);
-        var len = t.length >>> 0;
+        const t = Object(this);
+        const len = t.length >>> 0;
         if (len === 0) return -1;
 
-        var n = 0;
+        let n = 0;
         if (arguments.length > 0) {
             n = Number(arguments[1]);
             if (n !== n) n = 0;
@@ -1329,7 +1322,7 @@ if (!Array.prototype.indexOf) {
 
         if (n >= len) return -1;
 
-        var k = n >= 0 ? n : Math.max(len - Math.abs(n), 0);
+        let k = n >= 0 ? n : Math.max(len - Math.abs(n), 0);
 
         for (; k < len; k++) {
             if (k in t && t[k] === searchElement) return k;
@@ -1347,10 +1340,10 @@ function getEffectiveStyle(e, attr) {
         return document.defaultView.getComputedStyle(e, null).getPropertyValue(attr);
     } else if (e.currentStyle) {
         // IE
-        var ie_attr = attr.replace(/-(\w)/g, function (strMatch, p1) {
+        const ie_attr = attr.replace(/-(\w)/g, function (strMatch, p1) {
             return p1.toUpperCase();
         });
-        var f = e.currentStyle[ie_attr];
+        const f = e.currentStyle[ie_attr];
         if (f.length > 0) {
             return f;
         }
@@ -1358,11 +1351,11 @@ function getEffectiveStyle(e, attr) {
     return null;
 }
 
-var g_zoom_factor = null;
+let g_zoom_factor = null;
 function getZoomFactor() {
     if (g_zoom_factor !== null) return g_zoom_factor; // only compute once
 
-    var zoom = getViewParam("zoom");
+    const zoom = getViewParam("zoom");
     // Fill: At first use 100% zoom. Later, when everything has been rendered,
     // calculate the fill zoom factor and re-render with this option.
     if (zoom === null || zoom == "fill") g_zoom_factor = 100;
@@ -1415,8 +1408,8 @@ function zoomHandler(event, obj, forced_zoom) {
     // because IE can not tell us anything about the dimensions when
     // the object is not visible
     obj.style.display = "block";
-    var width = addZoomFactor(obj.width, forced_zoom);
-    var height = addZoomFactor(obj.height, forced_zoom);
+    const width = addZoomFactor(obj.width, forced_zoom);
+    const height = addZoomFactor(obj.height, forced_zoom);
 
     obj.style.display = "none";
 
@@ -1426,8 +1419,8 @@ function zoomHandler(event, obj, forced_zoom) {
     obj.style.display = "block";
 
     // Fix also the label position on e.g. automap nodes
-    var arr = obj.id.split("-");
-    var map_obj = getMapObjByDomObjId(arr[0]);
+    const arr = obj.id.split("-");
+    let map_obj = getMapObjByDomObjId(arr[0]);
     if (map_obj && typeof map_obj.updateLabel == "function") {
         map_obj.updateLabel();
     }
@@ -1483,7 +1476,7 @@ function _(s, replace) {
 
     // optional replace of macros
     if (typeof replace != "undefined") {
-        for (var i = 0; i < replace.length; i++) {
+        for (let i = 0; i < replace.length; i++) {
             s = s.replace("[" + replace[i][0] + "]", replace[i][1]);
         }
     }
@@ -1497,9 +1490,9 @@ function has_class(o, cn) {
 }
 
 function remove_class(o, cn) {
-    var parts = o.className.split(" ");
-    var new_parts = Array();
-    for (var x = 0; x < parts.length; x++) {
+    const parts = o.className.split(" ");
+    const new_parts = Array();
+    for (let x = 0; x < parts.length; x++) {
         if (parts[x] != cn) new_parts.push(parts[x]);
     }
     o.className = new_parts.join(" ");
@@ -1521,9 +1514,9 @@ function middle(x1, x2, cut) {
 
 // Returns the maximum value in an array
 function max(arr) {
-    var max = arr[0];
+    let max = arr[0];
 
-    for (var i = 1, len = arr.length; i < len; i++) {
+    for (let i = 1, len = arr.length; i < len; i++) {
         if (arr[i] > max) {
             max = arr[i];
         }
@@ -1534,9 +1527,9 @@ function max(arr) {
 
 // Returns the minimum value in an array
 function min(arr) {
-    var min = arr[0];
+    let min = arr[0];
 
-    for (var i = 1, len = arr.length; i < len; i++) {
+    for (let i = 1, len = arr.length; i < len; i++) {
         if (arr[i] < min) {
             min = arr[i];
         }
@@ -1565,19 +1558,19 @@ function newY(a, b, x, y) {
 //   'arg3': 'val3',
 // })
 function merge_args() {
-    var defaults = arguments[0];
-    var args = arguments[1] || {};
+    const defaults = arguments[0];
+    const args = arguments[1] || {};
 
-    for (var name in args) defaults[name] = args[name];
+    for (const name in args) defaults[name] = args[name];
 
     return defaults;
 }
 
 function executeJS(obj) {
-    var aScripts = obj.getElementsByTagName("script");
-    for (var i = 0; i < aScripts.length; i++) {
+    const aScripts = obj.getElementsByTagName("script");
+    for (let i = 0; i < aScripts.length; i++) {
         if (aScripts[i].src && aScripts[i].src !== "") {
-            var oScr = document.createElement("script");
+            const oScr = document.createElement("script");
             oScr.src = aScripts[i].src;
             document.getElementsByTagName("HEAD")[0].appendChild(oScr);
         } else {

--- a/share/frontend/nagvis-js/js/popupWindow.js
+++ b/share/frontend/nagvis-js/js/popupWindow.js
@@ -40,14 +40,14 @@ var dragObj = null;
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 function movemouse(e) {
- if(bDragging) {
-   dragObj.style.left = popupNN6 ? (pwTx + e.clientX - pwX) + 'px' : (pwTx + event.clientX - pwX) + 'px';
-   dragObj.style.top  = popupNN6 ? (pwTy + e.clientY - pwY) + 'px' : (pwTy + event.clientY - pwY) + 'px';
+    if (bDragging) {
+        dragObj.style.left = popupNN6 ? pwTx + e.clientX - pwX + "px" : pwTx + event.clientX - pwX + "px";
+        dragObj.style.top = popupNN6 ? pwTy + e.clientY - pwY + "px" : pwTy + event.clientY - pwY + "px";
 
-   return false;
- }
+        return false;
+    }
 
- return true;
+    return true;
 }
 
 /**
@@ -62,40 +62,38 @@ function movemouse(e) {
 function selectmouse(e) {
     bDragging = true;
 
-    dragObj = document.getElementById('popupWindow');
+    dragObj = document.getElementById("popupWindow");
 
-    pwTx = parseInt(dragObj.style.left+0, 10);
-    pwTy = parseInt(dragObj.style.top+0, 10);
+    pwTx = parseInt(dragObj.style.left + 0, 10);
+    pwTy = parseInt(dragObj.style.top + 0, 10);
     pwX = popupNN6 ? e.clientX : event.clientX;
     pwY = popupNN6 ? e.clientY : event.clientY;
 
     // Register the popup window handling on the body element
     // The document.onmousemove is used by the hover menu
-    document.body.onmousemove=movemouse;
+    document.body.onmousemove = movemouse;
 
     return false;
 }
 
 function popupWindowClose() {
-    var w = document.getElementById('popupWindow');
-    if (w)
-        document.body.removeChild(w);
+    var w = document.getElementById("popupWindow");
+    if (w) document.body.removeChild(w);
 
     // Some windows use the jscolor color picker. It might be visible while
     // a user closes the window. All eventual open color pickers are opened
     // within popup windows. So it is safe to close all color pickers when
     // closing a window
-    if (jscolor.picker && jscolor.picker.owner)
-        jscolor.picker.owner.hidePicker();
+    if (jscolor.picker && jscolor.picker.owner) jscolor.picker.owner.hidePicker();
 }
 
 function popupWindowPutContent(oContent) {
-    if(oContent === null || oContent.code === null) {
+    if (oContent === null || oContent.code === null) {
         return false;
     }
 
-    var oCell = document.getElementById('popupWindowContent');
-    if(oCell) {
+    var oCell = document.getElementById("popupWindowContent");
+    if (oCell) {
         oCell.innerHTML = oContent.code;
         executeJS(oCell);
     }
@@ -103,57 +101,55 @@ function popupWindowPutContent(oContent) {
 
 // Creates a javascript dialog
 function popupWindow(title, oContent, sWidth, closable) {
-    if(oContent === null || oContent.code === null)
-        return false;
+    if (oContent === null || oContent.code === null) return false;
 
-    if (typeof closable === 'undefined')
-        closable = true;
+    if (typeof closable === "undefined") closable = true;
 
     // Maybe some other window is still open. Close it now
     popupWindowClose();
 
     // Default window position
-    var posX = getScrollLeft() + (pageWidth()/2 - sWidth/2);
+    var posX = getScrollLeft() + (pageWidth() / 2 - sWidth / 2);
     var posY = getScrollTop() + 50;
 
-    var oContainerDiv = document.createElement('div');
-    oContainerDiv.setAttribute('id', 'popupWindow');
-    oContainerDiv.style.left = posX+'px';
-    oContainerDiv.style.top = posY+'px';
-    oContainerDiv.style.width = sWidth+'px';
+    var oContainerDiv = document.createElement("div");
+    oContainerDiv.setAttribute("id", "popupWindow");
+    oContainerDiv.style.left = posX + "px";
+    oContainerDiv.style.top = posY + "px";
+    oContainerDiv.style.width = sWidth + "px";
 
     oContainerDiv.url = oContent.url;
 
     // Render the close button
     if (closable) {
-        var oClose = document.createElement('div');
-        oClose.className = 'close';
+        var oClose = document.createElement("div");
+        oClose.className = "close";
 
-        oClose.onclick = function() {
+        oClose.onclick = function () {
             popupWindowClose();
             return false;
         };
 
-        oClose.appendChild(document.createTextNode('x'));
+        oClose.appendChild(document.createTextNode("x"));
         oContainerDiv.appendChild(oClose);
         oClose = null;
     }
 
     // Render the window title
-    var oTitle = document.createElement('h1');
+    var oTitle = document.createElement("h1");
     oTitle.appendChild(document.createTextNode(title));
 
     // Make title the drag window handler
     oTitle.onmousedown = selectmouse;
-    oTitle.onmouseup = function() {
+    oTitle.onmouseup = function () {
         bDragging = false;
     };
 
     oContainerDiv.appendChild(oTitle);
     oTitle = null;
 
-    var content = document.createElement('div');
-    content.setAttribute('id', 'popupWindowContent');
+    var content = document.createElement("div");
+    content.setAttribute("id", "popupWindowContent");
     oContainerDiv.appendChild(content);
     content = null;
 

--- a/share/frontend/nagvis-js/js/popupWindow.js
+++ b/share/frontend/nagvis-js/js/popupWindow.js
@@ -25,10 +25,10 @@
  * @author	Lars Michelsen <lm@larsmichelsen.com>
  */
 
-var popupNN6 = document.getElementById && !document.all;
-var bDragging = false;
-var pwX, pwY, pwTx, pwTy;
-var dragObj = null;
+const popupNN6 = document.getElementById && !document.all;
+let bDragging = false;
+let pwX, pwY, pwTx, pwTy;
+let dragObj = null;
 
 /**
  * movemouse()
@@ -77,7 +77,7 @@ function selectmouse(e) {
 }
 
 function popupWindowClose() {
-    var w = document.getElementById("popupWindow");
+    const w = document.getElementById("popupWindow");
     if (w) document.body.removeChild(w);
 
     // Some windows use the jscolor color picker. It might be visible while
@@ -92,7 +92,7 @@ function popupWindowPutContent(oContent) {
         return false;
     }
 
-    var oCell = document.getElementById("popupWindowContent");
+    const oCell = document.getElementById("popupWindowContent");
     if (oCell) {
         oCell.innerHTML = oContent.code;
         executeJS(oCell);
@@ -109,10 +109,10 @@ function popupWindow(title, oContent, sWidth, closable) {
     popupWindowClose();
 
     // Default window position
-    var posX = getScrollLeft() + (pageWidth() / 2 - sWidth / 2);
-    var posY = getScrollTop() + 50;
+    const posX = getScrollLeft() + (pageWidth() / 2 - sWidth / 2);
+    const posY = getScrollTop() + 50;
 
-    var oContainerDiv = document.createElement("div");
+    const oContainerDiv = document.createElement("div");
     oContainerDiv.setAttribute("id", "popupWindow");
     oContainerDiv.style.left = posX + "px";
     oContainerDiv.style.top = posY + "px";
@@ -122,7 +122,7 @@ function popupWindow(title, oContent, sWidth, closable) {
 
     // Render the close button
     if (closable) {
-        var oClose = document.createElement("div");
+        let oClose = document.createElement("div");
         oClose.className = "close";
 
         oClose.onclick = function () {
@@ -136,7 +136,7 @@ function popupWindow(title, oContent, sWidth, closable) {
     }
 
     // Render the window title
-    var oTitle = document.createElement("h1");
+    let oTitle = document.createElement("h1");
     oTitle.appendChild(document.createTextNode(title));
 
     // Make title the drag window handler
@@ -148,7 +148,7 @@ function popupWindow(title, oContent, sWidth, closable) {
     oContainerDiv.appendChild(oTitle);
     oTitle = null;
 
-    var content = document.createElement("div");
+    let content = document.createElement("div");
     content.setAttribute("id", "popupWindowContent");
     oContainerDiv.appendChild(content);
     content = null;

--- a/share/userfiles/templates/default.header.js
+++ b/share/userfiles/templates/default.header.js
@@ -144,7 +144,7 @@ function ddMenuToggle(event, id) {
 
 // Hide the given menus instant
 function ddMenuHide(close_menus) {
-    if (typeof close_menus === "undefined") var close_menus = open_menus.slice(); // copy open menus array
+    if (typeof close_menus === "undefined") close_menus = open_menus.slice(); // copy open menus array
 
     var h, index;
     for (var i = 0; i < close_menus.length; i++) {

--- a/share/userfiles/templates/default.header.js
+++ b/share/userfiles/templates/default.header.js
@@ -30,27 +30,23 @@
  */
 
 function headerDraw() {
-    if(typeof(oUserProperties) === 'undefined')
-        return;
+    if (typeof oUserProperties === "undefined") return;
 
-    if(typeof(oUserProperties.header) !== 'undefined' && oUserProperties.header === false)
-        toggleHeader(false);
+    if (typeof oUserProperties.header !== "undefined" && oUserProperties.header === false) toggleHeader(false);
 
-    addEvent(document, 'mousedown', checkHideMenu);
+    addEvent(document, "mousedown", checkHideMenu);
 }
 
 // Is executed when the user clicks somewhere on the map. Checks whether or
 // not one of the headers dropdown menus is currently open. Hides it when
 // the user clicks out of the menu or takes no action when clicking inside.
 function checkHideMenu(event) {
-    if (!event)
-        event = window.event;
+    if (!event) event = window.event;
 
     // Check whether or not a parent has the class "dropdown"
     var target = getTargetRaw(event);
     while (target) {
-        if (has_class(target, 'dropdown'))
-            return; // found the menu object, no further action
+        if (has_class(target, "dropdown")) return; // found the menu object, no further action
         target = target.parentNode;
     }
 
@@ -59,33 +55,31 @@ function checkHideMenu(event) {
 }
 
 function toggleHeader(store) {
-    var header  = document.getElementById('header');
-    var spacer  = document.getElementById('headerspacer');
-    var show    = document.getElementById('headershow');
+    var header = document.getElementById("header");
+    var spacer = document.getElementById("headerspacer");
+    var show = document.getElementById("headershow");
     var state = true;
 
     // Reset the header height cache
     g_header_height_cache = null;
 
-    if(header.style.display === '') {
-        header.style.display = 'none';
-        spacer.style.display = 'none';
-        show.style.display   = 'block';
+    if (header.style.display === "") {
+        header.style.display = "none";
+        spacer.style.display = "none";
+        show.style.display = "block";
         state = false;
     } else {
-        header.style.display = '';
-        spacer.style.display = '';
-        show.style.display   = 'none';
+        header.style.display = "";
+        spacer.style.display = "";
+        show.style.display = "none";
     }
 
     sidebarUpdatePosition();
-    if (g_view)
-        g_view.scaleView();
+    if (g_view) g_view.scaleView();
 
-    if(store === true)
-        storeUserOption('header', state);
+    if (store === true) storeUserOption("header", state);
 
-    show   = null;
+    show = null;
     spacer = null;
     header = null;
 }
@@ -93,21 +87,21 @@ function toggleHeader(store) {
 // Sets/Updates the state of a map in the header menu
 function headerUpdateState(map_conf) {
     // Exit this function on invalid call
-    if(map_conf === null || map_conf.length != 1)  {
+    if (map_conf === null || map_conf.length != 1) {
         eventlog("worker", "warning", "headerUpdateState: Invalid call - maybe broken ajax response");
         return false;
     }
 
     var map = map_conf[0];
 
-    var side = document.getElementById('side-state-' + map['name']);
+    var side = document.getElementById("side-state-" + map["name"]);
     if (side) {
-        side.className = 'statediv s' + map['summary_state'];
-        if (map['summary_problem_has_been_acknowledged'] == 1) {
-            side.className += ' sACK';
+        side.className = "statediv s" + map["summary_state"];
+        if (map["summary_problem_has_been_acknowledged"] == 1) {
+            side.className += " sACK";
         }
-        if (map['summary_in_downtime'] == 1) {
-            side.className += ' sDOWNTIME';
+        if (map["summary_in_downtime"] == 1) {
+            side.className += " sDOWNTIME";
         }
         side = null;
     }
@@ -118,16 +112,22 @@ open_menus = [];
 // Is called to initialize fetching states for the header/sidebar menu
 function headerUpdateStates() {
     for (var i = 0; i < g_map_names.length; i++) {
-        call_ajax(oGeneralProperties.path_server+'?mod=Overview&act=getObjectStates'
-                  + '&i[]=map-' + escapeUrlValues(g_map_names[i]) + getViewParams(), {
-            response_handler: headerUpdateState
-        });
+        call_ajax(
+            oGeneralProperties.path_server +
+                "?mod=Overview&act=getObjectStates" +
+                "&i[]=map-" +
+                escapeUrlValues(g_map_names[i]) +
+                getViewParams(),
+            {
+                response_handler: headerUpdateState
+            }
+        );
     }
 }
 
 function ddMenuToggle(event, id) {
     event = event || window.event;
-    var this_open = false
+    var this_open = false;
     for (var i = 0; i < open_menus.length; i++) {
         if (open_menus[i] == id) {
             this_open = true;
@@ -138,24 +138,21 @@ function ddMenuToggle(event, id) {
     // In any case close all open menus. When the triggered
     // menu was not open before, then open it up again.
     ddMenuHide();
-    if (!this_open)
-        ddMenu(id);
+    if (!this_open) ddMenu(id);
     return preventDefaultEvents(event);
 }
 
 // Hide the given menus instant
 function ddMenuHide(close_menus) {
-    if(typeof(close_menus) === 'undefined')
-        var close_menus = open_menus.slice(); // copy open menus array
+    if (typeof close_menus === "undefined") var close_menus = open_menus.slice(); // copy open menus array
 
     var h, index;
-    for(var i = 0; i < close_menus.length; i++) {
-        h = document.getElementById(close_menus[i] + '-ddcontent');
+    for (var i = 0; i < close_menus.length; i++) {
+        h = document.getElementById(close_menus[i] + "-ddcontent");
         h.style.display = "none";
 
         index = open_menus.indexOf(close_menus[i]);
-        if (index != -1)
-            open_menus.splice(index, 1);
+        if (index != -1) open_menus.splice(index, 1);
     }
 
     h = null;
@@ -167,35 +164,30 @@ function ddMenu(id, reposition) {
     // Hide all other open menus (which have not the id of the current menu in their id)
     for (var i = 0; i < open_menus.length; i++) {
         var other_id = open_menus[i];
-        if (id.indexOf('-') === -1) {
+        if (id.indexOf("-") === -1) {
             // main level menus (no minus in name) only hide other main level menus
-            if (other_id.indexOf(id) !== 0)
-                ddMenuHide([other_id]);
-        }
-        else {
+            if (other_id.indexOf(id) !== 0) ddMenuHide([other_id]);
+        } else {
             // sub level menus only hide other sub level menus of their parent menu
-            if (id != other_id
-                && other_id.indexOf('-') !== -1
-                && other_id.indexOf(id.split('-')[0]) === 0) {
+            if (id != other_id && other_id.indexOf("-") !== -1 && other_id.indexOf(id.split("-")[0]) === 0) {
                 ddMenuHide([other_id]);
             }
         }
     }
 
-    var h = document.getElementById(id + '-ddheader');
-    var c = document.getElementById(id + '-ddcontent');
+    var h = document.getElementById(id + "-ddheader");
+    var c = document.getElementById(id + "-ddcontent");
 
-    if (open_menus.indexOf(id) === -1)
-        open_menus.push(id);
+    if (open_menus.indexOf(id) === -1) open_menus.push(id);
 
     // Reposition by trigger object when some given (used on submenus)
     if (reposition === true) {
-        c.style.position = 'absolute';
-        c.style.left = '204px';
+        c.style.position = "absolute";
+        c.style.left = "204px";
         c.style.top = h.offsetTop + "px";
     }
 
-    c.style.display = 'block';
+    c.style.display = "block";
     return false;
 }
 
@@ -204,116 +196,103 @@ function ddMenu(id, reposition) {
 // ------------------------------
 
 function toggleSidebar(store) {
-    var sidebar = document.getElementById('sidebar');
-    var toggle  = document.getElementById('sidetoggle');
-    var content = document.getElementById('map');
+    var sidebar = document.getElementById("sidebar");
+    var toggle = document.getElementById("sidetoggle");
+    var content = document.getElementById("map");
     var is_overview = false;
-    if(content == null) {
-        content = document.getElementById('overview');
+    if (content == null) {
+        content = document.getElementById("overview");
         is_overview = true;
     }
 
     // If there is still no content don't execute the main code. So the sidebar
     // will not be available in undefined views like the WUI
-    if(content == null)
-        return false;
+    if (content == null) return false;
 
     var state = 1;
-    if(sidebarOpen()) {
-        sidebar.style.display = 'none';
-        if(is_overview === false) {
-            content.style.left = '0';
+    if (sidebarOpen()) {
+        sidebar.style.display = "none";
+        if (is_overview === false) {
+            content.style.left = "0";
         } else {
-            content.style.marginLeft = '0px';
+            content.style.marginLeft = "0px";
         }
-        toggle.firstChild.src = oGeneralProperties.path_images + 'internal/sidebar_open.png';
+        toggle.firstChild.src = oGeneralProperties.path_images + "internal/sidebar_open.png";
         state = 0;
     } else {
         // open the sidebar
 
         ddMenuHide(); // hide all dropdown menus
 
-        sidebar.style.display = 'inline';
-        if(is_overview === false) {
-            content.style.left = '200px';
+        sidebar.style.display = "inline";
+        if (is_overview === false) {
+            content.style.left = "200px";
         } else {
-            content.style.marginLeft = '200px';
+            content.style.marginLeft = "200px";
         }
-        toggle.firstChild.src = oGeneralProperties.path_images + 'internal/sidebar_close.png';
+        toggle.firstChild.src = oGeneralProperties.path_images + "internal/sidebar_close.png";
 
         sidebarUpdatePosition();
 
-        if (oGeneralProperties.header_show_states)
-            headerUpdateStates();
+        if (oGeneralProperties.header_show_states) headerUpdateStates();
     }
 
-    if(store === true)
-        storeUserOption('sidebar', state);
+    if (store === true) storeUserOption("sidebar", state);
 
-    state   = null;
+    state = null;
     content = null;
     sidebar = null;
     return false;
 }
 
 function sidebarOpen() {
-    var o = document.getElementById('sidebar');
-    if (!o)
-        return false;
-    return !(o.style.display  == 'none' || o.style.display == '');
+    var o = document.getElementById("sidebar");
+    if (!o) return false;
+    return !(o.style.display == "none" || o.style.display == "");
 }
 
 function getSidebarWidth() {
-    if(!sidebarOpen())
-        return 0;
-    else
-        return document.getElementById('sidebar').clientWidth;
+    if (!sidebarOpen()) return 0;
+    else return document.getElementById("sidebar").clientWidth;
 }
 
 // Cares about the initial drawing of the sidebar on page load
 // Loads the sidebar visibility state from the server
 function sidebarDraw() {
-    if(typeof(oUserProperties) === 'undefined')
-        return;
+    if (typeof oUserProperties === "undefined") return;
 
-    if(typeof(oUserProperties.sidebar) !== 'undefined' && oUserProperties.sidebar === 1)
-        toggleSidebar(false);
+    if (typeof oUserProperties.sidebar !== "undefined" && oUserProperties.sidebar === 1) toggleSidebar(false);
 
     // Initialize value
-    if(typeof(oUserProperties.sidebarOpenNodes) === 'undefined')
-        oUserProperties.sidebarOpenNodes = '';
+    if (typeof oUserProperties.sidebarOpenNodes === "undefined") oUserProperties.sidebarOpenNodes = "";
 
     // If no nodes are open don't try to open some
-    if(oUserProperties.sidebarOpenNodes === '')
-        return;
+    if (oUserProperties.sidebarOpenNodes === "") return;
 
-    var openNodes = oUserProperties.sidebarOpenNodes.split(',');
-    for(var i = 0, len = openNodes.length; i < len; i++) {
-        var node = document.getElementById(openNodes[i] + '-childs');
-        if(node) {
-            node.style.display = 'block';
-            add_class(node.parentNode, 'open');
-            remove_class(node.parentNode, 'closed');
+    var openNodes = oUserProperties.sidebarOpenNodes.split(",");
+    for (var i = 0, len = openNodes.length; i < len; i++) {
+        var node = document.getElementById(openNodes[i] + "-childs");
+        if (node) {
+            node.style.display = "block";
+            add_class(node.parentNode, "open");
+            remove_class(node.parentNode, "closed");
             node = null;
         }
     }
 }
 
 function sidebarUpdatePosition() {
-    var sidebar = document.getElementById('sidebar');
-    if (sidebar && sidebarOpen())
-        sidebar.style.top = getHeaderHeight() + 'px';
+    var sidebar = document.getElementById("sidebar");
+    if (sidebar && sidebarOpen()) sidebar.style.top = getHeaderHeight() + "px";
 }
 
 function sidebarDrawSubtree(node, index) {
     // Check if this node is expanded
-    for(var i = 0, len = oUserProperties.sidebarOpenNodes.length; i < len; i++)
-        if(oUserProperties.sidebarOpenNodes[i] == index)
-            return;
+    for (var i = 0, len = oUserProperties.sidebarOpenNodes.length; i < len; i++)
+        if (oUserProperties.sidebarOpenNodes[i] == index) return;
 
     // Hide sidebar when not in openNodes
-    if(node.parentNode != document.getElementById('sidebar'))
-        node.style.display = 'none';
+    if (node.parentNode != document.getElementById("sidebar")) node.style.display = "none";
 }
 
 function sidebarToggleSubtree(oTitle) {
@@ -321,35 +300,32 @@ function sidebarToggleSubtree(oTitle) {
     var this_id = oTitle.id;
     var state = 1;
     var openNodes;
-    if(oUserProperties.sidebarOpenNodes === '')
-        openNodes = [];
-    else
-        openNodes = oUserProperties.sidebarOpenNodes.split(',');
+    if (oUserProperties.sidebarOpenNodes === "") openNodes = [];
+    else openNodes = oUserProperties.sidebarOpenNodes.split(",");
 
     var oListItem = oTitle.parentNode.parentNode;
-    if(oList.style.display == 'none' || oList.style.display == '') {
+    if (oList.style.display == "none" || oList.style.display == "") {
         // Make the sublist visible
-        oList.style.display = 'block';
+        oList.style.display = "block";
 
         // Open the folder
-        add_class(oListItem, 'open');
-        remove_class(oListItem, 'closed');
+        add_class(oListItem, "open");
+        remove_class(oListItem, "closed");
     } else {
         // Hide the sublist
-        oList.style.display = 'none';
+        oList.style.display = "none";
 
         // Close the folder
-        add_class(oListItem, 'closed');
-        remove_class(oListItem, 'open');
+        add_class(oListItem, "closed");
+        remove_class(oListItem, "open");
         state = 0;
     }
 
     // Loop all currently open nodes to check wether they still exist or not
     // Remove not existing nodes -> cleanup data
-    for(var i = openNodes.length; i >= 0; i--) {
+    for (var i = openNodes.length; i >= 0; i--) {
         var node = document.getElementById(openNodes[i]);
-        if(!node)
-            openNodes.splice(i, 1);
+        if (!node) openNodes.splice(i, 1);
     }
 
     // Is it visible at the moment? Search for the index in openNodes list
@@ -357,12 +333,11 @@ function sidebarToggleSubtree(oTitle) {
 
     // When the new state is "closed" remove it from the openNodes list
     // When the node is visible and is not in the list yet, append it
-    if(state === 0 && open !== -1) {
+    if (state === 0 && open !== -1) {
         openNodes.splice(open, 1);
-    } else if(state === 1 && open === -1)
-        openNodes.push(this_id);
+    } else if (state === 1 && open === -1) openNodes.push(this_id);
 
-    storeUserOption('sidebarOpenNodes', openNodes.join(','));
+    storeUserOption("sidebarOpenNodes", openNodes.join(","));
 
     open = null;
     openNodes = null;
@@ -372,5 +347,5 @@ function sidebarToggleSubtree(oTitle) {
 }
 
 function sidebarGetListByTitle(title) {
-    return title.parentNode.parentNode.getElementsByTagName('ul')[0];
+    return title.parentNode.parentNode.getElementsByTagName("ul")[0];
 }

--- a/share/userfiles/templates/default.header.js
+++ b/share/userfiles/templates/default.header.js
@@ -44,7 +44,7 @@ function checkHideMenu(event) {
     if (!event) event = window.event;
 
     // Check whether or not a parent has the class "dropdown"
-    var target = getTargetRaw(event);
+    let target = getTargetRaw(event);
     while (target) {
         if (has_class(target, "dropdown")) return; // found the menu object, no further action
         target = target.parentNode;
@@ -55,10 +55,10 @@ function checkHideMenu(event) {
 }
 
 function toggleHeader(store) {
-    var header = document.getElementById("header");
-    var spacer = document.getElementById("headerspacer");
-    var show = document.getElementById("headershow");
-    var state = true;
+    let header = document.getElementById("header");
+    let spacer = document.getElementById("headerspacer");
+    let show = document.getElementById("headershow");
+    let state = true;
 
     // Reset the header height cache
     g_header_height_cache = null;
@@ -92,9 +92,9 @@ function headerUpdateState(map_conf) {
         return false;
     }
 
-    var map = map_conf[0];
+    const map = map_conf[0];
 
-    var side = document.getElementById("side-state-" + map["name"]);
+    let side = document.getElementById("side-state-" + map["name"]);
     if (side) {
         side.className = "statediv s" + map["summary_state"];
         if (map["summary_problem_has_been_acknowledged"] == 1) {
@@ -111,7 +111,7 @@ open_menus = [];
 
 // Is called to initialize fetching states for the header/sidebar menu
 function headerUpdateStates() {
-    for (var i = 0; i < g_map_names.length; i++) {
+    for (let i = 0; i < g_map_names.length; i++) {
         call_ajax(
             oGeneralProperties.path_server +
                 "?mod=Overview&act=getObjectStates" +
@@ -127,8 +127,8 @@ function headerUpdateStates() {
 
 function ddMenuToggle(event, id) {
     event = event || window.event;
-    var this_open = false;
-    for (var i = 0; i < open_menus.length; i++) {
+    let this_open = false;
+    for (let i = 0; i < open_menus.length; i++) {
         if (open_menus[i] == id) {
             this_open = true;
             break;
@@ -146,8 +146,8 @@ function ddMenuToggle(event, id) {
 function ddMenuHide(close_menus) {
     if (typeof close_menus === "undefined") close_menus = open_menus.slice(); // copy open menus array
 
-    var h, index;
-    for (var i = 0; i < close_menus.length; i++) {
+    let h, index;
+    for (let i = 0; i < close_menus.length; i++) {
         h = document.getElementById(close_menus[i] + "-ddcontent");
         h.style.display = "none";
 
@@ -162,8 +162,8 @@ function ddMenuHide(close_menus) {
 // main function to handle the mouse events //
 function ddMenu(id, reposition) {
     // Hide all other open menus (which have not the id of the current menu in their id)
-    for (var i = 0; i < open_menus.length; i++) {
-        var other_id = open_menus[i];
+    for (let i = 0; i < open_menus.length; i++) {
+        const other_id = open_menus[i];
         if (id.indexOf("-") === -1) {
             // main level menus (no minus in name) only hide other main level menus
             if (other_id.indexOf(id) !== 0) ddMenuHide([other_id]);
@@ -175,8 +175,8 @@ function ddMenu(id, reposition) {
         }
     }
 
-    var h = document.getElementById(id + "-ddheader");
-    var c = document.getElementById(id + "-ddcontent");
+    const h = document.getElementById(id + "-ddheader");
+    const c = document.getElementById(id + "-ddcontent");
 
     if (open_menus.indexOf(id) === -1) open_menus.push(id);
 
@@ -196,10 +196,10 @@ function ddMenu(id, reposition) {
 // ------------------------------
 
 function toggleSidebar(store) {
-    var sidebar = document.getElementById("sidebar");
-    var toggle = document.getElementById("sidetoggle");
-    var content = document.getElementById("map");
-    var is_overview = false;
+    let sidebar = document.getElementById("sidebar");
+    const toggle = document.getElementById("sidetoggle");
+    let content = document.getElementById("map");
+    let is_overview = false;
     if (content == null) {
         content = document.getElementById("overview");
         is_overview = true;
@@ -209,7 +209,7 @@ function toggleSidebar(store) {
     // will not be available in undefined views like the WUI
     if (content == null) return false;
 
-    var state = 1;
+    let state = 1;
     if (sidebarOpen()) {
         sidebar.style.display = "none";
         if (is_overview === false) {
@@ -246,7 +246,7 @@ function toggleSidebar(store) {
 }
 
 function sidebarOpen() {
-    var o = document.getElementById("sidebar");
+    const o = document.getElementById("sidebar");
     if (!o) return false;
     return !(o.style.display == "none" || o.style.display == "");
 }
@@ -269,9 +269,9 @@ function sidebarDraw() {
     // If no nodes are open don't try to open some
     if (oUserProperties.sidebarOpenNodes === "") return;
 
-    var openNodes = oUserProperties.sidebarOpenNodes.split(",");
-    for (var i = 0, len = openNodes.length; i < len; i++) {
-        var node = document.getElementById(openNodes[i] + "-childs");
+    const openNodes = oUserProperties.sidebarOpenNodes.split(",");
+    for (let i = 0, len = openNodes.length; i < len; i++) {
+        let node = document.getElementById(openNodes[i] + "-childs");
         if (node) {
             node.style.display = "block";
             add_class(node.parentNode, "open");
@@ -282,13 +282,13 @@ function sidebarDraw() {
 }
 
 function sidebarUpdatePosition() {
-    var sidebar = document.getElementById("sidebar");
+    const sidebar = document.getElementById("sidebar");
     if (sidebar && sidebarOpen()) sidebar.style.top = getHeaderHeight() + "px";
 }
 
 function sidebarDrawSubtree(node, index) {
     // Check if this node is expanded
-    for (var i = 0, len = oUserProperties.sidebarOpenNodes.length; i < len; i++)
+    for (let i = 0, len = oUserProperties.sidebarOpenNodes.length; i < len; i++)
         if (oUserProperties.sidebarOpenNodes[i] == index) return;
 
     // Hide sidebar when not in openNodes
@@ -296,14 +296,14 @@ function sidebarDrawSubtree(node, index) {
 }
 
 function sidebarToggleSubtree(oTitle) {
-    var oList = sidebarGetListByTitle(oTitle);
-    var this_id = oTitle.id;
-    var state = 1;
-    var openNodes;
+    let oList = sidebarGetListByTitle(oTitle);
+    const this_id = oTitle.id;
+    let state = 1;
+    let openNodes;
     if (oUserProperties.sidebarOpenNodes === "") openNodes = [];
     else openNodes = oUserProperties.sidebarOpenNodes.split(",");
 
-    var oListItem = oTitle.parentNode.parentNode;
+    let oListItem = oTitle.parentNode.parentNode;
     if (oList.style.display == "none" || oList.style.display == "") {
         // Make the sublist visible
         oList.style.display = "block";
@@ -323,13 +323,13 @@ function sidebarToggleSubtree(oTitle) {
 
     // Loop all currently open nodes to check wether they still exist or not
     // Remove not existing nodes -> cleanup data
-    for (var i = openNodes.length; i >= 0; i--) {
-        var node = document.getElementById(openNodes[i]);
+    for (let i = openNodes.length; i >= 0; i--) {
+        const node = document.getElementById(openNodes[i]);
         if (!node) openNodes.splice(i, 1);
     }
 
     // Is it visible at the moment? Search for the index in openNodes list
-    var open = openNodes.indexOf(this_id);
+    let open = openNodes.indexOf(this_id);
 
     // When the new state is "closed" remove it from the openNodes list
     // When the node is visible and is not in the list yet, append it


### PR DESCRIPTION
## Summary

Introduces consistent JavaScript formatting and linting across all first-party JS files (vendor `Ext*.js` files are excluded).

- **Prettier** enforces a consistent code style (4-space indent, double quotes, semicolons, printWidth 120)
- **ESLint** catches real code issues; `no-var` and `prefer-const` are enabled to enforce modern JS
- Both checks run as CI jobs on every push

## Changes

### Commit 1 — Prettier formatting
- Adds `.prettierrc`, `.prettierignore`, `package.json`
- Reformats all first-party JS files
- Adds `prettier` CI job

### Commit 2 — ESLint + bug fixes
- Adds `eslint.config.mjs` with `eslint-config-prettier` (no rule conflicts)
- Fixes real bugs found by ESLint:
  - `edit.js`, `nagvis.js`: `typeof x === undefined` (missing quotes) always evaluated to `false`
  - `ElementLine.js`: perfdata regex was a quoted string instead of a regex literal, making the replace a no-op
  - `ajax.js`: unnecessary backslash in `indexOf("\?")`
  - `ViewMap.js`: unreachable `break` after `return`
  - Various unnecessary regex escape characters
- Adds `eslint` CI job

### Commit 3 — Fix no-redeclare findings
- Removes duplicate `var` declarations throughout the codebase

### Commit 4 — Replace var with let/const
- Converts all `var` declarations to `let` or `const`
- Enables `no-var` and `prefer-const` ESLint rules to enforce this going forward