### PR TITLE
Fix tar command to extract into specific target directory

### DIFF
--- a/docs/de_DE/installer.html
+++ b/docs/de_DE/installer.html
@@ -18,7 +18,7 @@
         
         <h3>NagVis entpacken</h3>
         <p>Entpacken Sie das Archiv in ein beliebiges Verzeichnis (z.B. /tmp) und wechseln Sie in dieses Verzeichnis</p>
-        <pre>tar xvzf nagvis-1.8*.tar.gz /tmp
+        <pre>tar xvzf nagvis-1.8*.tar.gz -C /tmp
 cd /tmp/nagvis-1.8*</pre>
         
         <h3>Machen Sie den Installer ausf&uuml;hrbar</h3>

--- a/docs/en_US/installer.html
+++ b/docs/en_US/installer.html
@@ -19,7 +19,7 @@
         
         <h3>Unpack NagVis</h3>
         <p>Unpack the archive to a temporary place (for example /tmp) and change to that directory</p>
-        <pre>tar xvzf nagvis-1.8*.tar.gz /tmp
+        <pre>tar xvzf nagvis-1.8*.tar.gz -C /tmp
 cd /tmp/nagvis-1.8*</pre>
         
         <h3>Make installer executable</h3>


### PR DESCRIPTION
Fix tar command (missing `-C`) to extract into specific target directory. 
Otherwise you get:

```
tar: /tmp: Not found in archive
tar: Exiting with failure status due to previous errors
```