### PR TITLE
Fix JS crash on gadgets caused by block-scoped const after var-to-let refactor

### DIFF
--- a/share/frontend/nagvis-js/js/ElementGadget.js
+++ b/share/frontend/nagvis-js/js/ElementGadget.js
@@ -111,8 +111,9 @@ const ElementGadget = Element.extend({
         else sParams = "&" + sParams;
 
         this.detectGadgetType(sParams);
+        let oGadget;
         if (this.gadget_type === "img") {
-            const oGadget = document.createElement("img");
+            oGadget = document.createElement("img");
 
             // Register controls reposition handler to handle resizes during
             // loading the image (from alt="" text to the real image)

--- a/share/frontend/nagvis-js/js/ElementTile.js
+++ b/share/frontend/nagvis-js/js/ElementTile.js
@@ -63,15 +63,15 @@ const ElementTile = Element.extend({
 
         // Status image
         if (this.obj.conf.icon !== null && this.obj.conf.icon !== "") {
-            const oImg = document.createElement("img");
-            oImg.className = "state";
-            oImg.align = "right";
-            oImg.src = oGeneralProperties.path_iconsets + this.obj.conf.icon;
-            oImg.style.width = this.obj.conf.icon_size + "px";
-            oImg.style.height = this.obj.conf.icon_size + "px";
-            oImg.alt = this.obj.stateText();
+            const oStateImg = document.createElement("img");
+            oStateImg.className = "state";
+            oStateImg.align = "right";
+            oStateImg.src = oGeneralProperties.path_iconsets + this.obj.conf.icon;
+            oStateImg.style.width = this.obj.conf.icon_size + "px";
+            oStateImg.style.height = this.obj.conf.icon_size + "px";
+            oStateImg.alt = this.obj.stateText();
 
-            oLink.appendChild(oImg);
+            oLink.appendChild(oStateImg);
         }
 
         // Title
@@ -81,11 +81,11 @@ const ElementTile = Element.extend({
 
         // Only show map thumb when configured
         if (oPageProperties.showmapthumbs == 1 && this.obj.conf.overview_image != "") {
-            oImg = document.createElement("img");
-            oImg.style.width = "200px";
-            oImg.style.height = "150px";
-            oImg.src = this.obj.conf.overview_image;
-            oLink.appendChild(oImg);
+            const oThumbImg = document.createElement("img");
+            oThumbImg.style.width = "200px";
+            oThumbImg.style.height = "150px";
+            oThumbImg.src = this.obj.conf.overview_image;
+            oLink.appendChild(oThumbImg);
         }
 
         div.appendChild(oLink);


### PR DESCRIPTION
## Summary

- Fixes `TypeError: can't access property "style", this.dom_obj is null` (issue #440) at line 3862 of `NagVisCompressed.js` on maps with image-type gadgets
- Root cause: the `var`→`let`/`const` refactoring (9e5a033e) scoped `oGadget` to the `if` block in `ElementGadget.renderGadget()`, but the `else` branch and post-block code still used the bare name — making `this.dom_obj` never get set when the img branch ran, then crashing when the image load event fired and called `place()`
- Also fixes the same block-scope issue in `ElementTile.renderTile()` where `const oImg` in the status-image block was referenced without declaration in the map-thumbnail block