### PR TITLE
FIX: Fix PHP memory exhaustion on maps with many hosts

### DIFF
--- a/changelog.d/fix-host-member-memory.md
+++ b/changelog.d/fix-host-member-memory.md
@@ -1,0 +1,1 @@
+FIX: Fix PHP memory exhaustion on maps with many hosts by lazily loading host services on demand (#437)

--- a/share/server/core/classes/objects/NagVisHost.php
+++ b/share/server/core/classes/objects/NagVisHost.php
@@ -90,6 +90,44 @@ class NagVisHost extends NagVisStatefulObject
     }
 
     /**
+     * Returns the number of service members.
+     * When the service details have not been loaded yet (lazy loading), the
+     * total is derived from the service state counts fetched via hostMemberState.
+     * The host's own state, which is merged into the counts for the summary
+     * calculation, is excluded. The count is only reported when the host is
+     * configured to show its services in the hover menu, matching the condition
+     * under which the service details are loaded on demand.
+     *
+     * @return int
+     */
+    public function getNumMembers()
+    {
+        if (!empty($this->members)) {
+            return count($this->members);
+        }
+        if (
+            !$this->recognize_services
+            || $this->hover_menu != 1
+            || $this->hover_childs_show != 1
+            || $this->aStateCounts === null
+        ) {
+            return 0;
+        }
+        $total = 0;
+        foreach ($this->aStateCounts as $sState => $aSubstates) {
+            // The host state is added to the counts for summary purposes; only
+            // the service states represent actual members.
+            if (is_host_state($sState)) {
+                continue;
+            }
+            foreach ($aSubstates as $iCount) {
+                $total += $iCount;
+            }
+        }
+        return $total;
+    }
+
+    /**
      * Queues the state fetching to the backend.
      *
      * @param bool $bFetchObjectState Optional flag to disable fetching of the object status

--- a/share/server/core/classes/objects/NagVisMapObj.php
+++ b/share/server/core/classes/objects/NagVisMapObj.php
@@ -357,24 +357,32 @@ class NagVisMapObj extends NagVisStatefulObject
         foreach ($this->getStateRelevantMembers() as $OBJ) {
             $sType = $OBJ->getType();
 
-            // Host- and servicegroups can contain thousands of members. To avoid
-            // exhausting the PHP memory limit their member details are not loaded
-            // on map load, but lazily on demand via the getObjectMembers endpoint
-            // when a hover menu is opened (see #437). Only the cheap aggregate
-            // state counts are queried here, which is enough for icon colouring
-            // and for reporting the correct num_members to the frontend.
-            $bLazyMembers = $sType === 'hostgroup' || $sType === 'servicegroup';
+            // Hosts (with their services) and host-/servicegroups can contain
+            // thousands of members. To avoid exhausting the PHP memory limit their
+            // member details are not loaded on map load, but lazily on demand via
+            // the getObjectMembers endpoint when a hover menu is opened (see #437).
+            // Only the cheap aggregate state counts are queried here, which is
+            // enough for icon colouring and for reporting the correct num_members
+            // to the frontend so it can trigger the lazy fetch.
+            //
+            // Hosts only expose a num_members fallback (and therefore only support
+            // lazy loading) when recognize_services is enabled, because that is the
+            // only case in which the aggregate service state counts are fetched.
+            // Without it, hosts keep loading their services eagerly.
+            $bLazyMembers = $sType === 'hostgroup'
+                || $sType === 'servicegroup'
+                || ($sType === 'host' && $OBJ->getRecognizeServices());
 
             // Gadgets render synchronously and read conf.members directly at
             // render time, so their member details must be loaded eagerly even
-            // for the otherwise lazily loaded group types.
+            // for the otherwise lazily loaded object types.
             $bGadget = $OBJ->get('view_type') === 'gadget';
 
             if ($bLazyMembers && !$bGadget) {
                 $OBJ->queueState(GET_STATE, DONT_GET_SINGLE_MEMBER_STATES);
             } elseif ($this->isView === true || $bGadget) {
-                // On a viewed map the hover menus of hosts, dyngroups, aggregates
-                // and submaps need their single member states right away. When the
+                // On a viewed map the hover menus of dyngroups, aggregates and
+                // submaps need their single member states right away. When the
                 // map object is only rendered as a summary icon (e.g. overview or
                 // multisite snapin) no hover menu is shown, so the details are not
                 // fetched.


### PR DESCRIPTION
## Problem

The #437 memory fix made host-/servicegroup members load lazily, but the follow-up *"Restore service list in host hover menus"* (CMK-35933) kept plain **host** objects loading eagerly — because hosts had no `num_members` fallback to drive the frontend lazy fetch, so lazy loading left their hover menus empty.

As a result, viewing a map with many hosts and services still queued `GET_SINGLE_MEMBER_STATES` for every host, so `CoreBackendMgmt::fetchHostMemberDetails()` instantiated a `NagVisService` object for **every service of every host** in a single PHP request, exhausting the 128 MB memory limit:

```
PHP Fatal error: Allowed memory size of 134217728 bytes exhausted ...
  in .../server/core/classes/CoreBackendMgmt.php on line 752
```

## Fix

Extend the #437 lazy-loading approach to hosts:

1. **`NagVisHost::getNumMembers()`** (new) derives the service count from the cheap aggregate `hostMemberState` counts (excluding the host's own state via `is_host_state()`), so the frontend knows `num_members > 0` and triggers the existing lazy `getObjectMembers` fetch on hover. Guarded by the same conditions under which services were previously loaded (`recognize_services`, `hover_menu`, `hover_childs_show`).

2. **`NagVisMapObj::queueState()`** queues hosts lazily like groups, but **only when `recognize_services` is enabled** — that is the only case in which the aggregate service state counts are fetched. Fetching them otherwise would fold service states into the host summary and change icon colours, so hosts without `recognize_services` keep loading eagerly (unchanged behavior).

Net effect: host hover menus still show their service list (lazy-fetched on demand), while the eager per-service allocation that exhausted memory is eliminated — the same tradeoff #437 made for groups.

Jira: CMK-36603