### PR TITLE
FIX: Restore service list in host hover menus (CMK-35933)

### DIFF
--- a/changelog.d/fix-host-hover-services.md
+++ b/changelog.d/fix-host-hover-services.md
@@ -1,0 +1,1 @@
+FIX: Restore service list in host hover menus that disappeared after the lazy group member loading change (#437)

--- a/share/server/core/classes/objects/NagVisMapObj.php
+++ b/share/server/core/classes/objects/NagVisMapObj.php
@@ -348,17 +348,40 @@ class NagVisMapObj extends NagVisStatefulObject
      * the single objects.
      *
      * @param bool $_unused_flag
-     * @param bool $bFetchMemberState Whether to load individual member details (for hover)
+     * @param bool $_unused_flag2
      * @return void
      * @author    Lars Michelsen <lm@larsmichelsen.com>
      */
-    public function queueState($_unused_flag = true, $bFetchMemberState = true)
+    public function queueState($_unused_flag = true, $_unused_flag2 = true)
     {
         foreach ($this->getStateRelevantMembers() as $OBJ) {
+            $sType = $OBJ->getType();
+
+            // Host- and servicegroups can contain thousands of members. To avoid
+            // exhausting the PHP memory limit their member details are not loaded
+            // on map load, but lazily on demand via the getObjectMembers endpoint
+            // when a hover menu is opened (see #437). Only the cheap aggregate
+            // state counts are queried here, which is enough for icon colouring
+            // and for reporting the correct num_members to the frontend.
+            $bLazyMembers = $sType === 'hostgroup' || $sType === 'servicegroup';
+
             // Gadgets render synchronously and read conf.members directly at
-            // render time, so their group member details must be loaded eagerly.
-            $needsMembers = $bFetchMemberState || $OBJ->get('view_type') === 'gadget';
-            $OBJ->queueState(GET_STATE, $needsMembers);
+            // render time, so their member details must be loaded eagerly even
+            // for the otherwise lazily loaded group types.
+            $bGadget = $OBJ->get('view_type') === 'gadget';
+
+            if ($bLazyMembers && !$bGadget) {
+                $OBJ->queueState(GET_STATE, DONT_GET_SINGLE_MEMBER_STATES);
+            } elseif ($this->isView === true || $bGadget) {
+                // On a viewed map the hover menus of hosts, dyngroups, aggregates
+                // and submaps need their single member states right away. When the
+                // map object is only rendered as a summary icon (e.g. overview or
+                // multisite snapin) no hover menu is shown, so the details are not
+                // fetched.
+                $OBJ->queueState(GET_STATE, GET_SINGLE_MEMBER_STATES);
+            } else {
+                $OBJ->queueState(GET_STATE, DONT_GET_SINGLE_MEMBER_STATES);
+            }
         }
     }
 


### PR DESCRIPTION
   ## Problem

   After the fix for #437 (lazy group member loading), hovering over a **host** object on a NagVis map no longer lists its services — only the general host
   information is shown. This regressed between 2.4.0p26 and 2.4.0p30.

   ## Root cause

   The #437 fix changed `NagVisMap` and `NagVisMapObj::queueState` to always queue member states with `DONT_GET_SINGLE_MEMBER_STATES`. That is correct for
   host-/servicegroups, whose members are now loaded lazily on demand via the `getObjectMembers` endpoint — they expose `num_members` (derived from `aStateCounts`)
   so the frontend can trigger the lazy fetch.

   Host objects (and also dyngroups, aggregates and submaps) have **no `num_members` fallback**, so with `DONT_GET_SINGLE_MEMBER_STATES` their members were never
   loaded, `num_members` stayed `0`, and the frontend (`ElementHover.js` / `NagVisStatefulObject.fetchMembers`) never triggered the lazy fetch — leaving the hover
   menu without any services.

   ## Fix

   `NagVisMapObj::queueState` now restores eager member-detail loading on viewed maps for all object types **except** host-/servicegroups, which keep their lazy
   loading. Gadgets stay eager as before. This keeps the memory optimization from #437 intact while bringing back the host service hover (and the member lists for
   dyngroups, aggregates and submaps).


