### PR TITLE
FIX: Keep bracketed strings in service descriptions in hover menu

### DIFF
--- a/changelog.d/fix-hover-bracket-macro.md
+++ b/changelog.d/fix-hover-bracket-macro.md
@@ -1,0 +1,1 @@
+FIX: Hover menu no longer strips bracketed strings (e.g. "[xxx]") from service descriptions

--- a/share/frontend/nagvis-js/js/ElementHover.js
+++ b/share/frontend/nagvis-js/js/ElementHover.js
@@ -562,9 +562,14 @@ const ElementHover = Element.extend({
         if (this.obj.conf.hover_childs_show && this.obj.conf.hover_childs_show == "1")
             template_html = this.replaceChildMacros(template_html);
 
-        // Replace all normal macros
-        template_html = template_html.replace(/\[(\w*)\]/g, function () {
-            return oMacros[arguments[1]] || "";
+        // Replace all normal macros. This pass also runs over the already
+        // substituted child rows, so a bracketed string that is part of a
+        // child value (e.g. a service description like "Switch1 [xxx]") must
+        // not be mistaken for an unknown macro and dropped. Keep the original
+        // "[name]" text for tokens that are not actual macros, while still
+        // replacing defined macros that legitimately hold an empty value.
+        template_html = template_html.replace(/\[(\w*)\]/g, function (match, name) {
+            return Object.prototype.hasOwnProperty.call(oMacros, name) ? oMacros[name] : match;
         });
         return template_html;
     },


### PR DESCRIPTION
## Problem

When a service description contains a bracketed string (e.g. `Switch1 Interface 1 [xxx]`), the hover menu of the parent object drops the `[xxx]` part and only shows `Switch1 Interface 1`.

## Root cause

In `ElementHover.js`, the dynamic macro pass (`replaceDynamicMacros`) runs over the **whole** template *after* the child rows have already been substituted. At that point the child value — including the bracketed part of the service description — is part of the template. The regex `/\[(\w*)\]/g` then matches `[xxx]`, finds no matching macro, and replaced it with an empty string (`oMacros[name] || ""`), dropping it.

## Fix

Preserve the original `[name]` text for tokens that are not actual macros. Using `hasOwnProperty` (rather than the `|| "[name]"` idiom) ensures that defined macros holding a legitimately empty value — e.g. an empty plugin output for `[obj_summary_output]` — are still replaced correctly instead of being rendered as the literal `[obj_summary_output]`.

```js
template_html = template_html.replace(/\[(\w*)\]/g, function (match, name) {
    return Object.prototype.hasOwnProperty.call(oMacros, name) ? oMacros[name] : match;
});
```

## Steps to reproduce

1. Configure a service whose description contains brackets, e.g. `service_description Switch1 Interface 1 [xxx]`.
2. Open a NagVis map with an object whose hover menu lists that service.
3. Hover over the object.

Before: the service line shows `Switch1 Interface 1` (the `[xxx]` is missing).
After: the service line shows `Switch1 Interface 1 [xxx]`.
