### PR TITLE
Fix role permissions update silently failing with many maps

### DIFF
--- a/changelog.d/fix-role-perms-max-input-vars.md
+++ b/changelog.d/fix-role-perms-max-input-vars.md
@@ -1,0 +1,1 @@
+FIX: Updating role permissions silently fails when there are many maps due to PHP max_input_vars limit being exceeded

--- a/share/frontend/nagvis-js/js/ajax.js
+++ b/share/frontend/nagvis-js/js/ajax.js
@@ -194,9 +194,10 @@ function getFormParams(formId, skipHelperFields) {
         } else if (aFields[i].type == "checkbox") {
             if (aFields[i].checked) {
                 add_data(aFields[i].name, aFields[i].value);
-            } else {
-                add_data(aFields[i].name, "");
             }
+            // Unchecked checkboxes are intentionally not submitted, matching standard
+            // HTML form behaviour. This prevents hitting PHP's max_input_vars limit
+            // on forms with many checkboxes (e.g. role permissions with many maps).
         } else if (aFields[i].type == "radio") {
             if (aFields[i].checked) {
                 add_data(aFields[i].name, aFields[i].value);


### PR DESCRIPTION
## Summary

- `getFormParams()` in `ajax.js` submitted every checkbox unconditionally — checked as `"1"` and unchecked as `""`. With 328 maps × 3 permission checkboxes = 984 POST vars, plus the other form fields, PHP's default `max_input_vars=1000` limit is exceeded. PHP silently truncates `$_POST` at that point.
- The `_submit` button is rendered after all permission checkboxes in the DOM and gets dropped by the truncation. With `_submit` missing, `submitted()` returns false, `is_action()` returns false, and the update silently does nothing — no error, no success message, no change to `auth.db`.

## Changes

- **`ajax.js` `getFormParams()`**: skip unchecked checkboxes entirely, matching standard HTML form behaviour. `get_checkbox()` on the PHP side returns `false` for both absent keys and empty strings, and `updateRolePerms()` deletes all existing permissions before re-inserting the checked set, so behaviour is identical with far fewer POST variables.