### PR TITLE
Fix PHP memory exhaustion on maps with large host/servicegroups

### DIFF
--- a/changelog.d/fix-lazy-load-group-members.md
+++ b/changelog.d/fix-lazy-load-group-members.md
@@ -1,0 +1,1 @@
+FIX: Avoid PHP memory exhaustion on maps with large hostgroups/servicegroups by loading group members lazily on hover instead of eagerly on map load

--- a/share/frontend/nagvis-js/js/ElementGadget.js
+++ b/share/frontend/nagvis-js/js/ElementGadget.js
@@ -58,7 +58,7 @@ const ElementGadget = Element.extend({
     //
 
     requestGadget: function (param_str) {
-        const data = "members=" + escape(JSON.stringify(this.obj.conf.members));
+        const data = "members=" + escape(JSON.stringify(this.obj.conf.members || []));
         // FIXME: Change to async?
         return call_ajax(this.obj.conf.gadget_url + param_str, {
             method: "POST",

--- a/share/frontend/nagvis-js/js/ElementHover.js
+++ b/share/frontend/nagvis-js/js/ElementHover.js
@@ -106,7 +106,11 @@ const ElementHover = Element.extend({
         if (this.template_html === null || this.template_html === true) {
             return false; // template not available yet, skip rendering
         }
-        this.renderMenu();
+        if (this.obj.conf.num_members > 0 && (!this.obj.conf.members || this.obj.conf.members.length === 0)) {
+            this.obj.fetchMembers(this.renderMenu.bind(this));
+        } else {
+            this.renderMenu();
+        }
     },
 
     getTemplate: function () {

--- a/share/frontend/nagvis-js/js/NagVisStatefulObject.js
+++ b/share/frontend/nagvis-js/js/NagVisStatefulObject.js
@@ -108,6 +108,45 @@ const NagVisStatefulObject = NagVisObject.extend({
         return stateful;
     },
 
+    // Fetches member objects lazily from the server if not yet loaded, then calls callback.
+    fetchMembers: function (callback) {
+        if (this.conf.members && this.conf.members.length > 0) {
+            this.getMembers();
+            callback();
+            return;
+        }
+        if (!this.conf.num_members || this.conf.num_members == 0) {
+            callback();
+            return;
+        }
+        // Guard against concurrent fetches: queue the callback and let the
+        // in-flight request handle it.
+        if (this._members_loading) {
+            this._members_pending_cb = callback;
+            return;
+        }
+        this._members_loading = true;
+        call_ajax(
+            oGeneralProperties.path_server +
+                "?mod=Map&act=getObjectMembers&show=" +
+                g_view.id +
+                "&i=" +
+                this.conf.object_id,
+            {
+                response_handler: function (data) {
+                    this._members_loading = false;
+                    this.conf.members = data || [];
+                    this.getMembers();
+                    callback();
+                    if (this._members_pending_cb) {
+                        this._members_pending_cb();
+                        this._members_pending_cb = null;
+                    }
+                }.bind(this)
+            }
+        );
+    },
+
     /**
      * PUBLIC saveLastState()
      *

--- a/share/server/core/classes/CoreModMap.php
+++ b/share/server/core/classes/CoreModMap.php
@@ -52,6 +52,7 @@ class CoreModMap extends CoreModule
             'getMapProperties' => 'view',
             'getMapObjects' => 'view',
             'getObjectStates' => 'view',
+            'getObjectMembers' => 'view',
 
             'manage' => REQUIRES_AUTHORISATION,
             'doExportMap' => 'edit',
@@ -81,6 +82,7 @@ class CoreModMap extends CoreModule
             case 'getMapProperties':
             case 'getMapObjects':
             case 'getObjectStates':
+            case 'getObjectMembers':
             case 'manageTmpl':
             case 'addModify':
             case 'doExportMap':
@@ -138,6 +140,9 @@ class CoreModMap extends CoreModule
                     break;
                 case 'getObjectStates':
                     $sReturn = $this->getObjectStates();
+                    break;
+                case 'getObjectMembers':
+                    $sReturn = $this->getObjectMembersById();
                     break;
                 case 'manage':
                     $VIEW = new ViewManageMaps();
@@ -409,6 +414,43 @@ class CoreModMap extends CoreModule
         } else {
             return false;
         }
+    }
+
+    /**
+     * Returns the members of a single map object, identified by its object_id.
+     * Only the requested object is loaded from the backend to keep memory usage low.
+     *
+     * @return string JSON-encoded array of member objects
+     * @throws MapCfgInvalid
+     * @throws NagVisException
+     */
+    private function getObjectMembersById()
+    {
+        $aOpts = ['i' => MATCH_STRING_NO_SPACE_EMPTY];
+        $aVals = $this->getCustomOptions($aOpts, [], true);
+        $object_id = $aVals['i'];
+
+        if (!isset($object_id) || $object_id === '') {
+            return json_encode([]);
+        }
+
+        $MAPCFG = new GlobalMapCfg($this->name);
+        $MAPCFG->readMapConfig();
+        // Only load the one requested object to avoid loading the full map
+        $MAPCFG->filterMapObjects([$object_id]);
+
+        $MAP = new NagVisMap($MAPCFG, GET_STATE, IS_VIEW);
+
+        $map_members = $MAP->MAPOBJ->getMembers();
+        if (empty($map_members)) {
+            return json_encode([]);
+        }
+
+        $members = [];
+        foreach (reset($map_members)->getSortedObjectMembers() as $MEMBER) {
+            $members[] = $MEMBER->fetchObjectAsChild();
+        }
+        return json_encode($members);
     }
 
     /**

--- a/share/server/core/classes/objects/NagVisStatefulObject.php
+++ b/share/server/core/classes/objects/NagVisStatefulObject.php
@@ -1084,15 +1084,6 @@ class NagVisStatefulObject extends NagVisObject
             $arr['num_members'] = $num_members;
         }
 
-        // If there are some members fetch the information for them
-        if (isset($arr['num_members']) && $arr['num_members'] > 0) {
-            $members = [];
-            foreach ($this->getSortedObjectMembers() as $OBJ) {
-                $members[] = $OBJ->fetchObjectAsChild();
-            }
-            $arr['members'] = $members;
-        }
-
         return $arr;
     }
 


### PR DESCRIPTION
## Summary

- Removes eager member loading from `getObjectInformation()` — previously, every `getMapObjects` request (initial load + periodic polling) would instantiate and serialize all members of every hostgroup/servicegroup/aggregation on the map, exhausting the PHP memory limit (128 MB) on large monitoring sites
- Adds a new `getObjectMembers` backend endpoint that loads only the single requested object via `filterMapObjects`, returning its members on demand
- Frontend fetches member data lazily the first time a hover menu is opened for a group object; subsequent hovers use the cached result

## Details

**Root cause:** `NagVisStatefulObject::getObjectInformation()` unconditionally called `getSortedObjectMembers()` for every group object on every map render, including the periodic state-update poll. On large environments (thousands of services in a servicegroup), this caused OOM before the map could be loaded at all.

**Backend (`CoreModMap.php`):** New `getObjectMembers` action (requires `view` permission). Accepts `show` (map name) and `i` (object_id). Uses `filterMapObjects` so only the one requested object is loaded from the monitoring backend. Returns an early empty array if `i` is missing.

**Frontend (`NagVisStatefulObject.js`):** New `fetchMembers(callback)` method with an in-flight guard (`_members_loading` flag) to prevent duplicate concurrent requests when hover is triggered rapidly. A pending callback is queued and fired once the single in-flight request completes.

**Frontend (`ElementHover.js`):** `_render()` calls `fetchMembers` before rendering the menu when members have not yet been loaded.

**Frontend (`ElementGadget.js`):** Null-safety: `conf.members || []` prevents a crash when a gadget is placed on a group object whose members have not been fetched yet.