### PR TITLE
Fix element saving broken by unchecked-checkbox submission change

### DIFF
--- a/changelog.d/fix-element-saving-after-checkbox-submit-change.md
+++ b/changelog.d/fix-element-saving-after-checkbox-submit-change.md
@@ -1,0 +1,1 @@
+FIX: Saving map elements incorrectly applied all attributes after the unchecked-checkbox submission fix

--- a/share/server/core/classes/ViewMapAddModify.php
+++ b/share/server/core/classes/ViewMapAddModify.php
@@ -79,7 +79,7 @@ class ViewMapAddModify
 
             if (
                 (isset($attrDefs[$attr]['must']) && $attrDefs[$attr]['must'] == '1')
-                || !has_var('toggle_' . $attr)
+                || !has_var('_has_toggle_' . $attr)
                 || get_checkbox('toggle_' . $attr)
             ) {
                 if (isset($attrDefs[$attr]['array']) && $attrDefs[$attr]['array']) {
@@ -462,6 +462,12 @@ class ViewMapAddModify
         // Add a checkbox to toggle the usage of an attribute. But only add it for
         // non-must attributes.
         if (!$prop['must'] && $fieldType != 'readonly') {
+            // Sentinel hidden field so the server can detect that this toggle exists
+            // in the form regardless of whether the checkbox is checked or not.
+            // Unchecked checkboxes are not submitted by the browser (or by getFormParams),
+            // so has_var('toggle_X') alone cannot distinguish "toggle rendered but unchecked"
+            // from "no toggle rendered at all".
+            hidden('_has_toggle_' . $propname, '1');
             checkbox(
                 'toggle_' . $propname,
                 $isInherited === false,


### PR DESCRIPTION
## Summary

Followup to #439.

- #439 stopped `getFormParams()` from submitting empty values for unchecked checkboxes. This broke element saving: the `toggle_<attr>` checkboxes in `ViewMapAddModify` control whether an attribute overrides its inherited value. The PHP processing code used `has_var('toggle_' . $attr)` to distinguish "toggle rendered but unchecked (= use inherited)" from "no toggle rendered at all (= must-attribute, always include)". With unchecked checkboxes no longer submitted, `has_var` returned false for unchecked toggles too, so toggled-off attributes were incorrectly included unconditionally — causing all attributes to be saved as if selected.

## Changes

- **`ViewMapAddModify.php` render**: add a hidden sentinel field `_has_toggle_<attr>` alongside each toggle checkbox. Hidden fields are always submitted, so sentinel presence reliably signals "this toggle exists in the form."
- **`ViewMapAddModify.php` processing**: switch `has_var('toggle_' . $attr)` to `has_var('_has_toggle_' . $attr)`, restoring the correct distinction between unchecked toggle and absent toggle.