### PR TITLE
FEAT: Expose editHtml permission in role management GUI (#452)

### DIFF
--- a/changelog.d/feat-edithtml-role-permission.md
+++ b/changelog.d/feat-edithtml-role-permission.md
@@ -1,0 +1,1 @@
+FEAT: The "editHtml" permission can now be granted to roles via the role management GUI, instead of only being available to administrators (#452)

--- a/share/server/core/classes/CoreAuthorisationHandler.php
+++ b/share/server/core/classes/CoreAuthorisationHandler.php
@@ -63,7 +63,6 @@ class CoreAuthorisationHandler
             'createObject' => 'edit',
             'deleteObject' => 'edit',
             'addModify' => 'edit',
-            'editHtml' => 'edit',
         ],
         'Overview' => [
             'getOverviewRotations' => 'view',

--- a/share/server/core/classes/CorePDOHandler.php
+++ b/share/server/core/classes/CorePDOHandler.php
@@ -657,6 +657,18 @@ class CorePDOHandler
                 }
             }
 
+            // Add the "editHtml" permission on existing installs so it shows up
+            // in the role management GUI. Count-guarded to stay idempotent and
+            // to tolerate installs where it was already added manually.
+            if ($this->count('-perm-count', ['mod' => 'Map', 'act' => 'editHtml', 'obj' => '*']) <= 0) {
+                $reason = 'Could not add the Map/editHtml permission';
+                if (!$this->inTrans) {
+                    $this->DB->beginTransaction();
+                    $this->inTrans = true;
+                }
+                $this->query('-perm-add', ['mod' => 'Map', 'act' => 'editHtml', 'obj' => '*']);
+            }
+
             foreach (GlobalCore::getInstance()->demoMaps as $map) {
                 if (count(GlobalCore::getInstance()->getAvailableMaps('/^' . $map . '$/')) <= 0) {
                     continue;
@@ -829,6 +841,10 @@ class CorePDOHandler
         // Access controll: Edit/Delete maps
         $this->queryFatal('-perm-add', ['mod' => 'Map', 'act' => 'manage', 'obj' => '*']);
         $this->queryFatal('-perm-add', ['mod' => 'Map', 'act' => 'add', 'obj' => '*']);
+
+        // Access controll: Edit HTML content of map objects, grantable via the
+        // role management GUI (CVE-2024-47090)
+        $this->queryFatal('-perm-add', ['mod' => 'Map', 'act' => 'editHtml', 'obj' => '*']);
 
         $this->queryFatal('-perm-add', ['mod' => 'MainCfg', 'act' => 'edit', 'obj' => '*']);
 

--- a/share/server/core/classes/CorePDOHandler.php
+++ b/share/server/core/classes/CorePDOHandler.php
@@ -174,6 +174,10 @@ class CorePDOHandler
                 ],
 
                 'updates' => [
+                    '1100500' => [
+                        ['-perm-add', ['mod' => 'Map', 'act' => 'editHtml', 'obj' => '*']],
+                    ],
+
                     '1091500' => [
                         ['-perm-change-act', ['mod' => 'ChangePassword', 'old_act' => 'change', 'new_act' => '*']]
                     ],
@@ -655,18 +659,6 @@ class CorePDOHandler
                     $reason = "Could not update the database to version $ver: '$q[0]'";
                     $this->query($q[0], $q[1]);
                 }
-            }
-
-            // Add the "editHtml" permission on existing installs so it shows up
-            // in the role management GUI. Count-guarded to stay idempotent and
-            // to tolerate installs where it was already added manually.
-            if ($this->count('-perm-count', ['mod' => 'Map', 'act' => 'editHtml', 'obj' => '*']) <= 0) {
-                $reason = 'Could not add the Map/editHtml permission';
-                if (!$this->inTrans) {
-                    $this->DB->beginTransaction();
-                    $this->inTrans = true;
-                }
-                $this->query('-perm-add', ['mod' => 'Map', 'act' => 'editHtml', 'obj' => '*']);
             }
 
             foreach (GlobalCore::getInstance()->demoMaps as $map) {

--- a/share/server/core/classes/ViewManageRoles.php
+++ b/share/server/core/classes/ViewManageRoles.php
@@ -205,7 +205,12 @@ class ViewManageRoles
             'rotations' => [],
         ];
         foreach ($AUTHORISATION->getAllVisiblePerms() as $perm) {
-            if ($perm['mod'] == 'Map' && $perm['act'] != 'add' && $perm['act'] != 'manage') {
+            if (
+                $perm['mod'] == 'Map'
+                && $perm['act'] != 'add'
+                && $perm['act'] != 'manage'
+                && $perm['act'] != 'editHtml'
+            ) {
                 $map_name = $perm['obj'];
                 if (!isset($permissions_by_section['maps'][$map_name])) {
                     $permissions_by_section['maps'][$map_name] = [];


### PR DESCRIPTION
The `editHtml` permission introduced with CVE-2024-47090 was kept in the hidden `summarizePerms` list and never seeded into the `perms` table, so it could only be granted through manual SQL.

This seeds `Map/editHtml/*` on fresh installs and idempotently (count-guarded) on update — safe against the `UNIQUE(mod,act,obj)` constraint and installs that already added it manually — and stops hiding it in **Manage Roles → Permissions**. Default posture is unchanged: only Administrators have it (via their `*/*/*` wildcard), but an admin can now delegate HTML editing to another role from the GUI.

Refs #452