### PR TITLE
FIX: Line position snaps back after move due to coords dropped on save

### DIFF
--- a/changelog.d/fix-line-coords-dropped-on-save.md
+++ b/changelog.d/fix-line-coords-dropped-on-save.md
@@ -1,0 +1,1 @@
+FIX: Moving lines snaps back to original position because comma-separated coordinates are incorrectly filtered out before saving

--- a/share/frontend/nagvis-js/js/ajaxActions.js
+++ b/share/frontend/nagvis-js/js/ajaxActions.js
@@ -8,7 +8,11 @@ function saveObjectAttr(objId, attr) {
         // parseInt() returned NaN, because value was set to "auto";
         // but also allow relative coordinate strings (contain '%') and
         // comma-separated line endpoint coordinates (e.g. "100,500")
-        if (!isNaN(attr[key]) || isRelativeCoord(attr[key]) || (typeof attr[key] === "string" && attr[key].includes(",")))
+        if (
+            !isNaN(attr[key]) ||
+            isRelativeCoord(attr[key]) ||
+            (typeof attr[key] === "string" && attr[key].includes(","))
+        )
             urlPart += "&" + key + "=" + escapeUrlValues(attr[key]);
 
     call_ajax(

--- a/share/frontend/nagvis-js/js/ajaxActions.js
+++ b/share/frontend/nagvis-js/js/ajaxActions.js
@@ -6,8 +6,10 @@ function saveObjectAttr(objId, attr) {
     let urlPart = "";
     for (const key in attr)
         // parseInt() returned NaN, because value was set to "auto";
-        // but also allow relative coordinate strings (contain '%')
-        if (!isNaN(attr[key]) || isRelativeCoord(attr[key])) urlPart += "&" + key + "=" + escapeUrlValues(attr[key]);
+        // but also allow relative coordinate strings (contain '%') and
+        // comma-separated line endpoint coordinates (e.g. "100,500")
+        if (!isNaN(attr[key]) || isRelativeCoord(attr[key]) || (typeof attr[key] === "string" && attr[key].includes(",")))
+            urlPart += "&" + key + "=" + escapeUrlValues(attr[key]);
 
     call_ajax(
         oGeneralProperties.path_server +


### PR DESCRIPTION
## Summary

- Moving a line on a map caused it to snap back to its original position after saving
- Root cause: `isNaN("100,500")` evaluates to `true` in JavaScript, so the NaN guard introduced to skip `"auto"` coordinate values also silently dropped comma-separated line endpoint coordinates (e.g. `"100,500"`) from the `modifyObject` save request
- Fix: explicitly allow strings containing commas through the guard so line coordinates are included in the request

Reproduced by comparing NagVis behaviour in Checkmk 2.4.0p25 (working) vs 2.4.0p26 (broken), where this guard was introduced.