### PR TITLE
FIX: Remove empty bracketed strings in hover menu

### DIFF
--- a/share/frontend/nagvis-js/js/ElementHover.js
+++ b/share/frontend/nagvis-js/js/ElementHover.js
@@ -506,7 +506,16 @@ const ElementHover = Element.extend({
     },
 
     replaceDynamicMacros: function (template_html) {
-        const oMacros = {};
+        // Defaults: unset optional state macros collapse to an empty string
+        // instead of rendering as literal [obj_*] tokens.
+        const oMacros = {
+            obj_summary_acknowledged: "",
+            obj_acknowledged: "",
+            obj_summary_in_downtime: "",
+            obj_in_downtime: "",
+            obj_summary_stale: "",
+            obj_stale: ""
+        };
 
         if (g_view.type === "map") oMacros.map_name = oPageProperties.map_name;
 


### PR DESCRIPTION
Fixes the empty bracket variables in hover menu:
<img width="820" height="189" alt="image" src="https://github.com/user-attachments/assets/5fd8fe71-45fe-401e-a073-724d5fd8c2a2" />

To this:
<img width="607" height="184" alt="image" src="https://github.com/user-attachments/assets/a893fb41-b320-49b4-aa1c-1a3d3e138771" />

It still shows downtimes etc.