### PR TITLE
FIX: Restore map editing for non-admin roles (#452)

### DIFF
--- a/changelog.d/fix-edithtml-map-editing.md
+++ b/changelog.d/fix-edithtml-map-editing.md
@@ -1,0 +1,1 @@
+FIX: Non-admin roles (e.g. Managers) can edit maps again - the editHtml permission is now only required to change HTML content, not for every map modification (#452)

--- a/share/server/core/classes/ViewMapAddModify.php
+++ b/share/server/core/classes/ViewMapAddModify.php
@@ -160,9 +160,24 @@ class ViewMapAddModify
         $perm_user = get_checkbox('perm_user');
         $show_dialog = false;
 
+        // Only block when an HTML field (e.g. textbox "text") is actually
+        // changed, so regular map editing works without editHtml (CVE-2024-47090).
         global $AUTHORISATION;
         if (!$AUTHORISATION->isPermitted('Map', 'editHtml', '*')) {
-            throw new NagVisException(l('Cannot edit HTML. Please contact your administrator'));
+            $attrDefs = $this->MAPCFG->getValidObjectType($this->object_type);
+            foreach ($this->attrs as $key => $val) {
+                if (!isset($attrDefs[$key]['field_type']) || $attrDefs[$key]['field_type'] !== 'textarea') {
+                    continue;
+                }
+
+                $current = ($this->object_id !== null && $this->MAPCFG->objExists($this->object_id))
+                    ? $this->MAPCFG->getValue($this->object_id, $key, true)
+                    : null;
+
+                if ($val !== $current) {
+                    throw new NagVisException(l('Cannot edit HTML. Please contact your administrator'));
+                }
+            }
         }
 
         // Modification/Creation?

--- a/share/server/core/functions/html.php
+++ b/share/server/core/functions/html.php
@@ -431,7 +431,10 @@ function textarea($name, $default = '', $class = '', $style = '')
 
     global $AUTHORISATION;
     if (!$AUTHORISATION->isPermitted('Map', 'editHtml', '*')) {
-        echo '<b>Cannot edit HTML. Please contact your administrator.</b>';
+        // No editHtml permission (CVE-2024-47090): hide the editor but keep the
+        // current value so the object can still be saved/moved unchanged.
+        hidden($name, $default);
+        echo '<b>' . l('Cannot edit HTML. Please contact your administrator') . '</b>';
         return;
     }
     // plain <textarea>


### PR DESCRIPTION
The XSS mitigation for the WYSIWYG editor (CVE-2024-47090) added an `editHtml` permission check at the top of `handleAddModify()`, which runs for **every** map object save. As a result, roles without that permission (e.g. Managers) could no longer edit maps at all — adding a host, service or icon failed with *"Cannot edit HTML. Please contact your administrator"*.

This scopes the check to submissions that actually **change** an HTML field (the textbox `text`, field type `textarea`), comparing the submitted value against the stored one. Regular map editing works again without the permission, while changing HTML content still requires `editHtml`. `textarea()` now also keeps the current value in a hidden field so a textbox can be moved/resized and saved unchanged.

Fixes #452