### PR TITLE
Fix JS crash on maps with BW lines when perfdata labels don't fully match

### DIFF
--- a/changelog.d/fix-bw-line-js-crash.md
+++ b/changelog.d/fix-bw-line-js-crash.md
@@ -1,0 +1,1 @@
+FIX: JavaScript crash on maps with BW lines when only one of the in/out perfdata labels is matched

--- a/share/frontend/nagvis-js/js/ElementLine.js
+++ b/share/frontend/nagvis-js/js/ElementLine.js
@@ -790,7 +790,7 @@ const ElementLine = Element.extend({
     calcWeathermapColor: function (id) {
         if (this.obj.conf.summary_state == "ERROR") return oStates["ERROR"].color;
 
-        if (!this.perfdata) return oStates["CRITICAL"].color;
+        if (!this.perfdata || !this.perfdata[id]) return oStates["CRITICAL"].color;
 
         if (this.perfdata[id][2] == "%" && this.perfdata[id][1] !== null) {
             return this.getColorFill(this.perfdata[id][1]);
@@ -824,7 +824,8 @@ const ElementLine = Element.extend({
      */
     calculateUsage: function (oldPerfdata, output) {
         const newPerfdata = [];
-        let foundNew = false;
+        let foundIn = false;
+        let foundOut = false;
         let line_label_in = "in";
         let line_label_out = "out";
 
@@ -854,7 +855,7 @@ const ElementLine = Element.extend({
                     oldPerfdata[i][1] *= 8; // convert those hakish bytes to bits
                     newPerfdata[2] = this.perfdataCalcBitsReadable(oldPerfdata[i]);
                 }
-                foundNew = true;
+                foundIn = true;
             }
             if (oldPerfdata[i][0] == line_label_out && (oldPerfdata[i][2] === null || oldPerfdata[i][2] === "")) {
                 newPerfdata[1] = this.perfdataCalcPerc(oldPerfdata[i]);
@@ -864,10 +865,10 @@ const ElementLine = Element.extend({
                     oldPerfdata[i][1] *= 8; // convert those hakish bytes to bits
                     newPerfdata[3] = this.perfdataCalcBitsReadable(oldPerfdata[i]);
                 }
-                foundNew = true;
+                foundOut = true;
             }
         }
-        if (foundNew) return newPerfdata;
+        if (foundIn && foundOut) return newPerfdata;
         else return oldPerfdata;
     },
 


### PR DESCRIPTION
## Summary

- `calculateUsage()` used a single `foundNew` flag set independently for the `in` and `out` label matches. If only one label was found (e.g. mismatched label names, single-direction interface, or a Checkmk check variant with non-standard label names), it returned a partially populated `newPerfdata` array with the other index `undefined`.
- `calcWeathermapColor()` then crashed with `TypeError: Cannot read properties of undefined (reading '2')` when accessing `this.perfdata[1][2]`, aborting rendering of all subsequent objects on the map.

## Changes

- **`calculateUsage`**: split `foundNew` into separate `foundIn`/`foundOut` flags; only return the transformed `newPerfdata` when **both** labels are found — otherwise fall back to the original `oldPerfdata` so existing error paths handle it cleanly.
- **`calcWeathermapColor`**: extend the existing null guard to also cover a missing index (`!this.perfdata[id]`), as a defensive fallback.